### PR TITLE
Added support for changing the nickname at the "preLogin" stage

### DIFF
--- a/pkg/edition/java/proxy/events.go
+++ b/pkg/edition/java/proxy/events.go
@@ -140,11 +140,6 @@ func (e *GameProfileRequestEvent) OnlineMode() bool {
 	return e.onlineMode
 }
 
-// OriginalGameProfile returns the original game originalProfile.
-func (e *GameProfileRequestEvent) OriginalGameProfile() profile.GameProfile {
-	return e.original
-}
-
 // GameProfile returns the game originalProfile that will be used to initialize the connection with.
 // Should no originalProfile be set, the original originalProfile (given by the proxy) will be used.
 func (e *GameProfileRequestEvent) GameProfile() profile.GameProfile {


### PR DESCRIPTION
I am developing a redirect system and I found that the nickname change function during "preLogin" is not supported. I wrote this support and tested it both in online mode and offline mode.

Redirect system:
`[12.123.123.12, Nelonn] => Nelonnar`