### PR TITLE
fix: ignore ErrDecoderLeftBytes in status response decoding

### DIFF
--- a/pkg/edition/java/lite/forward.go
+++ b/pkg/edition/java/lite/forward.go
@@ -412,9 +412,25 @@ func fetchStatus(
 	dec.SetProtocol(protocol)
 	dec.SetState(state.Status)
 
+	return decodeStatusResponse(dec)
+}
+
+// StatusDecoder interface for decoding status responses (allows mocking in tests)
+type StatusDecoder interface {
+	Decode() (*proto.PacketContext, error)
+}
+
+// decodeStatusResponse decodes a status response from the decoder, handling the
+// ErrDecoderLeftBytes error that can occur when mods like BetterCompatibilityChecker
+// add extra data to the status response packet.
+func decodeStatusResponse(dec StatusDecoder) (*packet.StatusResponse, error) {
 	pongCtx, err := dec.Decode()
-	if err != nil {
+	if err != nil && !errors.Is(err, proto.ErrDecoderLeftBytes) {
 		return nil, fmt.Errorf("failed to decode status response: %w", err)
+	}
+	// If we got ErrDecoderLeftBytes, pongCtx should still be valid
+	if pongCtx == nil {
+		return nil, fmt.Errorf("failed to decode status response: got nil packet context")
 	}
 
 	res, ok := pongCtx.Packet.(*packet.StatusResponse)

--- a/pkg/edition/java/lite/forward_test.go
+++ b/pkg/edition/java/lite/forward_test.go
@@ -1,0 +1,132 @@
+package lite
+
+import (
+	"errors"
+	"testing"
+
+	"go.minekube.com/gate/pkg/edition/java/proto/packet"
+	"go.minekube.com/gate/pkg/gate/proto"
+)
+
+// TestDecodeStatusResponse_WithErrDecoderLeftBytes tests that decodeStatusResponse
+// properly handles ErrDecoderLeftBytes error (from BetterCompatibilityChecker mod)
+func TestDecodeStatusResponse_WithErrDecoderLeftBytes(t *testing.T) {
+	// Create a mock decoder that returns ErrDecoderLeftBytes
+	mockDecoder := &mockDecoder{
+		packetCtx: &proto.PacketContext{
+			Packet: &packet.StatusResponse{
+				Status: `{"version":{"name":"Test","protocol":754},"players":{"online":5,"max":20},"description":"Test Server"}`,
+			},
+		},
+		err: proto.ErrDecoderLeftBytes, // This is the error from BetterCompatibilityChecker
+	}
+
+	// Test that decodeStatusResponse handles the error correctly
+	result, err := decodeStatusResponse(mockDecoder)
+
+	// Should succeed despite ErrDecoderLeftBytes
+	if err != nil {
+		t.Errorf("decodeStatusResponse should ignore ErrDecoderLeftBytes, got error: %v", err)
+	}
+
+	if result == nil {
+		t.Fatal("decodeStatusResponse returned nil result")
+	}
+
+	// Verify the status response was properly decoded
+	expectedStatus := `{"version":{"name":"Test","protocol":754},"players":{"online":5,"max":20},"description":"Test Server"}`
+	if result.Status != expectedStatus {
+		t.Errorf("Expected status %q, got %q", expectedStatus, result.Status)
+	}
+}
+
+// TestDecodeStatusResponse_WithOtherError tests that other errors are still propagated
+func TestDecodeStatusResponse_WithOtherError(t *testing.T) {
+	// Create a mock decoder that returns a different error
+	otherErr := errors.New("connection timeout")
+	mockDecoder := &mockDecoder{
+		err: otherErr,
+	}
+
+	// Test that other errors are still propagated
+	result, err := decodeStatusResponse(mockDecoder)
+
+	// Should fail with the other error
+	if err == nil {
+		t.Error("decodeStatusResponse should propagate other errors")
+	}
+
+	if result != nil {
+		t.Error("decodeStatusResponse should return nil result on error")
+	}
+
+	// Verify the error is wrapped correctly
+	if !errors.Is(err, otherErr) {
+		t.Errorf("Expected error to contain %v, got %v", otherErr, err)
+	}
+}
+
+// TestDecodeStatusResponse_Success tests normal successful decoding
+func TestDecodeStatusResponse_Success(t *testing.T) {
+	// Create a mock decoder that succeeds
+	mockDecoder := &mockDecoder{
+		packetCtx: &proto.PacketContext{
+			Packet: &packet.StatusResponse{
+				Status: `{"version":{"name":"Normal","protocol":754},"players":{"online":10,"max":50}}`,
+			},
+		},
+		err: nil, // No error
+	}
+
+	// Test successful decoding
+	result, err := decodeStatusResponse(mockDecoder)
+
+	// Should succeed
+	if err != nil {
+		t.Errorf("decodeStatusResponse should succeed, got error: %v", err)
+	}
+
+	if result == nil {
+		t.Fatal("decodeStatusResponse returned nil result")
+	}
+
+	// Verify the status response
+	expectedStatus := `{"version":{"name":"Normal","protocol":754},"players":{"online":10,"max":50}}`
+	if result.Status != expectedStatus {
+		t.Errorf("Expected status %q, got %q", expectedStatus, result.Status)
+	}
+}
+
+// TestDecodeStatusResponse_WrongPacketType tests handling of unexpected packet types
+func TestDecodeStatusResponse_WrongPacketType(t *testing.T) {
+	// Create a mock decoder that returns wrong packet type
+	mockDecoder := &mockDecoder{
+		packetCtx: &proto.PacketContext{
+			Packet: &packet.StatusRequest{}, // Wrong type!
+		},
+		err: nil,
+	}
+
+	// Test that wrong packet type is handled
+	result, err := decodeStatusResponse(mockDecoder)
+
+	// Should fail
+	if err == nil {
+		t.Error("decodeStatusResponse should fail with wrong packet type")
+	}
+
+	if result != nil {
+		t.Error("decodeStatusResponse should return nil result on wrong packet type")
+	}
+}
+
+// mockDecoder implements the StatusDecoder interface for testing
+type mockDecoder struct {
+	packetCtx *proto.PacketContext
+	err       error
+}
+
+func (m *mockDecoder) Decode() (*proto.PacketContext, error) {
+	return m.packetCtx, m.err
+}
+

--- a/pkg/edition/java/lite/forward_test.go
+++ b/pkg/edition/java/lite/forward_test.go
@@ -10,23 +10,26 @@ import (
 
 // TestDecodeStatusResponse_WithErrDecoderLeftBytes tests that decodeStatusResponse
 // properly handles ErrDecoderLeftBytes error (from BetterCompatibilityChecker mod)
+// This test verifies the fix for issue #297: "Status/ping fails when server has the BetterCompatibilityChecker mod"
 func TestDecodeStatusResponse_WithErrDecoderLeftBytes(t *testing.T) {
 	// Create a mock decoder that returns ErrDecoderLeftBytes
+	// This simulates the scenario from issue #297 where BetterCompatibilityChecker mod
+	// adds extra data to status response packets
 	mockDecoder := &mockDecoder{
 		packetCtx: &proto.PacketContext{
 			Packet: &packet.StatusResponse{
 				Status: `{"version":{"name":"Test","protocol":754},"players":{"online":5,"max":20},"description":"Test Server"}`,
 			},
 		},
-		err: proto.ErrDecoderLeftBytes, // This is the error from BetterCompatibilityChecker
+		err: proto.ErrDecoderLeftBytes, // This is the error from BetterCompatibilityChecker (issue #297)
 	}
 
 	// Test that decodeStatusResponse handles the error correctly
 	result, err := decodeStatusResponse(mockDecoder)
 
-	// Should succeed despite ErrDecoderLeftBytes
+	// Should succeed despite ErrDecoderLeftBytes (fixing issue #297)
 	if err != nil {
-		t.Errorf("decodeStatusResponse should ignore ErrDecoderLeftBytes, got error: %v", err)
+		t.Errorf("decodeStatusResponse should ignore ErrDecoderLeftBytes (issue #297), got error: %v", err)
 	}
 
 	if result == nil {


### PR DESCRIPTION
Fixes #297

## Problem
Gate fails to proxy status/ping responses from modded servers with BetterCompatibilityChecker, showing error:
`failed to decode status response: decoder did not read all bytes of packet`

The BetterCompatibilityChecker mod adds extra data to status response packets, causing `ErrDecoderLeftBytes` error. Gate's `fetchStatus` function was treating this as a fatal error, but it should be ignored like in other parts of the codebase.

## Solution
- Refactors `fetchStatus` to extract `decodeStatusResponse` function for better testability
- Adds `StatusDecoder` interface to enable proper mocking in tests
- Ignores `ErrDecoderLeftBytes` error while preserving other error handling
- Adds comprehensive tests covering all scenarios:
  * `ErrDecoderLeftBytes` is ignored (BetterCompatibilityChecker case) 
  * Other errors are still propagated
  * Normal successful decoding works
  * Wrong packet types are handled

The fix matches how `ErrDecoderLeftBytes` is handled in `netmc/reader.go` and should resolve ping failures with modded servers.

## Testing
All tests pass, including new comprehensive test suite that specifically validates the fix for issue #297.