### PR TITLE
Fix broken .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,4 @@
 /.web/docs/.vitepress/cache
 tmp
 .geyser
-gate
+./gate


### PR DESCRIPTION
In eadb1fc an issue got introduced by adding `gate` to the `.gitignore`, which makes it so that each and every file named `gate` is ignored. This includes changes/additions to files inside the `pkg/gate` directory.

This PR fixes that by ignoring `gate`, but only inside the root.