### PR TITLE
Implement server registration and unregistration feature

### DIFF
--- a/pkg/edition/java/proxy/events.go
+++ b/pkg/edition/java/proxy/events.go
@@ -1330,3 +1330,37 @@ func (e *CookieRequestEvent) Allowed() bool { return !e.denied }
 
 // SetAllowed sets whether the cookie request is allowed to be forwarded to the client.
 func (e *CookieRequestEvent) SetAllowed(allowed bool) { e.denied = !allowed }
+
+//
+//
+//
+//
+//
+
+// ServerRegisteredEvent is fired when a backend server is registered with the proxy.
+// This allows plugins to react to dynamically added servers and perform necessary setup.
+type ServerRegisteredEvent struct {
+	server RegisteredServer
+}
+
+// Server returns the server that was registered.
+func (e *ServerRegisteredEvent) Server() RegisteredServer {
+	return e.server
+}
+
+//
+//
+//
+//
+//
+
+// ServerUnregisteredEvent is fired when a backend server is unregistered from the proxy.
+// This allows plugins to react to removed servers and perform necessary cleanup.
+type ServerUnregisteredEvent struct {
+	server ServerInfo
+}
+
+// ServerInfo returns the server info of the server that was unregistered.
+func (e *ServerUnregisteredEvent) ServerInfo() ServerInfo {
+	return e.server
+}

--- a/pkg/edition/java/proxy/proxy.go
+++ b/pkg/edition/java/proxy/proxy.go
@@ -490,6 +490,10 @@ func (p *Proxy) Register(info ServerInfo) (RegisteredServer, error) {
 	// so they won't be unregistered during config reloads
 
 	p.log.Info("registered new server", "name", info.Name(), "addr", info.Addr())
+	
+	// Fire ServerRegisteredEvent
+	p.event.Fire(&ServerRegisteredEvent{server: rs})
+	
 	return rs, nil
 }
 
@@ -511,6 +515,10 @@ func (p *Proxy) Unregister(info ServerInfo) bool {
 
 	p.log.Info("unregistered backend server",
 		"name", info.Name(), "addr", info.Addr())
+	
+	// Fire ServerUnregisteredEvent
+	p.event.Fire(&ServerUnregisteredEvent{server: info})
+	
 	return true
 }
 

--- a/pkg/edition/java/proxy/server_sync_test.go
+++ b/pkg/edition/java/proxy/server_sync_test.go
@@ -328,3 +328,150 @@ func TestServerInfoEqual(t *testing.T) {
 		})
 	}
 }
