### PR TITLE
ignore site and examples with empty go.mod file

### DIFF
--- a/examples/go.mod
+++ b/examples/go.mod
@@ -1,0 +1,1 @@
+// Empty file to prevent download in go package

--- a/site/go.mod
+++ b/site/go.mod
@@ -1,0 +1,1 @@
+// Empty file to prevent download in go package


### PR DESCRIPTION
Both `site/` and `examples/` contain large binary files unnecessary for building the package.

Go will download the entire folder structure at the level of the root `go.mod` file, ignoring any nested folders which contain a `go.mod`. As such, adding an empty `go.mod` file is sufficient to prevent `go get` from downloading the extra files. see: https://github.com/golang/go/issues/30058#issuecomment-543815369

Verified locally with `replace go.minekube.com/gate v0.15.1 => github.com/R167/gate v0.15.1-0.20220114021900-c1ac37f1f666` (`site` and `examples` are not included)

```sh
% ls ~/go/pkg/mod/github.com/\!r167/gate@v0.15.1-0.20220114021900-c1ac37f1f666
Dockerfile        Makefile          cmd               config.yml        go.mod            pkg
LICENSE           README.md         config-simple.yml gate.go           go.sum
% du -hd0 ~/go/pkg/mod/github.com/\!r167/gate@v0.15.1-0.20220114021900-c1ac37f1f666
864K	~/go/pkg/mod/github.com/!r167/gate@v0.15.1-0.20220114021900-c1ac37f1f666
```

not doing this downloads ~100MB just to install `go.minekube.com/gate` 😟
```sh
% du -hd0 ~/go/pkg/mod/go.minekube.com/gate@v0.15.1
 98M	~/go/pkg/mod/go.minekube.com/gate@v0.15.1
```