### PR TITLE
fix: Update display name action is not handled

### DIFF
--- a/pkg/edition/java/proto/packet/tab_list.go
+++ b/pkg/edition/java/proto/packet/tab_list.go
@@ -238,6 +238,11 @@ func (p *PlayerListItem) Decode(c *proto.PacketContext, rd io.Reader) (err error
 				if err != nil {
 					return err
 				}
+			case UpdateDisplayNamePlayerListItemAction:
+				item.DisplayName, err = readOptionalComponent(rd, c.Protocol)
+				if err != nil {
+					return err
+				}
 			case RemovePlayerListItemAction:
 			// Do nothing, all that is needed is the uuid
 			default:


### PR DESCRIPTION
Action 3 from the packet "Player info" (0x36) is not being handled