### PR TITLE
fix(java/config): validate forcedHosts against servers

### DIFF
--- a/pkg/edition/java/config/config.go
+++ b/pkg/edition/java/config/config.go
@@ -254,7 +254,9 @@ func (c *Config) Validate() (warns []error, errs []error) {
 
 	for host, servers := range c.ForcedHosts {
 		for _, name := range servers {
-			e("Forced host %q server %q must be registered under servers", host, name)
+			if _, ok := c.Servers[name]; !ok {
+				e("Forced host %q server %q must be registered under servers", host, name)
+			}
 		}
 	}
 


### PR DESCRIPTION
# fix(java/config): validate forcedHosts against servers

## Summary
In v0.56.0, forcedHosts validation errored for all entries due to a missing membership check. This adds a lookup against `c.Servers` before erroring so valid configs pass.

## Root Cause
- The `forcedHosts` loop unconditionally emitted an error for each server name, unlike the `try` loop which checks membership in `servers`.

## Fix
- Validate each forced host server name only if it’s not present in `servers`.
- File: `pkg/edition/java/config/config.go`
- Change:
```go
for host, servers := range c.ForcedHosts {
    for _, name := range servers {
        if _, ok := c.Servers[name]; !ok {
            e("Forced host %q server %q must be registered under servers", host, name)
        }
    }
}
```

## Reproduction (v0.56.0, lite disabled)
- Use the “basic configuration” from the docs:
```yaml
config:
  servers:
    lobby: localhost:25565
    creative: localhost:25566
    survival: localhost:25567
    minigames: localhost:25568

  try:
    - lobby

  forcedHosts:
    'creative.example.com': ['creative']
    'survival.example.com': ['survival']
    'games.example.com': ['minigames']
    'lobby.example.com': ['lobby']
```
- Run Gate with this config (v0.56.0):
  - Expected before fix: proxy exits with errors like:
```
config validation error {"error": "java: Forced host \"creative.example.com\" server \"creative\" must be registered under servers"}
config validation error {"error": "java: Forced host \"survival.example.com\" server \"survival\" must be registered under servers"}
config validation error {"error": "java: Forced host \"games.example.com\" server \"minigames\" must be registered under servers"}
config validation error {"error": "java: Forced host \"lobby.example.com\" server \"lobby\" must be registered under servers"}
```
  - After fix: no validation errors for the valid config above.

## Notes
- Lite mode behavior is unchanged: when lite is enabled, validation short-circuits earlier and skips this block.
- Intentional misconfigurations (forcedHosts referencing a non-registered server) still correctly produce an error.

## References
- Docs: https://gate.minekube.com/guide/forced-hosts#basic-configuration
- Discord thread: https://discordapp.com/channels/633708750032863232/1416916953133613138

## Reported by
- Louis (Discord, Sep 15, 2025)

## Attribution
This PR was prepared with assistance from Codex CLI (OpenAI). All code changes were reviewed by the author.
