### PR TITLE
feat: Support overriding forwarding secrets with environment variables

### DIFF
--- a/cmd/gate/root.go
+++ b/cmd/gate/root.go
@@ -158,6 +158,11 @@ func initViper(c *cli.Context, configFile string) (*viper.Viper, error) {
 	v.SetEnvPrefix("GATE")
 	v.AutomaticEnv() // read in environment variables that match
 	v.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
+	
+	// Bind custom environment variables for forwarding secrets
+	v.BindEnv("velocitySecret", "GATE_VELOCITY_SECRET")
+	v.BindEnv("bungeeGuardSecret", "GATE_BUNGEEGUARD_SECRET")
+	
 	return v, nil
 }
 

--- a/config.yml
+++ b/config.yml
@@ -89,8 +89,10 @@ config:
     # Options: legacy, none, bungeeguard, velocity
     mode: legacy
     # The secret used if the mode is velocity.
+    # Can also be set via environment variable: GATE_VELOCITY_SECRET
     #velocitySecret: secret_here
     # The secret used if the mode is bungeeguard.
+    # Can also be set via environment variable: GATE_BUNGEEGUARD_SECRET
     #bungeeGuardSecret: secret_here
   # Proxy protocol (HA-Proxy) determines whether Gate should support proxy protocol for players.
   # Do not enable this if you don't know what it is.

--- a/pkg/gate/gate.go
+++ b/pkg/gate/gate.go
@@ -333,6 +333,16 @@ func LoadConfig(v *viper.Viper) (*config.Config, error) {
 		return &cfg, fmt.Errorf("error loading config: %w", err)
 	}
 
+	// Apply environment variable overrides for specific fields
+	// This allows environment variables to override config file values
+	// Set custom environment variable names for forwarding secrets
+	if velocitySecret := v.GetString("velocitySecret"); velocitySecret != "" {
+		cfg.Config.Forwarding.VelocitySecret = velocitySecret
+	}
+	if bungeeGuardSecret := v.GetString("bungeeGuardSecret"); bungeeGuardSecret != "" {
+		cfg.Config.Forwarding.BungeeGuardSecret = bungeeGuardSecret
+	}
+
 	// Normalize forced hosts keys to lowercase
 	if len(cfg.Config.ForcedHosts) > 0 {
 		normalizedForcedHosts := make(map[string][]string, len(cfg.Config.ForcedHosts))


### PR DESCRIPTION
Binds the `velocitySecret` and `bungeeGuardSecret` configuration fields to dedicated environment variables for greater operational flexibility and security. Environment variables are always overwriting the config values.

The environment variables are:
- `GATE_VELOCITY_SECRET`
- `GATE_BUNGEEGUARD_SECRET`