### PR TITLE
Fix SoundEntityPacket panic and protocol desync

### DIFF
--- a/pkg/edition/java/proto/packet/sound.go
+++ b/pkg/edition/java/proto/packet/sound.go
@@ -131,10 +131,7 @@ func (s *SoundEntityPacket) Decode(c *proto.PacketContext, rd io.Reader) (err er
 	if s.SoundID == 0 {
 		pr.MinimalKey(&s.SoundName)
 
-		var hasFixedRange bool
-		pr.Bool(&hasFixedRange)
-
-		if hasFixedRange {
+		if pr.Ok() {
 			var fixedRange float32
 			pr.Float32(&fixedRange)
 			s.FixedRange = &fixedRange


### PR DESCRIPTION
This fixes a crash "Internal Server Error" that occurred when playing sounds attached to entities.

- fix encode panic: the encoder was attempting to dereference FixedRange before verifying it wasn't nil.
- fix decode desync: the decoder was missing the HasFixedRange boolean read, causing it to read garbage data for the rest of the packet.

this fixes #600 