### PR TITLE
fix(docs): use correct comment syntax for VitePress colored diffs in YAML blocks

### DIFF
--- a/.web/docs/guide/connect.md
+++ b/.web/docs/guide/connect.md
@@ -34,8 +34,8 @@ connect:
   # This feature is disabled by default, but you are encouraged to
   # enable it and get empowered by the additional network services
   # and by the growing community in this ecosystem.
-  enabled: false // [!code --]
-  enabled: true // [!code ++]
+  enabled: false # [!code --]
+  enabled: true # [!code ++]
   # The endpoint name is a globally unique identifier of your server.
   # If Connect is enabled, but no name is specified a random name is
   # generated on every restart (only recommended for testing).
@@ -43,7 +43,7 @@ connect:
   # It is supported to run multiple Gates on the same endpoint name for load balancing
   # (use the same connect.json token file from first Gate instance).
   #name: your-endpoint-name // [!code --]
-  name: my-server-name // [!code ++]
+  name: my-server-name # [!code ++]
 ```
 
 ```json [connect.json]
@@ -69,7 +69,7 @@ connect:
   enabled: true
   name: my-server-name
   # Allow offline mode (cracked) players to join through Connect
-  allowOfflineModePlayers: true // [!code ++]
+  allowOfflineModePlayers: true # [!code ++]
 ```
 
 :::

--- a/.web/docs/guide/lite.md
+++ b/.web/docs/guide/lite.md
@@ -156,7 +156,7 @@ config:
     routes:
       - host: abc.example.com
         backend: [10.0.0.3:25565, 10.0.0.4:25565]
-        cachePingTTL: 3m # or 180s // [!code ++]
+        cachePingTTL: 3m # or 180s [!code ++]
 ```
 
 _TTL - the Time-to-live before evicting the response data from the in-memory cache_
@@ -176,7 +176,7 @@ config:
     routes:
       - host: abc.example.com
         backend: 10.0.0.3:25568
-        cachePingTTL: -1s // [!code ++]
+        cachePingTTL: -1s # [!code ++]
 ```
 
 :::
@@ -225,7 +225,7 @@ config:
     routes:
       - host: localhost
         backend: play.example.com
-        modifyVirtualHost: true // [!code ++]
+        modifyVirtualHost: true # [!code ++]
 ```
 
 :::
@@ -260,7 +260,7 @@ config:
     routes:
       - host: abc.example.com
         backend: 10.0.0.3:25566
-        proxyProtocol: true // [!code ++]
+        proxyProtocol: true # [!code ++]
 ```
 
 - [Gate - Enable Proxy Protocol](https://github.com/minekube/gate/blob/7b03987bcdc7e8a6ed96156fa147bdd9dbf6ba4c/config.yml#L85)

--- a/.web/docs/guide/modded-servers.md
+++ b/.web/docs/guide/modded-servers.md
@@ -48,16 +48,16 @@ Always download the mod version that matches your Minecraft server version. Chec
 
 ```properties [server.properties]
 server-port=25566
-online-mode=false // [!code ++]
+online-mode=false # [!code ++]
 motd=Fabric Server with Gate Proxy
 ```
 
 ```toml [config/FabricProxy-Lite.toml]
-hackOnlineMode = false // [!code ++]
-hackEarlySend = false // [!code ++]
-hackMessageChain = false // [!code ++]
+hackOnlineMode = false # [!code ++]
+hackEarlySend = false # [!code ++]
+hackMessageChain = false # [!code ++]
 disconnectMessage = "This server requires you to connect with Gate."
-secret = "your-secret-key-here" // [!code ++]
+secret = "your-secret-key-here" # [!code ++]
 ```
 
 ```yaml [Gate config.yml]
@@ -68,8 +68,8 @@ config:
   try:
     - fabric-server
   forwarding:
-    mode: velocity // [!code ++]
-    velocitySecret: 'your-secret-key-here' // [!code ++]
+    mode: velocity # [!code ++]
+    velocitySecret: 'your-secret-key-here' # [!code ++]
   status:
     motd: |
       §bGate Proxy with Fabric
@@ -114,14 +114,14 @@ Ensure you download the correct mod version for your NeoForge server version. Ch
 
 ```properties [server.properties]
 server-port=25567
-online-mode=false // [!code ++]
+online-mode=false # [!code ++]
 motd=NeoForge Server with Gate Proxy
 ```
 
 ```toml [config/pcf-common.toml]
 #Modern Forwarding Settings
 [modernForwarding]
-    forwardingSecret = "your-secret-key-here" // [!code ++]
+    forwardingSecret = "your-secret-key-here" # [!code ++]
 
 [commandWrapping]
     #List of argument types that are not vanilla but are integrated into the server
@@ -136,8 +136,8 @@ config:
   try:
     - neoforge-server
   forwarding:
-    mode: velocity // [!code ++]
-    velocitySecret: 'your-secret-key-here' // [!code ++]
+    mode: velocity # [!code ++]
+    velocitySecret: 'your-secret-key-here' # [!code ++]
   status:
     motd: |
       §bGate Proxy with NeoForge
@@ -164,8 +164,8 @@ config:
     - neoforge-server
     - vanilla-server
   forwarding:
-    mode: velocity // [!code ++]
-    velocitySecret: 'shared-secret-key' // [!code ++]
+    mode: velocity # [!code ++]
+    velocitySecret: 'shared-secret-key' # [!code ++]
   status:
     motd: |
       §bGate Multi-Server Network


### PR DESCRIPTION
In line 45 of the [connect.md](https://github.com/minekube/gate/pull/572/files#diff-6a0bde8859067c9b9d7939f88449a97c09bbc1c390790368bd455b0fe06c4a3fR45) we have to keep the `//` probably because the hole line is commented out.