### PR TITLE
fallback forward the TabCompleteRequest to backend

### DIFF
--- a/pkg/edition/java/proxy/session_client_play.go
+++ b/pkg/edition/java/proxy/session_client_play.go
@@ -516,6 +516,15 @@ func (c *clientPlaySessionHandler) handleCommandTabComplete(p *packet.TabComplet
 			// additional tab completion support.
 			c.outstandingTabComplete = p
 		}
+		serverConn := c.player.connectedServer()
+		if serverConn == nil {
+			return
+		}
+		serverMc := serverConn.conn()
+		if serverMc == nil {
+			return
+		}
+		_ = serverMc.WritePacket(p)
 		return
 	}
 


### PR DESCRIPTION
Seems the client side proxy won't forward the tab complete request to backend as a fallback. I'm trying to fix this. :)
