### PR TITLE
Add boss bar API (#19)

### DIFF
--- a/pkg/edition/java/proto/packet/bossbar.go
+++ b/pkg/edition/java/proto/packet/bossbar.go
@@ -1,0 +1,211 @@
+package packet
+
+import (
+	"errors"
+	"io"
+
+	"go.minekube.com/common/minecraft/component"
+	"go.minekube.com/gate/pkg/edition/java/proto/util"
+	"go.minekube.com/gate/pkg/gate/proto"
+	"go.minekube.com/gate/pkg/util/uuid"
+)
+
+type BossBarAction uint8
+
+const (
+	BossBarActionAdd BossBarAction = iota
+	BossBarActionRemove
+	BossBarActionUpdatePercent
+	BossBarActionUpdateName
+	BossBarActionUpdateStyle
+	BossBarActionProperties
+)
+
+type BossBarColor uint8
+
+const (
+	BossBarColorPink BossBarColor = iota
+	BossBarColorBlue
+	BossBarColorRed
+	BossBarColorGreen
+	BossBarColorYellow
+	BossBarColorPurple
+	BossBarColorWhite
+)
+
+type BossBarOverlay uint8
+
+const (
+	BossBarOverlayProgress BossBarOverlay = iota
+	BossBarOverlayNotched6
+	BossBarOverlayNotched10
+	BossBarOverlayNotched12
+	BossBarOverlayNotched20
+)
+
+type BossBarFlag uint8
+
+const (
+	BossBarFlagDarkenScreen   BossBarFlag = 0x01
+	BossBarFlagPlayBossMusic  BossBarFlag = 0x02
+	BossBarFlagCreateWorldFog BossBarFlag = 0x04
+)
+
+var (
+	errBossBarNoName        = errors.New("action bar needs to have a name specified")
+	errBossBarInvalidAction = errors.New("unknown action for bossbar")
+)
+
+type BossBar struct {
+	UUID    uuid.UUID
+	Action  BossBarAction
+	Name    component.Component
+	Percent float32
+	Color   BossBarColor
+	Overlay BossBarOverlay
+	Flags   byte
+}
+
+func (bb *BossBar) Encode(c *proto.PacketContext, wr io.Writer) error {
+	err := util.WriteUUID(wr, bb.UUID)
+	if err != nil {
+		return err
+	}
+	err = util.WriteVarInt(wr, int(bb.Action))
+	if err != nil {
+		return err
+	}
+
+	switch bb.Action {
+	case BossBarActionAdd:
+		if bb.Name == nil {
+			return errBossBarNoName
+		}
+		err = util.WriteComponent(wr, c.Protocol, bb.Name)
+		if err != nil {
+			return err
+		}
+		err = util.WriteFloat32(wr, bb.Percent)
+		if err != nil {
+			return err
+		}
+		err = util.WriteVarInt(wr, int(bb.Color))
+		if err != nil {
+			return err
+		}
+		err = util.WriteVarInt(wr, int(bb.Overlay))
+		if err != nil {
+			return err
+		}
+		err = util.WriteByte(wr, bb.Flags)
+		if err != nil {
+			return err
+		}
+	case BossBarActionRemove:
+		// do nohing
+	case BossBarActionUpdatePercent:
+		if bb.Name == nil {
+			return errBossBarNoName
+		}
+		err = util.WriteComponent(wr, c.Protocol, bb.Name)
+		if err != nil {
+			return err
+		}
+	case BossBarActionUpdateStyle:
+		err = util.WriteVarInt(wr, int(bb.Color))
+		if err != nil {
+			return err
+		}
+		err = util.WriteVarInt(wr, int(bb.Overlay))
+		if err != nil {
+			return err
+		}
+	case BossBarActionProperties:
+		err = util.WriteByte(wr, bb.Flags)
+		if err != nil {
+			return err
+		}
+	default:
+		return errBossBarInvalidAction
+	}
+
+	return nil
+}
+
+func (bb *BossBar) Decode(c *proto.PacketContext, rd io.Reader) (err error) {
+	bb.UUID, err = util.ReadUUID(rd)
+	if err != nil {
+		return err
+	}
+	tmpAction, err := util.ReadVarInt(rd)
+	if err != nil {
+		return err
+	}
+	bb.Action = BossBarAction(tmpAction)
+
+	switch bb.Action {
+	case BossBarActionAdd:
+		bb.Name, err = util.ReadComponent(rd, c.Protocol)
+		if err != nil {
+			return err
+		}
+		bb.Percent, err = util.ReadFloat32(rd)
+		if err != nil {
+			return err
+		}
+		tmpColor, err := util.ReadVarInt(rd)
+		if err != nil {
+			return err
+		}
+		bb.Color = BossBarColor(tmpColor)
+		tmpOverlay, err := util.ReadVarInt(rd)
+		if err != nil {
+			return err
+		}
+		bb.Overlay = BossBarOverlay(tmpOverlay)
+		bb.Flags, err = util.ReadByte(rd)
+		if err != nil {
+			return err
+		}
+	case BossBarActionRemove:
+		// do nothing
+	case BossBarActionUpdatePercent:
+		bb.Percent, err = util.ReadFloat32(rd)
+		if err != nil {
+			return err
+		}
+	case BossBarActionUpdateName:
+		bb.Name, err = util.ReadComponent(rd, c.Protocol)
+		if err != nil {
+			return err
+		}
+	case BossBarActionUpdateStyle:
+		tmpColor, err := util.ReadVarInt(rd)
+		if err != nil {
+			return err
+		}
+		bb.Color = BossBarColor(tmpColor)
+		tmpOverlay, err := util.ReadVarInt(rd)
+		if err != nil {
+			return err
+		}
+		bb.Overlay = BossBarOverlay(tmpOverlay)
+	case BossBarActionProperties:
+		bb.Flags, err = util.ReadByte(rd)
+		if err != nil {
+			return err
+		}
+	default:
+		return errBossBarInvalidAction
+	}
+	return nil
+}
+
+func BossBarFlags(flags []BossBarFlag) byte {
+	var val byte
+	for _, flag := range flags {
+		val |= byte(flag)
+	}
+
+	return val
+}

--- a/pkg/edition/java/proto/state/states.go
+++ b/pkg/edition/java/proto/state/states.go
@@ -181,6 +181,13 @@ func init() {
 		m(0x17, version.Minecraft_1_19),
 		m(0x19, version.Minecraft_1_19_1),
 	)
+	Play.ClientBound.Register(&p.BossBar{},
+		m(0x0C, version.Minecraft_1_9),
+		m(0x0D, version.Minecraft_1_15),
+		m(0x0C, version.Minecraft_1_16),
+		m(0x0D, version.Minecraft_1_17),
+		m(0x0A, version.Minecraft_1_19),
+	)
 	Play.ClientBound.Register(&p.LegacyChat{},
 		m(0x02, version.Minecraft_1_7_2),
 		m(0x0F, version.Minecraft_1_9),

--- a/pkg/edition/java/proxy/bossbarmanager.go
+++ b/pkg/edition/java/proxy/bossbarmanager.go
@@ -1,0 +1,134 @@
+package proxy
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+
+	"go.minekube.com/gate/pkg/edition/java/proto/packet"
+	"go.minekube.com/gate/pkg/util/uuid"
+)
+
+var (
+	errBossBarNoUUID = errors.New("no uuid specified for boss bar")
+)
+
+type BossBarManager interface {
+	Add(player Player, bar packet.BossBar) error
+	Remove(player Player, bar packet.BossBar) error
+	Broadcast(bar packet.BossBar) error
+}
+
+type bossBarManager struct {
+	bars map[uuid.UUID]BossBarHolder
+	sync.Mutex
+
+	fnPlayer func(id uuid.UUID) *connectedPlayer
+}
+
+func (m *bossBarManager) get(bar packet.BossBar) (BossBarHolder, bool) {
+	barholder, ok := m.bars[bar.UUID]
+	return barholder, ok
+}
+
+func (m *bossBarManager) getOrCreate(bar packet.BossBar) (BossBarHolder, error) {
+	if bar.UUID == uuid.Nil {
+		return BossBarHolder{}, errBossBarNoUUID
+	}
+
+	if barholder, ok := m.bars[bar.UUID]; ok {
+		return barholder, nil
+	}
+
+	barholder := BossBarHolder{
+		subscribers: make(map[uuid.UUID]*connectedPlayer),
+	}
+	barholder.Register()
+
+	m.bars[bar.UUID] = barholder
+
+	return barholder, nil
+}
+
+// TODO: impl
+func (m *bossBarManager) onDisconnect(player Player) {
+}
+
+func (m *bossBarManager) Add(player Player, bar packet.BossBar) error {
+	m.Lock()
+	defer m.Unlock()
+
+	// this
+	p, ok := player.(*connectedPlayer)
+	if !ok {
+		fmt.Println("Add() failed to get player")
+		return nil
+	}
+	// or this?
+	// m.fnPlayer(player.ID())
+
+	bh, err := m.getOrCreate(bar)
+	if err != nil {
+		return err
+	}
+
+	bh.subscribers[player.ID()] = p
+	bar.Action = packet.BossBarActionAdd
+	return p.WritePacket(&bar)
+}
+
+func (m *bossBarManager) Remove(player Player, bar packet.BossBar) error {
+	m.Lock()
+	defer m.Unlock()
+
+	p, ok := player.(*connectedPlayer)
+	if !ok {
+		fmt.Println("Remove() failed to get player")
+		return nil
+	}
+
+	bh, ok := m.get(bar)
+	if !ok {
+		return nil
+	}
+
+	delete(bh.subscribers, player.ID())
+
+	// delete bar when nothing is left
+	if len(bh.subscribers) == 0 {
+		delete(m.bars, bar.UUID)
+	}
+
+	bar.Action = packet.BossBarActionRemove
+	return p.WritePacket(&bar)
+}
+
+func (m *bossBarManager) Broadcast(bar packet.BossBar) error {
+	m.Lock()
+	defer m.Unlock()
+
+	bh, ok := m.get(bar)
+	if !ok {
+		return nil
+	}
+
+	for _, player := range bh.subscribers {
+		err := player.WritePacket(&bar)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+type BossBarHolder struct {
+	subscribers map[uuid.UUID]*connectedPlayer
+
+	// register once
+	sync.Once
+}
+
+// TODO: implement??
+func (bbh *BossBarHolder) Register() {
+}

--- a/pkg/edition/java/proxy/bossbarmanager.go
+++ b/pkg/edition/java/proxy/bossbarmanager.go
@@ -20,27 +20,27 @@ type BossBarManager interface {
 }
 
 type bossBarManager struct {
-	bars map[uuid.UUID]BossBarHolder
+	bars map[uuid.UUID]*BossBarHolder
 	sync.Mutex
 
-	fnPlayer func(id uuid.UUID) *connectedPlayer
+	// fnPlayer func(id uuid.UUID) *connectedPlayer
 }
 
-func (m *bossBarManager) get(bar packet.BossBar) (BossBarHolder, bool) {
+func (m *bossBarManager) get(bar packet.BossBar) (*BossBarHolder, bool) {
 	barholder, ok := m.bars[bar.UUID]
 	return barholder, ok
 }
 
-func (m *bossBarManager) getOrCreate(bar packet.BossBar) (BossBarHolder, error) {
+func (m *bossBarManager) getOrCreate(bar packet.BossBar) (*BossBarHolder, error) {
 	if bar.UUID == uuid.Nil {
-		return BossBarHolder{}, errBossBarNoUUID
+		return nil, errBossBarNoUUID
 	}
 
 	if barholder, ok := m.bars[bar.UUID]; ok {
 		return barholder, nil
 	}
 
-	barholder := BossBarHolder{
+	barholder := &BossBarHolder{
 		subscribers: make(map[uuid.UUID]*connectedPlayer),
 	}
 	barholder.Register()

--- a/pkg/edition/java/proxy/proxy.go
+++ b/pkg/edition/java/proxy/proxy.go
@@ -104,7 +104,7 @@ func New(options Options) (p *Proxy, err error) {
 		playerNames:      map[string]*connectedPlayer{},
 		playerIDs:        map[uuid.UUID]*connectedPlayer{},
 		authenticator:    authn,
-		bossBarManager:   &bossBarManager{bars: make(map[uuid.UUID]BossBarHolder)},
+		bossBarManager:   &bossBarManager{bars: make(map[uuid.UUID]*BossBarHolder)},
 	}
 
 	c := options.Config

--- a/pkg/edition/java/proxy/proxy.go
+++ b/pkg/edition/java/proxy/proxy.go
@@ -60,6 +60,9 @@ type Proxy struct {
 
 	connectionsQuota *addrquota.Quota
 	loginsQuota      *addrquota.Quota
+
+	// TODO: maybe remove?
+	bossBarManager *bossBarManager
 }
 
 // Options are the options for a new Java edition Proxy.
@@ -101,6 +104,7 @@ func New(options Options) (p *Proxy, err error) {
 		playerNames:      map[string]*connectedPlayer{},
 		playerIDs:        map[uuid.UUID]*connectedPlayer{},
 		authenticator:    authn,
+		bossBarManager:   &bossBarManager{bars: make(map[uuid.UUID]BossBarHolder)},
 	}
 
 	c := options.Config
@@ -115,6 +119,10 @@ func New(options Options) (p *Proxy, err error) {
 	}
 
 	return p, nil
+}
+
+func (p *Proxy) BossBarManager() BossBarManager {
+	return p.bossBarManager
 }
 
 // ErrProxyAlreadyRun is returned by Proxy.Run if the proxy instance was already run.

--- a/pkg/edition/java/proxy/sesssion_auth.go
+++ b/pkg/edition/java/proxy/sesssion_auth.go
@@ -76,6 +76,7 @@ func (a *authSessionHandler) Activated() {
 		a.inbound.IdentifiedKey(),
 		newTabList(conn, conn.Protocol(), a.players),
 		a.sessionHandlerDeps,
+		a.proxy.bossBarManager,
 	)
 	a.connectedPlayer = player
 	if !a.registrar.canRegisterConnection(player) {


### PR DESCRIPTION
Initial work for adding boss bar to gate.
This current version works, but it does not follow how Velocity does it, it feels VERY Java specific in Velocity (ie. a function for update name, progress, overlay, flags, percent, when there can just be a single broadcast function instead.

Currently it does not implement disconnect, which it should.
I am also not sure how to handle the `Player`/`ConnectedPlayer`, there is a comment for two ways in the files.