### PR TITLE
Fix default Config marshaling weirdly

### DIFF
--- a/pkg/edition/java/config/config.go
+++ b/pkg/edition/java/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+
 	liteconfig "go.minekube.com/gate/pkg/edition/java/lite/config"
 	"go.minekube.com/gate/pkg/edition/java/proto/version"
 	"go.minekube.com/gate/pkg/util/componentutil"
@@ -22,7 +23,7 @@ var DefaultConfig = Config{
 	},
 	Status: Status{
 		ShowMaxPlayers: 1000,
-		Motd:           defaultMotd(),
+		Motd:           "§bA Gate Proxy\n§bVisit ➞ §fgithub.com/minekube/gate",
 		// Contains Gate's icon
 		Favicon:         "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAYAAACqaXHeAAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAABmJLR0QA/wD/AP+gvaeTAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAB3RJTUUH5AgJCgs6JBZy0AAAB+lJREFUeNrtmGuMXVUZht/LOvcz7diWklbJaKGCWKXFUiiBQjAEhRSLSCEqIKAiogRTmiriBeSiUUhjMCZe2qQxNE0EUZSCidAgYMBSLBJCDC1taAg4xaq1cz/788feZzqgocCoP2Q/f87JOXvvfOtd73dZGygpKSkpKSkpKSkpKSkpKSkpKSkpKXnzwNd7w+ULD0NEBtmQBFqQBNuICFRYwzc3bf7/E+Cyo+cgAIiEbESWJdl1WSQ5VGvWRwnk/0XgpnvfmAhrv3h+HhgFFeJCBCLw8Wt//B8XIB3ogs8umJMHAOCQvtnYtfP5eRGxVNaxMmdKgqzdWSfbIuuuocHBLa2ednx16WJcd9fvXn9EAQSQyGgBwUCMMbAvAvHfcIAOaBHnl0REY9fO56+itFHSjbI/JHuxrMWyl8r6mq27m+3WKpJ1kvjG2UtevyUtyDqK0t2UNklaLalu63+fAp9bNBdZFogsq0j6OsVVkix7L8WNkh6VLVuLlXyapKbsMUkrR4aGV9caNbRnTkWKPC0kgdpv7e7n2GgH7ant8WgiYomoX8uqUXoIwKm1Rn0wJQMAGu0mBv8xhEZPAxIhOX9W8byR4VHUGjUcf86qyaVApVrB6MgYIC4leaUsS/oLySsprQcwBgRkVW1fIfsGWVVJn29Naf8CwPYUedAjQ8OsNxuHApiHwAwAIwB2AtjaaNX/CgQAiuQM27NIhixQqqaU+mTtA9AfEUMA0JzSRERMB3BUIPoCgQjsiIg/NHuaewDg0TtvxqJlK964A6447nAE0CLwM0mnygbFGzujY19WMhD5bjgZTu6hdLekE4qduDAi1jWntIEseimuIHmBrLfJVuGAAdmbZV1t6yGnNI3kBkkLaE2zRNnDsnbLGiR1EcUHK5WKlbyc5BdkvUdSPXeAB21tln3D6PDIvdV6DQBeVYRXdYDyvHsXyYW5dd1PYoNURafTwS2/fRIAsPKU+eg96C17EVhNcavskPgCQCDCtK4RuaLY0WdlPWW7T9a7JS+RdYukpbJHip3PcoHctXUmKyMZkuBK+jTJb8tqSeqn9ICthuyFsk4kubZar50P4DeTSgHZAHAEyd6i7z9LYgcA9M6chuuXnwzLoPLWiIjbKd7ezfV8B+JIkp+gVNzPj0jaKvsQ2xtkLZI1n+TRo8Mj99QatY85+WRJ62TXJW0leb6kfZ2xzp/rzcZ8ktcUi98B4hJZD1KqyLqU5E0AZgH4EoDfA/j7GxbAuc0PpshCgJcoDiHGOxIDMZfgdACh5InFbRuJflA1kffJNsVNtXptS7GzOyJii6RFsqqkZjsZ1XqtX/aLJLPiOcOSnsuybLA1tQ2S51CcXQi/RvZ9TgaBEZA/BHAugEUAjgMwH8ADkxAgARGaULlJERGAJESWWdK1kpZJHJMUyncaFD+TZdltTumxl17oP3f2nEN6Jc0DeSmIWQAato/tVm5KjbzwVos5iONiklSlVoHtOsljKMFWJvswWSsmtHMCqBffWwCOnJwANgKxp7soWdNJNYAYcTKyTLBlSklWWK7ISnnQqgDAvMXz4pmt2z4gcRWlYwrrTsxvOC+uRBSuA0AS+8UhUqUC2XWK04tYJOmCA6R476RqgJMRgW0SB2Q1Zb+dZB+JJyQByDqUrpP0fVGZk1fSOsO5AJCNbX/cfoKsNZJmSRqguE7SJol7bH9K1umyUaz/XwSgVIzfgpMySmOSQHIUwG1FK504JXVQ9NQD7f5rLILxlKRtebvxQbLOlvWELIyOjIbkJ11JqNaqMxAxOz8cGRLzRUgflTSrsPIaklcC6NgJqZJOG0+viQIExgsrRZAqnuUBWbuKHBeAXwL46cSeHnnezwCQAXh6UqNwqiTUW80XndJ6O3X7/WVO6RxSmjKtF+3eNqq16hSSVyt5vu3udXjh2V1w8ludjPz3tKNSq3ZaU3tQrVdnyn6fnf+n4h6Nf0/dexq2VKlVIWsMwKauQQGcPSHnEcA7AawHcA+ANQAOnpQDsixDZBlk/Uj2SbZOk3WQ5B/IOhOIxyNQp3iKpJOK9naErDpJ9B15GGxvL4oWZF+i5L0A/kZruaT3jhc6KSGimwIDpMaK8fZwSStJPgLgfgB3ALgAwEIAZwEYALARQA+ACwEcUYR/RwB/4mTOAgBw43nvR6okSJoj61uyz7RV3T/Pu7uAp2ytln2LrDapiyWudUoLZK2XfbgnnAEo7bb9sKwzC6tfjyy+Um81EMAMST+XdXxeawAAzwM4EcB2AMcDuBXAgn8T8kjhgpUA+ic1CeaFMN89kNudfBGlU2V9UPZcWQ1JeyU9RvInTmk3xdmSWpSeQAC2Hpd9nqxPyjpKsmTtJLlByS+KfFqSKW4OZHAlgcBuAJdTugTAoUWcOwDsLcJ6GMAyAMsLUWYCGAWwragLGwtnYNIOAICbLz4DKe0/0R13+hI8fv+jDVlJ0miWZUOykZLHT3sUQRAUUa3X8OGrvotf3bqyRYlOaSCyLJvoIjIPpd5uoG/uO/DcMzu743i1iHOsk3U6BMffPnXPbEUdyCJigOTL3htM6jD0Sr53+VmQ07gQ432aQiBQq9cAomhdQgBo9bQg7x+eim6AyDJUm00gAikRlLCvswc9noZqT6uozvGyELvvRI5ddhUeufM7ebcgX/k+BXwNCy8pKSkpKSkpKSkpKSkpKSkpKSkpKXkz8k8RHxEbZN/8lgAAACV0RVh0ZGF0ZTpjcmVhdGUAMjAyMC0wOC0wOVQxMDoxMTo0MyswMDowMN6nNEYAAAAldEVYdGRhdGU6bW9kaWZ5ADIwMjAtMDgtMDlUMTA6MTE6NDMrMDA6MDCv+oz6AAAAAElFTkSuQmCC",
 		LogPingRequests: false,
@@ -65,16 +66,9 @@ var DefaultConfig = Config{
 	RequireBuiltinCommandPermissions:    false,
 	AnnounceProxyCommands:               true,
 	Debug:                               false,
-	ShutdownReason:                      defaultShutdownReason(),
+	ShutdownReason:                      "§cGate proxy is shutting down...\nPlease reconnect in a moment!",
 	ForceKeyAuthentication:              true,
 	Lite:                                liteconfig.DefaultConfig,
-}
-
-func defaultMotd() *configutil.TextComponent {
-	return text("§bA Gate Proxy\n§bVisit ➞ §fgithub.com/minekube/gate")
-}
-func defaultShutdownReason() *configutil.TextComponent {
-	return text("§cGate proxy is shutting down...\nPlease reconnect in a moment!")
 }
 
 // Config is the configuration of the proxy.
@@ -113,8 +107,8 @@ type Config struct { // TODO use https://github.com/projectdiscovery/yamldoc-go 
 	AnnounceProxyCommands            bool `yaml:"announceProxyCommands"`
 	ForceKeyAuthentication           bool `yaml:"forceKeyAuthentication"` // Added in 1.19
 
-	Debug          bool                      `yaml:"debug"`
-	ShutdownReason *configutil.TextComponent `yaml:"shutdownReason"`
+	Debug          bool   `yaml:"debug"`
+	ShutdownReason string `yaml:"shutdownReason"`
 
 	Lite liteconfig.Config `yaml:"lite"`
 }
@@ -122,10 +116,10 @@ type Config struct { // TODO use https://github.com/projectdiscovery/yamldoc-go 
 type (
 	ForcedHosts map[string][]string // virtualhost:server names
 	Status      struct {
-		ShowMaxPlayers  int                       `yaml:"showMaxPlayers"`
-		Motd            *configutil.TextComponent `yaml:"motd"`
-		Favicon         favicon.Favicon           `yaml:"favicon"`
-		LogPingRequests bool                      `yaml:"logPingRequests"`
+		ShowMaxPlayers  int             `yaml:"showMaxPlayers"`
+		Motd            string          `yaml:"motd"`
+		Favicon         favicon.Favicon `yaml:"favicon"`
+		LogPingRequests bool            `yaml:"logPingRequests"`
 	}
 	Query struct {
 		Enabled     bool `yaml:"enabled"`
@@ -262,7 +256,7 @@ func (c *Config) Validate() (warns []error, errs []error) {
 	return
 }
 
-func text(s string) *configutil.TextComponent {
+func StrToTextComponent(s string) *configutil.TextComponent {
 	return (*configutil.TextComponent)(must(componentutil.ParseTextComponent(
 		version.MinimumVersion.Protocol, s)))
 }

--- a/pkg/edition/java/proxy/proxy.go
+++ b/pkg/edition/java/proxy/proxy.go
@@ -4,13 +4,14 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"go.minekube.com/gate/pkg/edition/java/proto/state"
 	"net"
 	"reflect"
 	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"go.minekube.com/gate/pkg/edition/java/proto/state"
 
 	"github.com/go-logr/logr"
 	"github.com/pires/go-proxyproto"
@@ -177,7 +178,7 @@ func (p *Proxy) Start(ctx context.Context) error {
 	logInfo()
 
 	defer func() {
-		p.Shutdown(p.config().ShutdownReason.T()) // disconnects players
+		p.Shutdown(config.StrToTextComponent(p.config().ShutdownReason).T()) // disconnects players
 	}()
 
 	eg, ctx := errgroup.WithContext(ctx)

--- a/pkg/edition/java/proxy/session_status.go
+++ b/pkg/edition/java/proxy/session_status.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/go-logr/logr"
+	"go.minekube.com/gate/pkg/edition/java/config"
 	"go.minekube.com/gate/pkg/edition/java/forge/modinfo"
 	"go.minekube.com/gate/pkg/edition/java/netmc"
 	"go.minekube.com/gate/pkg/edition/java/ping"
@@ -95,7 +96,7 @@ func newInitialPing(p *Proxy, protocol proto.Protocol) *ping.ServerPing {
 			Online: p.PlayerCount(),
 			Max:    p.cfg.Status.ShowMaxPlayers,
 		},
-		Description: p.cfg.Status.Motd.T(),
+		Description: config.StrToTextComponent(p.cfg.Status.Motd).T(),
 		Favicon:     p.cfg.Status.Favicon,
 		ModInfo:     modInfo,
 	}


### PR DESCRIPTION
Basically the config took a string input on the file, but the internal had a different type, which meant when you "wrote" the config file, it would write the *entire* byte array of that other type.

I modified the `text(str)` function to instead be an global function to be used in the exactly *two* places that needed it. rather than on the global config struct

How you can test is just make a plugin that writes the config file from the same default data struct.

This also allows for Plugins to "alter" that part of the config. 