### PR TITLE
fix: PreviousServer is always nil

### DIFF
--- a/pkg/edition/java/proxy/events.go
+++ b/pkg/edition/java/proxy/events.go
@@ -442,17 +442,18 @@ func (e *PlayerChooseInitialServerEvent) SetInitialServer(server RegisteredServe
 
 // ServerPreConnectEvent is fired before the player connects to a server.
 type ServerPreConnectEvent struct {
-	player   Player
-	original RegisteredServer
-
-	server RegisteredServer
+	player         Player
+	original       RegisteredServer
+	server         RegisteredServer
+	previousServer RegisteredServer // nil-able
 }
 
-func newServerPreConnectEvent(player Player, server RegisteredServer) *ServerPreConnectEvent {
+func newServerPreConnectEvent(player Player, server RegisteredServer, previousServer RegisteredServer) *ServerPreConnectEvent {
 	return &ServerPreConnectEvent{
-		player:   player,
-		original: server,
-		server:   server,
+		player:         player,
+		original:       server,
+		server:         server,
+		previousServer: previousServer,
 	}
 }
 
@@ -487,6 +488,12 @@ func (e *ServerPreConnectEvent) Allowed() bool {
 // nil if Allowed() returns false.
 func (e *ServerPreConnectEvent) Server() RegisteredServer {
 	return e.server
+}
+
+// PreviousServer returns the server the player was previously connected to.
+// May return nil if there was none!
+func (e *ServerPreConnectEvent) PreviousServer() RegisteredServer {
+	return e.previousServer
 }
 
 //

--- a/pkg/edition/java/proxy/server.go
+++ b/pkg/edition/java/proxy/server.go
@@ -219,6 +219,8 @@ type serverConnection struct {
 	player *connectedPlayer
 	log    logr.Logger
 
+	previousServer *registeredServer // nil-able
+
 	completedJoin      atomic.Bool
 	gracefulDisconnect atomic.Bool
 	pendingPings       *lru.SyncCache[int64, time.Time]
@@ -228,11 +230,12 @@ type serverConnection struct {
 	connPhase  phase.BackendConnectionPhase
 }
 
-func newServerConnection(server *registeredServer, player *connectedPlayer) *serverConnection {
+func newServerConnection(server *registeredServer, previousServer *registeredServer, player *connectedPlayer) *serverConnection {
 	return &serverConnection{
-		server:       server,
-		player:       player,
-		pendingPings: lru.NewSync[int64, time.Time](lru.WithCapacity(5)),
+		server:         server,
+		player:         player,
+		previousServer: previousServer,
+		pendingPings:   lru.NewSync[int64, time.Time](lru.WithCapacity(5)),
 		log: player.log.WithName("serverConn").WithValues(
 			"serverName", server.info.Name(),
 			"serverAddr", server.info.Addr()),

--- a/pkg/edition/java/proxy/session_backend_transition.go
+++ b/pkg/edition/java/proxy/session_backend_transition.go
@@ -163,6 +163,7 @@ func (b *backendTransitionSessionHandler) handleJoinGame(pc *proto.PacketContext
 	if !ok {
 		return
 	}
+	previousServer := b.serverConn.previousServer
 
 	failResult := func(format string, a ...any) {
 		err := fmt.Errorf(format, a...)
@@ -173,9 +174,7 @@ func (b *backendTransitionSessionHandler) handleJoinGame(pc *proto.PacketContext
 
 	b.serverConn.player.mu.Lock()
 	existingConn := b.serverConn.player.connectedServer_
-	var previousServer RegisteredServer
 	if existingConn != nil {
-		previousServer = existingConn.server
 		// Shut down the existing server connection.
 		b.serverConn.player.connectedServer_ = nil
 		b.serverConn.player.mu.Unlock()


### PR DESCRIPTION
fixes #539
closes #540

- Added a `previousServer` field to `ServerPreConnectEvent` and `serverConnection` to track the server a player was previously connected to.
- Updated constructors and methods to accommodate the new `previousServer` parameter, improving connection request handling and event firing.
- Enhanced `createConnectionRequest` to include the previous connection for better context during server transitions.