### PR TITLE
Fix/forge-and-fabric

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea
 .yarn
 /.web/docs/.vitepress/cache
+tmp

--- a/.web/docs/.vitepress/config.ts
+++ b/.web/docs/.vitepress/config.ts
@@ -151,6 +151,10 @@ export default defineConfig({
               text: 'Compatibility',
               link: '/guide/compatibility',
             },
+            {
+              text: 'Modded Servers',
+              link: '/guide/modded-servers',
+            },
           ],
         },
         {
@@ -175,6 +179,10 @@ export default defineConfig({
             {
               text: 'Rate Limiting',
               link: '/guide/rate-limiting',
+            },
+            {
+              text: 'Modded Servers Config',
+              link: '/guide/config/modded-servers',
             },
           ],
         },

--- a/.web/docs/guide/compatibility.md
+++ b/.web/docs/guide/compatibility.md
@@ -4,6 +4,8 @@ Gate is compatible with many Minecraft server implementations.
 The expectation is that if the server acts like vanilla, Gate will work,
 and we make special provisions for modded setups where we can.
 
+Gate provides excellent support for **modded servers** including Fabric and NeoForge. See our [Modded Servers Guide](modded-servers) for detailed setup instructions.
+
 Gate is compatible with Minecraft 1.8 through the latest version
 and we maintainers update Gate as soon as a new Minecraft version is released.
 
@@ -26,6 +28,32 @@ Spigot does not support Gate/Velocity modern forwarding, but does support legacy
 
 Forks of Spigot are not well-tested with Gate, though they may work perfectly fine.
 
+## Modded Servers <VPBadge>Supported</VPBadge>
+
+Gate has excellent compatibility with modded Minecraft servers:
+
+### Fabric <VPBadge>Fully Supported</VPBadge>
+
+- **Native compatibility** - Works out of the box
+- **Velocity modern forwarding** - Using FabricProxy-Lite mod
+- **All Fabric versions** - 1.16+ supported
+- **Mod compatibility** - Extensive testing with popular mods
+
+### NeoForge <VPBadge>Fully Supported</VPBadge>
+
+- **Velocity modern forwarding** - Using Proxy-Compatible-Forge mod
+- **Full protocol support** - 1.20.x+ compatibility
+- **Command support** - Proper handling of modded commands
+- **Cross-version support** - Works with various Minecraft versions
+
+### Legacy Forge
+
+- **Limited support** - Basic functionality works
+- **Legacy forwarding only** - Use BungeeCord forwarding
+- **Older versions** - 1.12.2 and below may have compatibility issues
+
+For detailed setup instructions, configuration examples, and troubleshooting, see our comprehensive [Modded Servers Guide](modded-servers).
+
 ## Proxy-behind-proxy setups
 
 These setups are only supported with [Lite mode](lite#proxy-behind-proxy) or [Connect enabled](connect)!
@@ -33,4 +61,3 @@ These setups are only supported with [Lite mode](lite#proxy-behind-proxy) or [Co
 You are best advised to avoid other kinds of setups, as they can cause lots of issues.
 Most proxy-behind-proxy setups are either illogical in the first place or can be handled more
 gracefully by purpose-built solutions like [Connect](https://connect.minekube.com/) or [Lite mode](lite).
-

--- a/.web/docs/guide/connect.md
+++ b/.web/docs/guide/connect.md
@@ -39,7 +39,7 @@ connect:
   name: my-server-name // [!code ++]
 ```
 
-Then you neeed to set the `CONNECT_TOKEN` environment variable or create a `connect.json` next to your config with the following format:
+Then you need to set the `CONNECT_TOKEN` environment variable or create a `connect.json` next to your config with the following format:
 
 ```json
 {"token":"YOUR-TOKEN"}

--- a/.web/docs/guide/modded-servers.md
+++ b/.web/docs/guide/modded-servers.md
@@ -1,0 +1,216 @@
+# Modded Server Compatibility
+
+Gate provides excellent compatibility with modded Minecraft servers including **Fabric** and **NeoForge**. This guide will help you set up Gate to work seamlessly with your modded servers.
+
+## Overview
+
+Gate provides comprehensive support for modded Minecraft servers, implementing the same forwarding protocols as described in the [Velocity documentation](https://docs.papermc.io/velocity/player-information-forwarding/):
+
+### Forwarding Modes Supported
+
+- **Velocity modern forwarding** - Secure binary format with MAC authentication (Minecraft 1.13+)
+- **Legacy BungeeCord forwarding** - Compatible with older versions and servers
+- **BungeeGuard forwarding** - Enhanced security over legacy forwarding
+- **No forwarding** - Basic proxy functionality without player data forwarding
+
+## Fabric Server Setup
+
+Gate works with Fabric out of the box, but you should add support for player info forwarding using a mod like [FabricProxy-Lite](https://modrinth.com/mod/fabricproxy-lite) (which supports Velocity modern forwarding).
+
+In addition, if you intend to run mods that add new content on top of Vanilla, you should install [CrossStitch](https://modrinth.com/mod/crossstitch), which improves support for certain Minecraft features that are extended by mods, such as custom argument types. This mod is officially maintained by the Velocity project.
+
+### Required Mods
+
+#### FabricProxy-Lite (For Velocity Forwarding)
+
+- **Purpose**: Enables Velocity modern forwarding for Fabric servers
+- **Download**: [FabricProxy-Lite on Modrinth](https://modrinth.com/mod/fabricproxy-lite)
+- **Requires**: [Fabric API](https://modrinth.com/mod/fabric-api) (dependency)
+
+::: warning Version Compatibility
+Always download the mod version that matches your Minecraft server version. Check the compatibility table on the mod page.
+:::
+
+#### CrossStitch (Recommended for Modded Content)
+
+- **Purpose**: Improves support for Minecraft features extended by mods (custom argument types, etc.)
+- **Download**: [CrossStitch on Modrinth](https://modrinth.com/mod/crossstitch)
+- **Maintained by**: Velocity project (official)
+
+### Server Configuration
+
+::: code-group
+
+```properties [server.properties]
+server-port=25566
+online-mode=false // [!code ++]
+motd=Fabric Server with Gate Proxy
+```
+
+```toml [config/FabricProxy-Lite.toml]
+hackOnlineMode = false // [!code ++]
+hackEarlySend = false // [!code ++]
+hackMessageChain = false // [!code ++]
+disconnectMessage = "This server requires you to connect with Gate."
+secret = "your-secret-key-here" // [!code ++]
+```
+
+```yaml [Gate config.yml]
+config:
+  bind: 0.0.0.0:25565
+  servers:
+    fabric-server: localhost:25566
+  try:
+    - fabric-server
+  forwarding:
+    mode: velocity // [!code ++]
+    velocitySecret: 'your-secret-key-here' // [!code ++]
+  status:
+    motd: |
+      §bGate Proxy with Fabric
+      §eVelocity Forwarding Enabled
+```
+
+:::
+
+::: tip Configuration File
+If `FabricProxy-Lite.toml` doesn't appear in the `config/` directory after server restart, create it manually or use environment variables:
+
+**Environment Variables Alternative:**
+
+```bash
+export FABRIC_PROXY_SECRET="your-secret-key-here"
+export FABRIC_PROXY_HACK_ONLINE_MODE=false
+export FABRIC_PROXY_HACK_EARLY_SEND=false
+export FABRIC_PROXY_HACK_MESSAGE_CHAIN=false
+```
+
+:::
+
+## NeoForge Server Setup
+
+Gate works with NeoForge out of the box, but you should add support for player info forwarding using a mod like [Proxy-Compatible-Forge](https://github.com/adde0109/Proxy-Compatible-Forge) (which supports Velocity modern forwarding).
+
+### Required Mods
+
+#### Proxy-Compatible-Forge (For Velocity Forwarding)
+
+- **Purpose**: Enables Velocity modern forwarding for NeoForge servers
+- **Download**: [Proxy-Compatible-Forge on GitHub](https://github.com/adde0109/Proxy-Compatible-Forge/releases)
+- **Supports**: NeoForge 1.16.5 - 1.20.x+
+
+::: warning Version Compatibility
+Ensure you download the correct mod version for your NeoForge server version. Check the releases page for compatibility information.
+:::
+
+### Server Configuration
+
+::: code-group
+
+```properties [server.properties]
+server-port=25567
+online-mode=false // [!code ++]
+motd=NeoForge Server with Gate Proxy
+```
+
+```toml [config/pcf-common.toml]
+#Modern Forwarding Settings
+[modernForwarding]
+    forwardingSecret = "your-secret-key-here" // [!code ++]
+
+[commandWrapping]
+    #List of argument types that are not vanilla but are integrated into the server
+    moddedArgumentTypes = ["livingthings:sampler_types"]
+```
+
+```yaml [Gate config.yml]
+config:
+  bind: 0.0.0.0:25565
+  servers:
+    neoforge-server: localhost:25567
+  try:
+    - neoforge-server
+  forwarding:
+    mode: velocity // [!code ++]
+    velocitySecret: 'your-secret-key-here' // [!code ++]
+  status:
+    motd: |
+      §bGate Proxy with NeoForge
+      §eVelocity Forwarding Enabled
+```
+
+:::
+
+## Multi-Server Setup
+
+You can run both Fabric and NeoForge servers behind the same Gate proxy:
+
+::: code-group
+
+```yaml [Gate config.yml]
+config:
+  bind: 0.0.0.0:25565
+  servers:
+    fabric-server: localhost:25566 # Fabric server
+    neoforge-server: localhost:25567 # NeoForge server
+    vanilla-server: localhost:25568 # Vanilla server
+  try:
+    - fabric-server
+    - neoforge-server
+    - vanilla-server
+  forwarding:
+    mode: velocity // [!code ++]
+    velocitySecret: 'shared-secret-key' // [!code ++]
+  status:
+    motd: |
+      §bGate Multi-Server Network
+      §eFabric • NeoForge • Vanilla
+```
+
+:::
+
+## Troubleshooting
+
+### Common Issues
+
+#### Connection Refused
+
+- **Check server ports** - ensure servers are running on configured ports
+- **Verify firewall** - make sure ports are accessible
+- **Check server logs** - look for startup errors
+
+#### Forwarding Issues
+
+- **Secret mismatch** - ensure `velocitySecret` matches in both Gate and mod configs
+- **Online mode** - must be `false` on backend servers when using forwarding
+- **Mod compatibility** - verify the forwarding mod supports your server version
+
+### Mod Compatibility Notes
+
+#### Incompatible Mods
+
+Some older mods may not work with current NeoForge versions:
+
+- **NeoVelocity 1.2.4** - Incompatible with NeoForge 21.8.x
+- **NeoForwarding 1.3.0** - Only supports older NeoForge versions
+
+### Security Considerations
+
+When running modded servers:
+
+- **Use velocity forwarding** when possible for better security
+- **Configure firewalls** to block direct access to backend servers
+- **Regular updates** - keep Gate and mods updated
+
+## Getting Help
+
+If you encounter issues:
+
+1. **Check the logs** - both Gate and server logs
+2. **Verify versions** - ensure compatibility between Gate, server, and mods
+3. **Community support** - join the [Gate Discord](https://minekube.com/discord)
+4. **GitHub issues** - If you encounter a reproducible bug or have a technical issue that includes logs, error messages, or steps to reproduce, please report it on the [Gate repository](https://github.com/minekube/gate/issues). For general questions or troubleshooting without technical details, use the [Gate Discord](https://minekube.com/discord).
+
+---
+
+_This guide covers the most common modded server setups. For specific mod compatibility questions, consult the mod's documentation or community._

--- a/pkg/edition/java/proto/packet/config/KnownPacks.go
+++ b/pkg/edition/java/proto/packet/config/KnownPacks.go
@@ -2,10 +2,11 @@ package config
 
 import (
 	"fmt"
+	"io"
+
 	"go.minekube.com/gate/pkg/edition/java/proto/util"
 	"go.minekube.com/gate/pkg/gate/proto"
 	"go.minekube.com/gate/pkg/util/errs"
-	"io"
 )
 
 const MaxLengthPacks = 64

--- a/pkg/edition/java/proto/util/reader.go
+++ b/pkg/edition/java/proto/util/reader.go
@@ -122,7 +122,7 @@ func ReadVarIntReturnN(r io.Reader) (result int, n int, err error) {
 				break
 			}
 		}
-		return int(val), n, nil
+		return int(int32(val)), n, nil
 	}
 
 	var bytesRead byte = 0

--- a/pkg/edition/java/proto/util/varint_test.go
+++ b/pkg/edition/java/proto/util/varint_test.go
@@ -1,0 +1,289 @@
+package util
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"testing"
+)
+
+// TestVarIntNegativeValues tests that VarInt properly handles negative values
+// This is critical for Forge/NeoForge compatibility, particularly with CrossStitch mod
+func TestVarIntNegativeValues(t *testing.T) {
+	testCases := []int{
+		-256,        // CrossStitch mod_argument identifier
+		-1,          // Simple negative
+		0,           // Zero
+		127,         // Positive within single byte
+		128,         // Positive requiring multiple bytes
+		2147483647,  // Max positive int32
+		-2147483648, // Min negative int32
+	}
+
+	for _, testValue := range testCases {
+		t.Run(fmt.Sprintf("VarInt_%d", testValue), func(t *testing.T) {
+			var buf bytes.Buffer
+
+			// Write the value
+			err := WriteVarInt(&buf, testValue)
+			if err != nil {
+				t.Fatalf("Failed to write VarInt %d: %v", testValue, err)
+			}
+
+			// Read it back
+			readValue, err := ReadVarInt(&buf)
+			if err != nil {
+				t.Fatalf("Failed to read VarInt %d: %v", testValue, err)
+			}
+
+			// Compare
+			if readValue != testValue {
+				t.Errorf("VarInt mismatch: wrote %d, read %d", testValue, readValue)
+			}
+		})
+	}
+}
+
+// TestCrossStitchCompatibility specifically tests the CrossStitch mod case
+func TestCrossStitchCompatibility(t *testing.T) {
+	// This is the specific case that causes "identifier not found" errors
+	crossStitchId := -256
+
+	var buf bytes.Buffer
+	err := WriteVarInt(&buf, crossStitchId)
+	if err != nil {
+		t.Fatalf("Failed to write CrossStitch mod argument ID: %v", err)
+	}
+
+	readValue, err := ReadVarInt(&buf)
+	if err != nil {
+		t.Fatalf("Failed to read CrossStitch mod argument ID: %v", err)
+	}
+
+	if readValue != crossStitchId {
+		t.Errorf("CrossStitch mod argument ID mismatch: wrote %d, read %d", crossStitchId, readValue)
+	}
+
+	// Verify the bytes match expected encoding
+	buf.Reset()
+	WriteVarInt(&buf, crossStitchId)
+	actualBytes := buf.Bytes()
+	expected := []byte{128, 254, 255, 255, 15} // Expected encoding for -256
+
+	if !bytes.Equal(actualBytes, expected) {
+		t.Errorf("CrossStitch mod argument ID encoding mismatch: got %v, expected %v", actualBytes, expected)
+	}
+}
+
+// varIntBytes calculates the number of bytes needed to encode a VarInt
+// Ported from Velocity's ProtocolUtils.varIntBytes()
+func varIntBytes(value int) int {
+	// Convert to uint32 for bit operations, matching Java's behavior
+	uvalue := uint32(value)
+
+	// Count leading zeros and use lookup table approach like Velocity
+	leadingZeros := 0
+	if uvalue == 0 {
+		return 1 // Special case for 0
+	}
+
+	// Count leading zeros manually since Go doesn't have Integer.numberOfLeadingZeros
+	temp := uvalue
+	for temp != 0 {
+		leadingZeros++
+		temp >>= 1
+	}
+	leadingZeros = 32 - leadingZeros
+
+	// Use Velocity's formula: ceil((31 - (leadingZeros - 1)) / 7)
+	if leadingZeros == 32 {
+		return 1 // Special case for 0
+	}
+	return int(math.Ceil(float64(31-(leadingZeros-1)) / 7.0))
+}
+
+// writeVarIntOld implements the traditional VarInt encoding for testing
+// Ported from Velocity's writeVarIntOld method
+func writeVarIntOld(buf *bytes.Buffer, value int) {
+	uvalue := uint32(value)
+	for {
+		if (uvalue & 0xFFFFFF80) == 0 {
+			buf.WriteByte(byte(uvalue))
+			return
+		}
+		buf.WriteByte(byte(uvalue&0x7F | 0x80))
+		uvalue >>= 7
+	}
+}
+
+// readVarIntOld implements the traditional VarInt decoding for testing
+// Ported from Velocity's oldReadVarIntSafely method
+func readVarIntOld(buf *bytes.Buffer) int {
+	i := 0
+	maxRead := min(5, buf.Len())
+	for j := 0; j < maxRead; j++ {
+		if buf.Len() == 0 {
+			return math.MinInt32
+		}
+		k := int(buf.Next(1)[0])
+		i |= (k & 0x7F) << (j * 7)
+		if (k & 0x80) != 128 {
+			return i
+		}
+	}
+	return math.MinInt32
+}
+
+// min returns the minimum of two integers
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+// TestNegativeVarIntBytes tests byte length calculation for negative values
+// Ported from Velocity's negativeVarIntBytes test
+func TestNegativeVarIntBytes(t *testing.T) {
+	if varIntBytes(-1) != 5 {
+		t.Errorf("Expected -1 to require 5 bytes, got %d", varIntBytes(-1))
+	}
+	if varIntBytes(math.MinInt32) != 5 {
+		t.Errorf("Expected MinInt32 to require 5 bytes, got %d", varIntBytes(math.MinInt32))
+	}
+}
+
+// TestZeroVarIntBytes tests byte length calculation for zero and small positive values
+// Ported from Velocity's zeroVarIntBytes test
+func TestZeroVarIntBytes(t *testing.T) {
+	if varIntBytes(0) != 1 {
+		t.Errorf("Expected 0 to require 1 byte, got %d", varIntBytes(0))
+	}
+	if varIntBytes(1) != 1 {
+		t.Errorf("Expected 1 to require 1 byte, got %d", varIntBytes(1))
+	}
+}
+
+// TestConsistencyAcrossNumberBits tests VarInt encoding consistency across bit boundaries
+// Ported from Velocity's ensureConsistencyAcrossNumberBits test
+func TestConsistencyAcrossNumberBits(t *testing.T) {
+	for i := 0; i <= 31; i++ {
+		number := (1 << i) - 1
+		expected := conventionalWrittenBytes(number)
+		actual := varIntBytes(number)
+		if actual != expected {
+			t.Errorf("Mismatch with %d-bit number %d: expected %d bytes, got %d", i, number, expected, actual)
+		}
+	}
+}
+
+// conventionalWrittenBytes calculates bytes using traditional method
+// Ported from Velocity's conventionalWrittenBytes method
+func conventionalWrittenBytes(value int) int {
+	wouldBeWritten := 0
+	uvalue := uint32(value)
+	for {
+		if (uvalue & ^uint32(0x7F)) == 0 {
+			wouldBeWritten++
+			return wouldBeWritten
+		}
+		wouldBeWritten++
+		uvalue >>= 7
+	}
+}
+
+// TestPositiveVarIntRoundtrip tests positive VarInt values with incremental steps
+// Ported from Velocity's testPositiveOld test
+func TestPositiveVarIntRoundtrip(t *testing.T) {
+	for i := 0; i >= 0 && i < 1000000; i += 127 {
+		var buf bytes.Buffer
+		err := WriteVarInt(&buf, i)
+		if err != nil {
+			t.Fatalf("Failed to write VarInt %d: %v", i, err)
+		}
+
+		readValue, err := ReadVarInt(&buf)
+		if err != nil {
+			t.Fatalf("Failed to read VarInt %d: %v", i, err)
+		}
+
+		if readValue != i {
+			t.Errorf("VarInt roundtrip failed for %d: got %d", i, readValue)
+		}
+
+		// Prevent infinite loop
+		if i > math.MaxInt32-127 {
+			break
+		}
+	}
+}
+
+// TestNegativeVarIntRoundtrip tests negative VarInt values with incremental steps
+// Ported from Velocity's testNegativeOld test
+func TestNegativeVarIntRoundtrip(t *testing.T) {
+	for i := 0; i <= 0 && i > -1000000; i -= 127 {
+		var buf bytes.Buffer
+		err := WriteVarInt(&buf, i)
+		if err != nil {
+			t.Fatalf("Failed to write VarInt %d: %v", i, err)
+		}
+
+		readValue, err := ReadVarInt(&buf)
+		if err != nil {
+			t.Fatalf("Failed to read VarInt %d: %v", i, err)
+		}
+
+		if readValue != i {
+			t.Errorf("VarInt roundtrip failed for %d: got %d", i, readValue)
+		}
+
+		// Prevent infinite loop
+		if i < math.MinInt32+127 {
+			break
+		}
+	}
+}
+
+// TestBytesWrittenAtBitBoundaries tests that our implementation matches traditional encoding
+// Ported from Velocity's testBytesWrittenAtBitBoundaries test
+func TestBytesWrittenAtBitBoundaries(t *testing.T) {
+	for bit := 0; bit <= 31; bit++ {
+		number := (1 << bit) - 1
+
+		// Test with our implementation
+		var bufNew bytes.Buffer
+		err := WriteVarInt(&bufNew, number)
+		if err != nil {
+			t.Fatalf("Failed to write VarInt %d: %v", number, err)
+		}
+
+		// Test with old implementation
+		var bufOld bytes.Buffer
+		writeVarIntOld(&bufOld, number)
+
+		// Compare byte arrays
+		newBytes := bufNew.Bytes()
+		oldBytes := bufOld.Bytes()
+
+		if !bytes.Equal(newBytes, oldBytes) {
+			t.Errorf("Encoding of %d was invalid: new=%v, old=%v", number, newBytes, oldBytes)
+		}
+
+		// Test reading with both implementations
+		bufNewCopy := bytes.NewBuffer(newBytes)
+		readNew, err := ReadVarInt(bufNewCopy)
+		if err != nil {
+			t.Fatalf("Failed to read VarInt %d with new implementation: %v", number, err)
+		}
+
+		bufOldCopy := bytes.NewBuffer(oldBytes)
+		readOld := readVarIntOld(bufOldCopy)
+
+		if readNew != number {
+			t.Errorf("New implementation read mismatch for %d: got %d", number, readNew)
+		}
+		if readOld != number && readOld != math.MinInt32 {
+			t.Errorf("Old implementation read mismatch for %d: got %d", number, readOld)
+		}
+	}
+}

--- a/pkg/util/connectutil/config/config.go
+++ b/pkg/util/connectutil/config/config.go
@@ -8,7 +8,6 @@ var DefaultConfig = Config{
 	WatchServiceAddr:       DefaultWatchServiceAddr,
 	Name:                   "",
 	EnforcePassthrough:     false,
-	AllowUnencryptedTunnel: false,
 	TokenFilePath:          tokenFilename,
 	Service: Service{
 		Enabled:                 false,
@@ -24,7 +23,6 @@ type Config struct {
 	Name                   string `yaml:"name,omitempty" json:"name,omitempty"`                                     // Endpoint name
 	EnforcePassthrough     bool   `yaml:"enforcePassthrough,omitempty" json:"enforcePassthrough,omitempty"`         // Setting to true will reject all sessions in non-passthrough mode.
 	WatchServiceAddr       string `yaml:"watchServiceAddr,omitempty" json:"watchServiceAddr,omitempty"`             // The address of the WatchService
-	AllowUnencryptedTunnel bool   `yaml:"allowUnencryptedTunnel,omitempty" json:"allowUnencryptedTunnel,omitempty"` // Allow unencrypted tunnels
 	TokenFilePath          string `yaml:"tokenFilePath,omitempty" json:"tokenFilePath,omitempty"`                   // Path to the token file
 
 	Service Service

--- a/pkg/util/connectutil/config/config.go
+++ b/pkg/util/connectutil/config/config.go
@@ -4,11 +4,11 @@ const DefaultWatchServiceAddr = "wss://watch-connect.minekube.net"
 
 // DefaultConfig is a default Config.
 var DefaultConfig = Config{
-	Enabled:                false,
-	WatchServiceAddr:       DefaultWatchServiceAddr,
-	Name:                   "",
-	EnforcePassthrough:     false,
-	TokenFilePath:          tokenFilename,
+	Enabled:            false,
+	WatchServiceAddr:   DefaultWatchServiceAddr,
+	Name:               "",
+	EnforcePassthrough: false,
+	TokenFilePath:      tokenFilename,
 	Service: Service{
 		Enabled:                 false,
 		Addr:                    "localhost:8443",
@@ -19,11 +19,11 @@ var DefaultConfig = Config{
 
 // Config is the config for Connect.
 type Config struct {
-	Enabled                bool   `yaml:"enabled,omitempty" json:"enabled,omitempty"`                               // Whether to connect Gate to the WatchService
-	Name                   string `yaml:"name,omitempty" json:"name,omitempty"`                                     // Endpoint name
-	EnforcePassthrough     bool   `yaml:"enforcePassthrough,omitempty" json:"enforcePassthrough,omitempty"`         // Setting to true will reject all sessions in non-passthrough mode.
-	WatchServiceAddr       string `yaml:"watchServiceAddr,omitempty" json:"watchServiceAddr,omitempty"`             // The address of the WatchService
-	TokenFilePath          string `yaml:"tokenFilePath,omitempty" json:"tokenFilePath,omitempty"`                   // Path to the token file
+	Enabled            bool   `yaml:"enabled,omitempty" json:"enabled,omitempty"`                       // Whether to connect Gate to the WatchService
+	Name               string `yaml:"name,omitempty" json:"name,omitempty"`                             // Endpoint name
+	EnforcePassthrough bool   `yaml:"enforcePassthrough,omitempty" json:"enforcePassthrough,omitempty"` // Setting to true will reject all sessions in non-passthrough mode.
+	WatchServiceAddr   string `yaml:"watchServiceAddr,omitempty" json:"watchServiceAddr,omitempty"`     // The address of the WatchService
+	TokenFilePath      string `yaml:"tokenFilePath,omitempty" json:"tokenFilePath,omitempty"`           // Path to the token file
 
 	Service Service
 }


### PR DESCRIPTION
fixes bug: Modern forwarding cause disconnect with NeoForge 1.21.1 #545
fixes #544

- Added a new guide for modded servers, detailing compatibility with Fabric and NeoForge, including setup instructions and required mods.
- Updated compatibility information in the existing compatibility guide to highlight support for modded servers.
- Introduced new links in the configuration for easy navigation to the modded servers guide.
- Improved VarInt handling in the protocol to ensure compatibility with modded setups, including tests for negative values and CrossStitch compatibility.
- Minor refactor in the Connect configuration for better readability.