### PR TITLE
feat: Add maximum player limit feature for lite

### DIFF
--- a/.web/docs/guide/lite.md
+++ b/.web/docs/guide/lite.md
@@ -41,6 +41,31 @@ config:
         backend: [ 10.0.0.2:25566 ]
 ```
 
+## Maximum Players Limit
+
+You can limit the total number of players that can connect to your Gate Lite instance by setting the `maxPlayers` option:
+
+```yaml
+config:
+  lite:
+    enabled: true
+    maxPlayers: 100 # Limit to 100 concurrent players // [!code ++]
+    maxPlayersMessage: "§cThis Node is full.Please try another node." # Custom rejection message // [!code ++]
+    routes:
+      - host: abc.example.com
+        backend: 10.0.0.3:25568
+```
+
+When the maximum player limit is reached, any new connection attempts will be rejected with a custom message indicating that the server is full. For example:
+
+```
+§cThis Node is full.Please try another node.
+```
+
+You can customize this message by setting the `maxPlayersMessage` configuration option. The default message is in Chinese and translates to "This node has too many players, please use another node".
+
+Setting `maxPlayers` to `0` (the default) means there is no limit on the number of concurrent players.
+
 ## Ping Response Caching
 
 Players send server list ping requests to Gate Lite to display the motd (message of the day).

--- a/config-lite.yml
+++ b/config-lite.yml
@@ -18,6 +18,13 @@ config:
     # If enabled, the proxy will act as a lightweight reverse proxy to support new types of deployment architecture.
     # Default: false
     enabled: true
+    # Maximum number of players to accept, 0 means unlimited.
+    # When this limit is reached, new connections will be rejected.
+    # Default: 0
+    maxPlayers: 0
+    # Custom message to show when the maximum player limit is reached.
+    # Default: §cThis Node is full.Please try another node.
+    maxPlayersMessage: "§cThis Node is full.Please try another node."
     # The routes that the proxy redirects player connections to based on matching the virtual host address.
     # The routes are matched in order of appearance.
     # Examples:

--- a/pkg/edition/java/lite/config/config.go
+++ b/pkg/edition/java/lite/config/config.go
@@ -15,15 +15,19 @@ import (
 
 // DefaultConfig is the default configuration for Lite mode.
 var DefaultConfig = Config{
-	Enabled: false,
-	Routes:  []Route{},
+	Enabled:    false,
+	Routes:     []Route{},
+	MaxPlayers: 0, // 0 means unlimited
+	MaxPlayersMessage: "§cThis Node is full.Please try another node.",
 }
 
 type (
 	// Config is the configuration for Lite mode.
 	Config struct {
-		Enabled bool    `yaml:"enabled,omitempty" json:"enabled,omitempty"`
-		Routes  []Route `yaml:"routes,omitempty" json:"routes,omitempty"`
+		Enabled          bool    `yaml:"enabled,omitempty" json:"enabled,omitempty"`
+		Routes           []Route `yaml:"routes,omitempty" json:"routes,omitempty"`
+		MaxPlayers       int     `yaml:"maxPlayers,omitempty" json:"maxPlayers,omitempty"` // Maximum number of players to accept, 0 means unlimited
+		MaxPlayersMessage string  `yaml:"maxPlayersMessage,omitempty" json:"maxPlayersMessage,omitempty"` // Message to show when reaching max players limit
 	}
 	Route struct {
 		Host          configutil.SingleOrMulti[string] `json:"host,omitempty" yaml:"host,omitempty"`

--- a/pkg/edition/java/lite/counter.go
+++ b/pkg/edition/java/lite/counter.go
@@ -1,0 +1,28 @@
+package lite
+
+import (
+	"sync/atomic"
+)
+
+// ConnectionCounter tracks the number of active connections in LiteMode
+var ConnectionCounter = &counter{}
+
+// counter is a thread-safe counter for connections
+type counter struct {
+	count int32
+}
+
+// Increment increments the counter by 1 and returns the new value
+func (c *counter) Increment() int32 {
+	return atomic.AddInt32(&c.count, 1)
+}
+
+// Decrement decrements the counter by 1 and returns the new value
+func (c *counter) Decrement() int32 {
+	return atomic.AddInt32(&c.count, -1)
+}
+
+// Count returns the current count
+func (c *counter) Count() int32 {
+	return atomic.LoadInt32(&c.count)
+} 

--- a/pkg/edition/java/proxy/session_client_handshake.go
+++ b/pkg/edition/java/proxy/session_client_handshake.go
@@ -100,6 +100,8 @@ func (h *handshakeSessionHandler) handleHandshake(handshake *packet.Handshake, p
 		h.conn.SetState(nextState)
 		dialTimeout := time.Duration(h.config().ConnectionTimeout)
 		if nextState == state.Login {
+			// Set the current lite mode config
+			lite.SetConfig(&h.config().Lite)
 			// Lite mode enabled, pipe the connection.
 			lite.Forward(dialTimeout, h.config().Lite.Routes, h.log, h.conn, handshake, pc)
 			return


### PR DESCRIPTION
- Added maxPlayers and maxPlayersMessage options in the configuration file to allow setting a maximum number of connected players and customizing the full message.
- Updated documentation to explain how to configure the maximum player limit.
- Implemented maximum player count check in connection handling logic, rejecting connection requests that exceed the limit and returning a custom message.