### PR TITLE
feat: add strategy support to lite mode

### DIFF
--- a/pkg/edition/java/lite/config/config.go
+++ b/pkg/edition/java/lite/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"encoding/json"
 	"fmt"
+	"slices"
 	"time"
 
 	"go.minekube.com/gate/pkg/edition/java/forge/modinfo"
@@ -32,9 +33,10 @@ type (
 		Fallback      *Status                          `json:"fallback,omitempty" yaml:"fallback,omitempty"`         // nil = disabled
 		ProxyProtocol bool                             `json:"proxyProtocol,omitempty" yaml:"proxyProtocol,omitempty"`
 		// Deprecated: use TCPShieldRealIP instead.
-		RealIP            bool `json:"realIP,omitempty" yaml:"realIP,omitempty"`
-		TCPShieldRealIP   bool `json:"tcpShieldRealIP,omitempty" yaml:"tcpShieldRealIP,omitempty"`
-		ModifyVirtualHost bool `json:"modifyVirtualHost,omitempty" yaml:"modifyVirtualHost,omitempty"`
+		RealIP            bool   `json:"realIP,omitempty" yaml:"realIP,omitempty"`
+		TCPShieldRealIP   bool   `json:"tcpShieldRealIP,omitempty" yaml:"tcpShieldRealIP,omitempty"`
+		ModifyVirtualHost bool   `json:"modifyVirtualHost,omitempty" yaml:"modifyVirtualHost,omitempty"`
+		Strategy          string `json:"strategy,omitempty" yaml:"strategy,omitempty"`
 	}
 	Status struct {
 		MOTD    *configutil.TextComponent `yaml:"motd,omitempty" json:"motd,omitempty"`
@@ -71,6 +73,20 @@ func (r *Route) CachePingEnabled() bool { return r.GetCachePingTTL() > 0 }
 // GetTCPShieldRealIP returns the configured TCPShieldRealIP or deprecated RealIP value.
 func (r *Route) GetTCPShieldRealIP() bool { return r.TCPShieldRealIP || r.RealIP }
 
+var (
+	StrategyRandom           = "random"
+	StrategyRoundRobin       = "round-robin"
+	StrategyLeastConnections = "least-connections"
+	StrategyLowestLatency    = "lowest-latency"
+)
+
+var allowedStrategies = []string{
+	StrategyRandom,
+	StrategyRoundRobin,
+	StrategyLeastConnections,
+	StrategyLowestLatency,
+}
+
 func (c Config) Validate() (warns []error, errs []error) {
 	e := func(m string, args ...any) { errs = append(errs, fmt.Errorf(m, args...)) }
 
@@ -85,6 +101,9 @@ func (c Config) Validate() (warns []error, errs []error) {
 		}
 		if len(ep.Backend) == 0 {
 			e("Route %d: no backend configured", i)
+		}
+		if ok := slices.Contains(allowedStrategies, ep.Strategy); !ok && ep.Strategy != "" {
+			e("Route %d: invalid strategy '%s'", i, ep.Strategy)
 		}
 		for i, addr := range ep.Backend {
 			_, err := netutil.Parse(addr, "tcp")


### PR DESCRIPTION
Add strategies to lite mode.

Draft because of two reasons:
1. Did not yet implement support for multiple Gate instances.
2. Least-connection counter does not remove counts. 

Co-author: @okeanosthedev