### PR TITLE
fix: wrap SetReader with fullReader to fix large packet read issues

### DIFF
--- a/pkg/edition/java/proto/codec/decoder.go
+++ b/pkg/edition/java/proto/codec/decoder.go
@@ -71,7 +71,7 @@ func (d *Decoder) setProtocol(protocol proto.Protocol) {
 
 func (d *Decoder) SetReader(rd io.Reader) {
 	d.mu.Lock()
-	d.rd = rd
+	d.rd = &fullReader{rd} // Wrap with fullReader to ensure complete reads
 	d.mu.Unlock()
 }
 


### PR DESCRIPTION
## Summary

When `SetReader` is called (e.g., after enabling encryption), the new reader was not wrapped with `fullReader`. This caused incomplete reads for large packets because a single `Read()` call may return fewer bytes than requested.

## Problem

The `Decoder` uses a `fullReader` wrapper to ensure complete reads via `io.ReadFull`:

```go
func NewDecoder(r io.Reader, ...) *Decoder {
    return &Decoder{
        rd: &fullReader{r}, // using the fullReader is essential here!
        ...
    }
}

type fullReader struct{ io.Reader }
func (fr *fullReader) Read(p []byte) (int, error) { return io.ReadFull(fr.Reader, p) }
```

However, `SetReader` did not wrap the new reader:

```go
func (d *Decoder) SetReader(rd io.Reader) {
    d.mu.Lock()
    d.rd = rd  // Missing fullReader wrapper!
    d.mu.Unlock()
}
```

When encryption is enabled, `SetReader` is called with a `cipher.StreamReader`, losing the `fullReader` protection. This causes large packets to be read incompletely, resulting in connection drops.

## Fix

Wrap the reader with `fullReader` in `SetReader()`:

```go
func (d *Decoder) SetReader(rd io.Reader) {
    d.mu.Lock()
    d.rd = &fullReader{rd}
    d.mu.Unlock()
}
```

## Testing

Tested with Syncmatica mod which sends large plugin messages (~100KB+) for schematic sharing. Before the fix, players were disconnected immediately after attempting to share schematics. After the fix, schematic sharing works correctly.

## Related Issues

Likely related to #587 (large modpack disconnection issues)