### PR TITLE
fix: increase byte array length limit for 1.7.x clients in WriteBytes17

### DIFF
--- a/pkg/edition/java/proto/util/writer.go
+++ b/pkg/edition/java/proto/util/writer.go
@@ -220,9 +220,9 @@ func WriteBytes17(wr io.Writer, b []byte, allowExtended bool) error {
 				ForgeMaxArrayLength, len(b))
 		}
 	} else {
-		if len(b) > math.MaxInt8 {
+		if len(b) > math.MaxInt16 {
 			return fmt.Errorf("cannot write byte array longer than %d (got %d bytes)",
-				math.MaxInt8, len(b))
+				math.MaxInt16, len(b))
 		}
 	}
 	// Writes a 2 or 3 byte number that represents the length of the packet. (3 byte "shorts" for

--- a/pkg/edition/java/proto/util/writer_test.go
+++ b/pkg/edition/java/proto/util/writer_test.go
@@ -1,0 +1,152 @@
+package util
+
+import (
+	"bytes"
+	"math"
+	"testing"
+)
+
+// TestWriteBytes17_NonExtended tests WriteBytes17 with allowExtended=false
+// This is the case that was failing for 1.7.x clients with encryption requests
+func TestWriteBytes17_NonExtended(t *testing.T) {
+	tests := []struct {
+		name        string
+		data        []byte
+		expectError bool
+		description string
+	}{
+		{
+			name:        "small_array",
+			data:        make([]byte, 100),
+			expectError: false,
+			description: "Small array should work",
+		},
+		{
+			name:        "max_int8_boundary",
+			data:        make([]byte, 127), // math.MaxInt8
+			expectError: false,
+			description: "Array at old limit (127) should work",
+		},
+		{
+			name:        "above_old_limit",
+			data:        make([]byte, 162), // Size from issue #533
+			expectError: false,
+			description: "Array of 162 bytes (from issue #533) should work with new limit",
+		},
+		{
+			name:        "large_valid_array",
+			data:        make([]byte, 1000),
+			expectError: false,
+			description: "Larger array should work with new limit",
+		},
+		{
+			name:        "max_int16_boundary",
+			data:        make([]byte, math.MaxInt16), // 32767
+			expectError: false,
+			description: "Array at new limit (32767) should work",
+		},
+		{
+			name:        "above_new_limit",
+			data:        make([]byte, math.MaxInt16+1), // 32768
+			expectError: true,
+			description: "Array above new limit should fail",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			err := WriteBytes17(&buf, tt.data, false) // allowExtended = false
+
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("Expected error for %s, but got none", tt.description)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Unexpected error for %s: %v", tt.description, err)
+				}
+			}
+		})
+	}
+}
+
+// TestWriteBytes17_Extended tests WriteBytes17 with allowExtended=true
+func TestWriteBytes17_Extended(t *testing.T) {
+	tests := []struct {
+		name        string
+		data        []byte
+		expectError bool
+		description string
+	}{
+		{
+			name:        "small_array_extended",
+			data:        make([]byte, 100),
+			expectError: false,
+			description: "Small array should work in extended mode",
+		},
+		{
+			name:        "large_array_extended",
+			data:        make([]byte, 50000),
+			expectError: false,
+			description: "Large array should work in extended mode",
+		},
+		{
+			name:        "forge_max_boundary",
+			data:        make([]byte, ForgeMaxArrayLength),
+			expectError: false,
+			description: "Array at forge limit should work",
+		},
+		{
+			name:        "above_forge_limit",
+			data:        make([]byte, ForgeMaxArrayLength+1),
+			expectError: true,
+			description: "Array above forge limit should fail",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			err := WriteBytes17(&buf, tt.data, true) // allowExtended = true
+
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("Expected error for %s, but got none", tt.description)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Unexpected error for %s: %v", tt.description, err)
+				}
+			}
+		})
+	}
+}
+
+// TestWriteBytes17_1_7_x_EncryptionRequest tests the specific case from issue #533
+// where a 1.7.x client fails to login due to encryption request packet size
+func TestWriteBytes17_1_7_x_EncryptionRequest(t *testing.T) {
+	// Simulate a typical RSA public key size that would be used in encryption requests
+	// RSA 1024-bit public key in DER format is typically around 162 bytes
+	publicKey := make([]byte, 162) // Size from the actual error in issue #533
+	verifyToken := make([]byte, 4) // Typical verify token size
+
+	var buf bytes.Buffer
+
+	// Test public key writing (this was failing before the fix)
+	err := WriteBytes17(&buf, publicKey, false)
+	if err != nil {
+		t.Errorf("Failed to write public key for 1.7.x client: %v", err)
+	}
+
+	// Test verify token writing
+	err = WriteBytes17(&buf, verifyToken, false)
+	if err != nil {
+		t.Errorf("Failed to write verify token for 1.7.x client: %v", err)
+	}
+
+	// Verify that data was actually written
+	if buf.Len() == 0 {
+		t.Error("No data was written to buffer")
+	}
+}


### PR DESCRIPTION
## Problem
Issue #533 reported that 1.7.x clients fail to login with the error:
`Cannot write byte array longer than 127 (got 162 bytes)`

This affects basic connectivity for 1.7.x Minecraft clients, preventing them from logging into the proxy.

Fixes #533

## Root Cause
The `WriteBytes17()` function in `pkg/edition/java/proto/util/writer.go` was checking byte array length against `math.MaxInt8` (127) when `allowExtended=false`, but this limit is too restrictive for 1.7.x encryption requests.

RSA public keys used in encryption requests are typically ~162 bytes in DER format, which exceeds the 127-byte limit.

## Solution
Updated `WriteBytes17()` to use `math.MaxInt16` (32767) instead of `math.MaxInt8` (127) for non-extended mode, matching Velocity's behavior.

**Reference**: Velocity's `ProtocolUtils.writeByteArray17()` uses `Short.MAX_VALUE` (32767) when `allowExtended=false`.

## Changes
- **`writer.go`**: Changed limit from `math.MaxInt8` to `math.MaxInt16`
- **`writer_test.go`**: Added comprehensive tests including:
  - The specific 162-byte case from issue #533
  - Boundary testing for both old and new limits
  - Extended vs non-extended mode testing

## Testing
✅ All new tests pass  
✅ Existing proto package tests pass  
✅ Project builds successfully  
✅ Specific test case for 162-byte array (from #533) now works

## Verification
The fix specifically addresses the case where:
1. 1.7.x client attempts to login
2. Gate sends EncryptionRequest packet with RSA public key (~162 bytes)
3. `WriteBytes17(publicKey, false)` is called
4. Previously failed at 127-byte limit, now succeeds with 32767-byte limit

This change maintains backward compatibility while fixing 1.7.x client login issues.