### PR TITLE
Fix typo in lite docs

### DIFF
--- a/.web/docs/guide/lite.md
+++ b/.web/docs/guide/lite.md
@@ -60,7 +60,7 @@ config:
     routes:
       - host: abc.example.com
         backend: [ 10.0.0.3:25565, 10.0.0.4:25565 ]
-        pingCacheTTL: 3m # or 180s // [!code ++]
+        cachePingTTL: 3m # or 180s // [!code ++]
 ```
 
 _TTL - the Time-to-live before evicting the response data from the in-memory cache_
@@ -78,7 +78,7 @@ config:
     routes:
       - host: abc.example.com
         backend: 10.0.0.3:25568
-        pingCacheTTL: -1 // [!code ++]
+        cachePingTTL: -1 // [!code ++]
 ```
 
 ## Sample config


### PR DESCRIPTION
In [lite documentation](https://gate.minekube.com/guide/lite.html), the cache setting for ping is set to `pingCacheTTL`.
But, the actual setting is `cachePingTTL`.