### PR TITLE
feat(docs): clarify Bedrock Edition support

### DIFF
--- a/.web/docs/guide/bedrock.md
+++ b/.web/docs/guide/bedrock.md
@@ -773,7 +773,7 @@ bedrock:
 - **Java mods** - Forge/Fabric mods don't work with Bedrock clients
 - **Complex redstone** - Some advanced redstone may behave differently
 - **Lite Mode** - Gate Lite isn't compatible with Bedrock Edition but we are working on it!
-- **Connect** - Minekube Connect does not currently support Bedrock Edition connections, but this is planned for a future release.
+- **Connect** - [Minekube Connect](https://connect.minekube.com/) does not currently support Bedrock Edition connections, but this is planned for a future release.
 > Don't ask about ETA as we work in our free time with the [contributions of the community](https://github.com/minekube/gate/graphs/contributors/)
 
 ---


### PR DESCRIPTION
This pull request adds the Bedrock Edition compatibility documentation in `.web/docs/guide/bedrock.md` to clarify support for Minekube Connect and Gate Lite. The changes aim to provide users with more accurate information about current limitations and future plans, as I was searching for it and took a time figuring it out.

Bedrock Edition compatibility updates:

* Added a note that Gate Lite is not currently compatible with Bedrock Edition, but support is being worked on.
* Clarified that Minekube Connect does not support Bedrock Edition connections yet, with future support planned and no ETA due to volunteer-based development.