### PR TITLE
fix(web): fix bedrock quick link

### DIFF
--- a/.web/docs/index.md
+++ b/.web/docs/index.md
@@ -20,7 +20,7 @@ hero:
       link: /guide/lite
     - theme: alt
       text: Bedrock
-      link: /guide/lite
+      link: /guide/bedrock
     - theme: alt
       text: Extensions
       link: /extensions


### PR DESCRIPTION
Fixes bedrock link on gate website to direct to /guide/bedrock and not /guide/lite.

Thanks Tarna on Discord for reporting this.