### PR TITLE
feat: add option to disable auto config reload

### DIFF
--- a/.web/docs/guide/config/reload.md
+++ b/.web/docs/guide/config/reload.md
@@ -1,6 +1,6 @@
 ---
-title: "Gate Auto Config Reload - Live Configuration Updates"
-description: "Learn about Gate automatic config reloading feature. Update server settings without restarting or disconnecting players."
+title: 'Gate Auto Config Reload - Live Configuration Updates'
+description: 'Learn about Gate automatic config reloading feature. Update server settings without restarting or disconnecting players.'
 ---
 
 # Auto Config Reload
@@ -41,6 +41,26 @@ This feature is always enabled by default, given that you have a config file.
 
 ## How to disable it
 
-Please note that the auto config reload feature cannot be disabled.
-If you feel a compelling need to do so, please don't hesitate to [open an issue](https://github.com/minekube/gate/issues/new?title=Disable%20auto%20config%20reload&body=I%20want%20to%20disable%20auto%20config%20reload%20because%20...)
-on our GitHub repository.
+You can disable auto config reload in several ways:
+
+### Command line flag
+
+```bash
+gate --no-auto-reload
+```
+
+### Environment variable
+
+```bash
+GATE_NO_AUTO_RELOAD=true gate
+```
+
+### Config file
+
+Add to your `config.yml`:
+
+```yaml
+noAutoReload: true
+```
+
+This is useful in environments where file watching is not available or causes permission issues (e.g., NixOS with sops-nix).

--- a/pkg/gate/config/config.go
+++ b/pkg/gate/config/config.go
@@ -33,6 +33,9 @@ type Config struct {
 	Connect connect.Config `json:"connect,omitempty" yaml:"connect,omitempty"`
 	// See API struct.
 	API API `json:"api,omitempty" yaml:"api,omitempty"`
+	// NoAutoReload disables automatic config file reloading.
+	// This is useful in environments where file watching causes issues.
+	NoAutoReload bool `json:"noAutoReload,omitempty" yaml:"noAutoReload,omitempty"`
 }
 
 // HealthService is a GRPC health probe service for use with Kubernetes pods.


### PR DESCRIPTION
Adds support for disabling automatic config file reloading via:

- `--no-auto-reload` command line flag
- `GATE_NO_AUTO_RELOAD` environment variable  
- `noAutoReload: true` config file option

This addresses issue #602 where auto reload fails with permission denied errors in environments like NixOS with sops-nix where file watching is not available or causes issues.

**Changes:**
- Added `--no-auto-reload` flag to CLI
- Added `GATE_NO_AUTO_RELOAD` environment variable support
- Added `noAutoReload` config option support
- Updated documentation to reflect the new disable option

**Usage examples:**
```bash
# Via flag
gate --no-auto-reload

# Via environment variable
GATE_NO_AUTO_RELOAD=true gate

# Via config file
# config.yml:
noAutoReload: true
```

Fixes #602