### PR TITLE
Fix velocity for 1.18

### DIFF
--- a/examples/simple-network/config-velocity.yml
+++ b/examples/simple-network/config-velocity.yml
@@ -1,0 +1,18 @@
+# This is a simplified config where the rest of the
+# settings are omitted and will be set by default.
+# See config.yml for the full configuration options.
+#
+# The Minecraft editions Gate supports.
+editions:
+  # Java Minecraft edition is the first popular edition for desktops.
+  java:
+    enabled: true
+    config:
+      bind: 0.0.0.0:25565
+      servers:
+        velocity: 127.0.0.1:25568
+      try:
+        - velocity
+      forwarding:
+        mode: velocity
+        velocitySecret: my-secret

--- a/examples/simple-network/velocity/README.md
+++ b/examples/simple-network/velocity/README.md
@@ -1,8 +1,8 @@
 # Velocity test server
 
-This is a minimal config for testing velocity support on 1.18. It **does not**
-contain a server jar and you need to download one yourself https://papermc.io/downloads#Paper-1.18.
+This is a minimal config for testing velocity forwording mode supported by Gate on an 1.18 paper server.
+It **does not** contain a server jar and you need to download one yourself https://papermc.io/downloads#Paper-1.18.
 This config is known to work with [paper-1.18.1-148.jar](https://papermc.io/api/v2/projects/paper/versions/1.18.1/builds/148/downloads/paper-1.18.1-148.jar),
 though any version of paper which supports modern velocity should work.
 
-You need to connect to it with `gate --config config-velocity.yml` in the parent directory.
+In order to start Gate with the provided config run `gate --config config-velocity.yml` in the parent directory.

--- a/examples/simple-network/velocity/README.md
+++ b/examples/simple-network/velocity/README.md
@@ -1,0 +1,9 @@
+# Velocity test server
+
+This is a minimal config for testing velocity support on 1.18. It **does not**
+contain a server jar and you need to download one yourself https://papermc.io/downloads#Paper-1.18.
+This config is known to work with [paper-1.18.1-148.jar](https://papermc.io/api/v2/projects/paper/versions/1.18.1/builds/148/downloads/paper-1.18.1-148.jar),
+though any version of paper which supports modern velocity should work.
+
+You need to connect to it
+it with `gate --config config-velocity.yml` in the parent directory.

--- a/examples/simple-network/velocity/README.md
+++ b/examples/simple-network/velocity/README.md
@@ -5,5 +5,4 @@ contain a server jar and you need to download one yourself https://papermc.io/do
 This config is known to work with [paper-1.18.1-148.jar](https://papermc.io/api/v2/projects/paper/versions/1.18.1/builds/148/downloads/paper-1.18.1-148.jar),
 though any version of paper which supports modern velocity should work.
 
-You need to connect to it
-it with `gate --config config-velocity.yml` in the parent directory.
+You need to connect to it with `gate --config config-velocity.yml` in the parent directory.

--- a/examples/simple-network/velocity/bukkit.yml
+++ b/examples/simple-network/velocity/bukkit.yml
@@ -1,0 +1,3 @@
+settings:
+  allow-end: false
+  connection-throttle: -1

--- a/examples/simple-network/velocity/eula.txt
+++ b/examples/simple-network/velocity/eula.txt
@@ -1,0 +1,1 @@
+eula=true

--- a/examples/simple-network/velocity/paper.yml
+++ b/examples/simple-network/velocity/paper.yml
@@ -1,0 +1,4 @@
+settings:
+  velocity-support:
+    enabled: true
+    secret: my-secret

--- a/examples/simple-network/velocity/server.properties
+++ b/examples/simple-network/velocity/server.properties
@@ -1,0 +1,5 @@
+server-port=25568
+motd=Velocity!!
+use-native-transport=false
+online-mode=false
+allow-nether=false

--- a/examples/simple-network/velocity/spigot.yml
+++ b/examples/simple-network/velocity/spigot.yml
@@ -1,0 +1,3 @@
+settings:
+  # Legacy player info forwarding mode (UUID, IP & game profile signatures)
+  bungeecord: false

--- a/pkg/edition/java/proto/packet/login.go
+++ b/pkg/edition/java/proto/packet/login.go
@@ -97,7 +97,7 @@ func (l *LoginPluginResponse) Decode(_ *proto.PacketContext, rd io.Reader) (err 
 	if err != nil {
 		return err
 	}
-	l.Data, err = util.ReadBytes(rd)
+	l.Data, err = util.ReadRawBytes(rd)
 	if errors.Is(err, io.EOF) {
 		// Ignore if we couldn't read data
 		return nil

--- a/pkg/edition/java/proto/packet/login.go
+++ b/pkg/edition/java/proto/packet/login.go
@@ -3,12 +3,13 @@ package packet
 import (
 	"errors"
 	"fmt"
+	"io"
+
 	"go.minekube.com/gate/pkg/edition/java/proto/util"
 	"go.minekube.com/gate/pkg/edition/java/proto/version"
 	"go.minekube.com/gate/pkg/gate/proto"
 	"go.minekube.com/gate/pkg/util/errs"
 	"go.minekube.com/gate/pkg/util/uuid"
-	"io"
 )
 
 type ServerLogin struct {
@@ -84,7 +85,7 @@ func (l *LoginPluginResponse) Encode(_ *proto.PacketContext, wr io.Writer) (err 
 	if err != nil {
 		return err
 	}
-	return util.WriteBytes(wr, l.Data)
+	return util.WriteRawBytes(wr, l.Data)
 }
 
 func (l *LoginPluginResponse) Decode(_ *proto.PacketContext, rd io.Reader) (err error) {

--- a/pkg/edition/java/proto/util/reader.go
+++ b/pkg/edition/java/proto/util/reader.go
@@ -5,11 +5,12 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
-	"go.minekube.com/gate/pkg/edition/java/profile"
-	"go.minekube.com/gate/pkg/util/uuid"
 	"io"
 	"io/ioutil"
 	"math"
+
+	"go.minekube.com/gate/pkg/edition/java/profile"
+	"go.minekube.com/gate/pkg/util/uuid"
 )
 
 func ReadString(rd io.Reader) (string, error) {
@@ -75,6 +76,13 @@ func ReadBytesLen(rd io.Reader, maxLength int) (bytes []byte, err error) {
 	bytes = make([]byte, length)
 	_, err = rd.Read(bytes)
 	return
+}
+
+// Reads a non length prefixed string from the reader. This is necessary for parsing
+// certain packets like the velocity login/hello packet (no length prefix).
+func ReadRawBytes(rd io.Reader) ([]byte, error) {
+	b, err := ioutil.ReadAll(rd)
+	return b, err
 }
 
 // ReadStringWithoutLen reads a non length-prefixed string from the Reader.

--- a/pkg/edition/java/proto/util/reader.go
+++ b/pkg/edition/java/proto/util/reader.go
@@ -81,8 +81,7 @@ func ReadBytesLen(rd io.Reader, maxLength int) (bytes []byte, err error) {
 // Reads a non length prefixed string from the reader. This is necessary for parsing
 // certain packets like the velocity login/hello packet (no length prefix).
 func ReadRawBytes(rd io.Reader) ([]byte, error) {
-	b, err := ioutil.ReadAll(rd)
-	return b, err
+	return ioutil.ReadAll(rd)
 }
 
 // ReadStringWithoutLen reads a non length-prefixed string from the Reader.

--- a/pkg/edition/java/proto/util/writer.go
+++ b/pkg/edition/java/proto/util/writer.go
@@ -111,7 +111,8 @@ func WriteBytes(wr io.Writer, b []byte) (err error) {
 	return err
 }
 
-// Like WriteBytes, but doesn't include the length prefix
+// Writes a raw strema of bytes to a file with no length prefix.
+// Necessary for the Velocity hello/login packet (it uses a non-standard packet format)
 func WriteRawBytes(wr io.Writer, b []byte) (err error) {
 	_, err = wr.Write(b)
 	return err

--- a/pkg/edition/java/proto/util/writer.go
+++ b/pkg/edition/java/proto/util/writer.go
@@ -3,10 +3,11 @@ package util
 import (
 	"encoding/binary"
 	"fmt"
-	"go.minekube.com/gate/pkg/edition/java/profile"
-	"go.minekube.com/gate/pkg/util/uuid"
 	"io"
 	"math"
+
+	"go.minekube.com/gate/pkg/edition/java/profile"
+	"go.minekube.com/gate/pkg/util/uuid"
 )
 
 func WriteString(writer io.Writer, val string) (err error) {
@@ -106,6 +107,12 @@ func WriteBytes(wr io.Writer, b []byte) (err error) {
 	if err != nil {
 		return err
 	}
+	_, err = wr.Write(b)
+	return err
+}
+
+// Like WriteBytes, but doesn't include the length prefix
+func WriteRawBytes(wr io.Writer, b []byte) (err error) {
 	_, err = wr.Write(b)
 	return err
 }

--- a/pkg/util/netutil/hostportaddr.go
+++ b/pkg/util/netutil/hostportaddr.go
@@ -46,13 +46,12 @@ func WrapAddr(addr net.Addr) (net.Addr, error) {
 		return addr, nil
 	}
 	var (
-		host, port string
+		port string
 		err        error
 		p          int
 		a          = &address{Addr: addr}
 	)
-	host, port, err = net.SplitHostPort(addr.String())
-	a.host = host
+	a.host, port, err = net.SplitHostPort(addr.String())
 	if err == nil {
 		p, err = strconv.Atoi(port)
 	}

--- a/pkg/util/netutil/hostportaddr.go
+++ b/pkg/util/netutil/hostportaddr.go
@@ -51,7 +51,7 @@ func WrapAddr(addr net.Addr) (net.Addr, error) {
 		p          int
 		a          = &address{Addr: addr}
 	)
-	a.host, port, err = net.SplitHostPort(addr.String())
+	host, port, err = net.SplitHostPort(addr.String())
 	a.host = host
 	if err == nil {
 		p, err = strconv.Atoi(port)


### PR DESCRIPTION
While #48 fixed part of the issue supporting velocity, there was still one byte[] allocation which was causing the `0` prefix issue. In addition, needed to make a couple changes to conform with the implementation of Velocity which does **not** write a length prefix for the login packet ([code](https://github.com/PaperMC/Velocity/blob/2586210ca67f2510eb4f91bf7567643f8a26ee7b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/LoginPluginResponse.java#L81-L85)).

Changes:
- Added `ReadRawBytes` to write bytes with no length prefix
- Changed velocity to only report the user's host, not `host:port`
- Fixed `netutil.WrapAddr` to use the parsed host. Previously it was clobbering the host, resulting in an empty string #53 

I additionally added an example config for a PaperMC velocity server and corresponding `config-velocity.yml` for starting `gate` with the velocity server. Of note, I *did not* vendor the `.jar` file, mostly because I wanted to keep this lighter-weight and adding a 30M jar seemed a bit much 🤷.

Credits: I wouldn't have been able to figure this out without ash's comments on the discord server