### PR TITLE
Fix of payload error

### DIFF
--- a/pkg/edition/java/proto/packet/plugin/message.go
+++ b/pkg/edition/java/proto/packet/plugin/message.go
@@ -38,6 +38,7 @@ func (p *Message) Decode(c *proto.PacketContext, r io.Reader) (err error) {
 	}
 	if c.Protocol.GreaterEqual(version.Minecraft_1_13) {
 		p.Channel = TransformLegacyToModernChannel(p.Channel)
+		return
 	}
 	if c.Protocol.GreaterEqual(version.Minecraft_1_8) {
 		p.Data, err = io.ReadAll(r)


### PR DESCRIPTION
During a missing return, gate was sending a Chanel formatted to 1.8 and has overwritten the above 1.13 method