### PR TITLE
1.21.7 support & ServerLinks packet decode fix

### DIFF
--- a/pkg/edition/java/proto/state/register.go
+++ b/pkg/edition/java/proto/state/register.go
@@ -621,6 +621,7 @@ func init() {
 	)
 	Play.ClientBound.Register(&p.ServerLinks{},
 		m(0x7B, version.Minecraft_1_21),
+		m(0x82, version.Minecraft_1_21_2),
 	)
 	Play.ClientBound.Register(&cookie.CookieRequest{},
 		m(0x16, version.Minecraft_1_20_5),

--- a/pkg/edition/java/proto/version/version.go
+++ b/pkg/edition/java/proto/version/version.go
@@ -49,6 +49,7 @@ var (
 	Minecraft_1_21_4 = v(769, "1.21.4")
 	Minecraft_1_21_5 = v(770, "1.21.5")
 	Minecraft_1_21_6 = v(771, "1.21.6")
+	Minecraft_1_21_7 = v(772, "1.21.7")
 
 	// Versions ordered from lowest to highest
 	Versions = []*proto.Version{
@@ -68,7 +69,7 @@ var (
 		Minecraft_1_18, Minecraft_1_18_2,
 		Minecraft_1_19, Minecraft_1_19_1, Minecraft_1_19_3, Minecraft_1_19_4,
 		Minecraft_1_20, Minecraft_1_20_2, Minecraft_1_20_3, Minecraft_1_20_5,
-		Minecraft_1_21, Minecraft_1_21_2, Minecraft_1_21_4, Minecraft_1_21_5, Minecraft_1_21_6,
+		Minecraft_1_21, Minecraft_1_21_2, Minecraft_1_21_4, Minecraft_1_21_5, Minecraft_1_21_6, Minecraft_1_21_7,
 	}
 )
 


### PR DESCRIPTION
Feat: Add support for Minecraft 1.21.7 (Protocol 772)
Fix: Correct ServerLinks packet decoding for 1.21.2+