### PR TITLE
fix: Update default usernameFormat for Bedrock

### DIFF
--- a/.web/docs/guide/bedrock.md
+++ b/.web/docs/guide/bedrock.md
@@ -109,7 +109,7 @@ bedrock:
 
 | Option             | Description                                                 | Default              |
 | ------------------ | ----------------------------------------------------------- | -------------------- |
-| `usernameFormat`   | Format string for Bedrock usernames (use `%s` for username) | `""` (no formatting) |
+| `usernameFormat`   | Format string for Bedrock usernames (use `%s` for username) | `".%s"`              |
 | `geyserListenAddr` | Address where Gate listens for Geyser connections           | `localhost:25567`    |
 | `floodgateKeyPath` | Path to Floodgate encryption key                            | `floodgate.pem`      |
 


### PR DESCRIPTION
usernameFormat is by default ".%s" and not just "%s"