+
+// TestServerRegistrationEvents tests that ServerRegisteredEvent and ServerUnregisteredEvent
+// are fired when servers are registered and unregistered.
+func TestServerRegistrationEvents(t *testing.T) {
+	eventMgr := event.New()
+	
+	// Track events
+	var registeredServers []string
+	var unregisteredServers []string
+	
+	// Subscribe to ServerRegisteredEvent
+	event.Subscribe(eventMgr, 0, func(e *ServerRegisteredEvent) {
+		registeredServers = append(registeredServers, e.Server().ServerInfo().Name())
+	})
+	
+	// Subscribe to ServerUnregisteredEvent
+	event.Subscribe(eventMgr, 0, func(e *ServerUnregisteredEvent) {
+		unregisteredServers = append(unregisteredServers, e.ServerInfo().Name())
+	})
+	
+	// Create proxy with event manager
+	cfg := &config.Config{
+		Servers: map[string]string{},
+		Lite:    liteconfig.Config{Enabled: false},
+	}
+	
+	authenticator, err := auth.New(auth.Options{})
+	if err != nil {
+		t.Fatalf("Failed to create authenticator: %v", err)
+	}
+	
+	proxy := &Proxy{
+		log:           logr.Discard(),
+		cfg:           cfg,
+		event:         eventMgr,
+		servers:       make(map[string]*registeredServer),
+		configServers: make(map[string]bool),
+		authenticator: authenticator,
+	}
+	
+	// Register a server
+	serverInfo := NewServerInfo("test-server", mustParseAddr("localhost:25565"))
+	_, err = proxy.Register(serverInfo)
+	if err != nil {
+		t.Fatalf("Failed to register server: %v", err)
+	}
+	
+	// Wait for event to process
+	eventMgr.Wait()
+	
+	// Verify ServerRegisteredEvent was fired
+	if len(registeredServers) != 1 {
+		t.Errorf("Expected 1 registered event, got %d", len(registeredServers))
+	}
+	if len(registeredServers) > 0 && registeredServers[0] != "test-server" {
+		t.Errorf("Expected registered server to be 'test-server', got '%s'", registeredServers[0])
+	}
+	
+	// Unregister the server
+	if !proxy.Unregister(serverInfo) {
+		t.Fatal("Failed to unregister server")
+	}
+	
+	// Wait for event to process
+	eventMgr.Wait()
+	
+	// Verify ServerUnregisteredEvent was fired
+	if len(unregisteredServers) != 1 {
+		t.Errorf("Expected 1 unregistered event, got %d", len(unregisteredServers))
+	}
+	if len(unregisteredServers) > 0 && unregisteredServers[0] != "test-server" {
+		t.Errorf("Expected unregistered server to be 'test-server', got '%s'", unregisteredServers[0])
+	}
+}
+
+// TestServerRegistrationEventsMultiple tests that events are fired for multiple server operations
+func TestServerRegistrationEventsMultiple(t *testing.T) {
+	eventMgr := event.New()
+	
+	// Track events
+	registeredCount := 0
+	unregisteredCount := 0
+	
+	// Subscribe to events
+	event.Subscribe(eventMgr, 0, func(e *ServerRegisteredEvent) {
+		registeredCount++
+	})
+	
+	event.Subscribe(eventMgr, 0, func(e *ServerUnregisteredEvent) {
+		unregisteredCount++
+	})
+	
+	// Create proxy with event manager
+	cfg := &config.Config{
+		Servers: map[string]string{},
+		Lite:    liteconfig.Config{Enabled: false},
+	}
+	
+	authenticator, err := auth.New(auth.Options{})
+	if err != nil {
+		t.Fatalf("Failed to create authenticator: %v", err)
+	}
+	
+	proxy := &Proxy{
+		log:           logr.Discard(),
+		cfg:           cfg,
+		event:         eventMgr,
+		servers:       make(map[string]*registeredServer),
+		configServers: make(map[string]bool),
+		authenticator: authenticator,
+	}
+	
+	// Register multiple servers
+	servers := []ServerInfo{
+		NewServerInfo("server1", mustParseAddr("localhost:25565")),
+		NewServerInfo("server2", mustParseAddr("localhost:25566")),
+		NewServerInfo("server3", mustParseAddr("localhost:25567")),
+	}
+	
+	for _, s := range servers {
+		_, err := proxy.Register(s)
+		if err != nil {
+			t.Fatalf("Failed to register server %s: %v", s.Name(), err)
+		}
+	}
+	
+	eventMgr.Wait()
+	
+	// Verify all registration events were fired
+	if registeredCount != 3 {
+		t.Errorf("Expected 3 registered events, got %d", registeredCount)
+	}
+	
+	// Unregister all servers
+	for _, s := range servers {
+		if !proxy.Unregister(s) {
+			t.Errorf("Failed to unregister server %s", s.Name())
+		}
+	}
+	
+	eventMgr.Wait()
+	
+	// Verify all unregistration events were fired
+	if unregisteredCount != 3 {
+		t.Errorf("Expected 3 unregistered events, got %d", unregisteredCount)
+	}
+}


### PR DESCRIPTION
Add `ServerRegisteredEvent` and `ServerUnregisteredEvent` to allow plugins to react to dynamic server changes.

closes #592

---
<a href="https://cursor.com/background-agent?bcId=bc-f1a1158a-c2be-4258-b8c9-ffc120fb904b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f1a1158a-c2be-4258-b8c9-ffc120fb904b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

