### PR TITLE
Fixed config path in k8s examples

### DIFF
--- a/.examples/kubernetes/bundle.yaml
+++ b/.examples/kubernetes/bundle.yaml
@@ -88,7 +88,7 @@ spec:
         - containerPort: 25565
           name: minecraft
         volumeMounts:
-        - mountPath: /gate/config.yml
+        - mountPath: /config.yml
           name: config
           subPath: config.yml
       volumes:

--- a/.examples/kubernetes/deploy.yaml
+++ b/.examples/kubernetes/deploy.yaml
@@ -17,7 +17,7 @@ spec:
               name: minecraft
           volumeMounts:
             - name: config
-              mountPath: /gate/config.yml
+              mountPath: /config.yml
               subPath: config.yml
       volumes:
         - name: config


### PR DESCRIPTION
Since 35699c8dcdf9d36d150cfd5870ae3125d0a2e376, the docker image looks for the config.yml file in root.