### PR TITLE
fix incorrect escaped null char in forge token

### DIFF
--- a/pkg/edition/java/forge/legacy.go
+++ b/pkg/edition/java/forge/legacy.go
@@ -12,7 +12,7 @@ import (
 const (
 	// Clients attempting to connect to 1.8-1.12.2 Forge servers will have
 	// this token appended to the hostname in the initial handshake packet.
-	HandshakeHostnameToken = `\0FML\0`
+	HandshakeHostnameToken = "\000FML\000"
 	// The channel for legacy forge handshakes.
 	LegacyHandshakeChannel = "FML|HS"
 	// The reset packet discriminator.


### PR DESCRIPTION
its fix the forge token that cause identify forge package failed