### PR TITLE
fix missed order on locking plugin channels

### DIFF
--- a/pkg/edition/java/proxy/player.go
+++ b/pkg/edition/java/proxy/player.go
@@ -462,8 +462,8 @@ func (p *connectedPlayer) knownChannels() sets.String {
 
 // runs fn while pluginChannels is locked. Used for modifying channel set.
 func (p *connectedPlayer) lockedKnownChannels(fn func(knownChannels sets.String)) {
-	p.pluginChannelsMu.RUnlock()
-	defer p.pluginChannelsMu.RLock()
+	p.pluginChannelsMu.RLock()
+	defer p.pluginChannelsMu.Unlock()
 	fn(p.pluginChannels)
 }
 

--- a/pkg/edition/java/proxy/player.go
+++ b/pkg/edition/java/proxy/player.go
@@ -463,7 +463,7 @@ func (p *connectedPlayer) knownChannels() sets.String {
 // runs fn while pluginChannels is locked. Used for modifying channel set.
 func (p *connectedPlayer) lockedKnownChannels(fn func(knownChannels sets.String)) {
 	p.pluginChannelsMu.RLock()
-	defer p.pluginChannelsMu.Unlock()
+	defer p.pluginChannelsMu.RUnlock()
 	fn(p.pluginChannels)
 }
 


### PR DESCRIPTION
Unlocking an unlocked mutex is applying some issues when the server need to register their plugin channels, like `WorldEdit` or something else.