### PR TITLE
Add bungeeguard fowarding mode

### DIFF
--- a/pkg/edition/java/config/config.go
+++ b/pkg/edition/java/config/config.go
@@ -133,8 +133,9 @@ type (
 		ShowPlugins bool `yaml:"showPlugins"`
 	}
 	Forwarding struct {
-		Mode           ForwardingMode `yaml:"mode"`
-		VelocitySecret string         `yaml:"velocitySecret"` // Used with "velocity" mode
+		Mode              ForwardingMode `yaml:"mode"`
+		VelocitySecret    string         `yaml:"velocitySecret"`    // Used with "velocity" mode
+		BungeeguardSecret string         `yaml:"bungeeguardSecret"` // Used with "bungeeguard" mode
 	}
 	Compression struct {
 		Threshold int `yaml:"threshold"`
@@ -169,6 +170,8 @@ const (
 	// VelocityForwardingMode is a forwarding mode specified by the Velocity java proxy and
 	// supported by PaperSpigot for versions starting at 1.13.
 	VelocityForwardingMode ForwardingMode = "velocity"
+	// BungeeGuardFowardingMode is a forwarding mode used by versions lower than 1.13
+	BungeeGuardFowardingMode ForwardingMode = "bungeeguard"
 )
 
 // Validate validates Config.

--- a/pkg/edition/java/config/config.go
+++ b/pkg/edition/java/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+
 	liteconfig "go.minekube.com/gate/pkg/edition/java/lite/config"
 	"go.minekube.com/gate/pkg/edition/java/proto/version"
 	"go.minekube.com/gate/pkg/util/componentutil"
@@ -218,9 +219,9 @@ func (c *Config) Validate() (warns []error, errs []error) {
 	case NoneForwardingMode:
 		w("Player forwarding is disabled! Backend servers will have players with " +
 			"offline-mode UUIDs and the same IP as the proxy.")
-	case LegacyForwardingMode, VelocityForwardingMode:
+	case LegacyForwardingMode, VelocityForwardingMode, BungeeGuardFowardingMode:
 	default:
-		e("Unknown forwarding mode %q, must be one of none,legacy,velocity", c.Forwarding.Mode)
+		e("Unknown forwarding mode %q, must be one of none,legacy,velocity,bungeeguard", c.Forwarding.Mode)
 	}
 
 	if len(c.Servers) == 0 {

--- a/pkg/edition/java/proxy/phase/types.go
+++ b/pkg/edition/java/proxy/phase/types.go
@@ -77,7 +77,7 @@ func (*legacyForgeConnType) AddGameProfileTokensIfRequired(
 	// since both use the "hostname" field in the handshake. We add a special property to the
 	// profile instead, which will be ignored by non-Forge servers and can be intercepted by a
 	// Forge coremod, such as SpongeForge.
-	if forwardingType == config.LegacyForwardingMode {
+	if forwardingType == config.LegacyForwardingMode || forwardingType == config.BungeeGuardFowardingMode {
 		original.Properties = append(original.Properties, profile.Property{Name: "forgeClient", Value: "true"})
 	}
 	return original

--- a/pkg/edition/java/proxy/server.go
+++ b/pkg/edition/java/proxy/server.go
@@ -342,7 +342,7 @@ func (s *serverConnection) handshakeAddr(vHost string, player Player) string {
 	var ok bool
 	if ha, ok = s.Server().ServerInfo().(HandshakeAddresser); !ok {
 		if ha, ok = s.Server().(HandshakeAddresser); !ok {
-			if s.config().Forwarding.Mode == config.LegacyForwardingMode {
+			if s.config().Forwarding.Mode == config.LegacyForwardingMode || s.config().Forwarding.Mode == config.BungeeGuardFowardingMode {
 				return s.createLegacyForwardingAddress()
 			}
 		}

--- a/pkg/edition/java/proxy/session_backend_login.go
+++ b/pkg/edition/java/proxy/session_backend_login.go
@@ -250,7 +250,7 @@ func (b *backendLoginSessionHandler) handleServerLoginSuccess() {
 }
 
 func (b *backendLoginSessionHandler) Disconnected() {
-	if b.config().Forwarding.Mode == config.LegacyForwardingMode {
+	if b.config().Forwarding.Mode == config.LegacyForwardingMode || b.config().Forwarding.Mode == config.BungeeGuardFowardingMode {
 		b.requestCtx.result(nil, errs.NewSilentErr(`The connection to the remote server was unexpectedly closed.
 This is usually because the remote server does not have BungeeCord IP forwarding correctly enabled.`))
 	} else {

--- a/pkg/edition/java/proxy/session_client_auth.go
+++ b/pkg/edition/java/proxy/session_client_auth.go
@@ -73,6 +73,9 @@ func (a *authSessionHandler) Activated() {
 	gameProfile := *a.inbound.delegate.Type().AddGameProfileTokensIfRequired(
 		a.profile, a.config().Forwarding.Mode)
 
+	if a.config().Forwarding.Mode == config.BungeeGuardFowardingMode {
+		gameProfile.Properties = append(gameProfile.Properties, profile.Property{Name: "bungeeguard-token", Value: a.config().Forwarding.BungeeguardSecret})
+	}
 	profileRequest := NewGameProfileRequestEvent(a.inbound, gameProfile, a.onlineMode)
 	a.eventMgr.Fire(profileRequest)
 	conn := a.inbound.delegate.MinecraftConn


### PR DESCRIPTION
closes #97, this adds [BungeeGuard](https://github.com/lucko/BungeeGuard) fowarding mode. which is the legacy Bungeecord mode added with a property called "bungeeguard-token" in the GameProfile that has a secret value.