### PR TITLE
Fix gate github issue 578

### DIFF
--- a/pkg/edition/java/proto/codec/decoder.go
+++ b/pkg/edition/java/proto/codec/decoder.go
@@ -118,6 +118,12 @@ retry:
 	}
 	ctx, err = d.decodePayload(payload)
 	if err != nil {
+		// Special case: ErrDecoderLeftBytes should still return the ctx
+		// This allows callers to decide whether to ignore this error
+		if errors.Is(err, proto.ErrDecoderLeftBytes) {
+			ctx.BytesRead = n
+			return ctx, err
+		}
 		return nil, err
 	}
 	ctx.BytesRead = n


### PR DESCRIPTION
Return packet context along with `proto.ErrDecoderLeftBytes` to fix a nil pointer dereference in the Java receive loop (issue #578).

A refactoring caused `decoder.readPacket()` to return `nil, err` for all errors, including `proto.ErrDecoderLeftBytes`. However, `reader.ReadPacket()` expects the packet context even with this specific error, as it's designed to swallow it. This mismatch resulted in `reader.ReadPacket()` returning `nil, nil`, leading to a nil pointer dereference when `packetCtx.BytesRead` was accessed. The fix ensures the context is always returned for `ErrDecoderLeftBytes`.

---
<a href="https://cursor.com/background-agent?bcId=bc-c0dab1e9-cbfc-4b9a-885a-0f3d770ff1f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c0dab1e9-cbfc-4b9a-885a-0f3d770ff1f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

