### PR TITLE
Implement Code of Conduct handling in player configuration

### DIFF
--- a/pkg/edition/java/proxy/events.go
+++ b/pkg/edition/java/proxy/events.go
@@ -414,6 +414,69 @@ func (e *PostLoginEvent) Player() Player {
 //
 //
 //
+//
+//
+
+// PlayerConfigurationStartEvent is fired when the backend starts the configuration stage
+//
+// This is the earliest proxy-side hook to send config-state packets (e.g. CodeOfConductPacket)
+// before configuration finishes.
+type PlayerConfigurationStartEvent struct {
+	player        Player
+	server        RegisteredServer
+	codeOfConduct []byte
+}
+
+// Player returns the player entering configuration stage.
+func (e *PlayerConfigurationStartEvent) Player() Player {
+	return e.player
+}
+
+// Server returns the backend server the player is currently configuring against.
+func (e *PlayerConfigurationStartEvent) Server() RegisteredServer {
+	return e.server
+}
+
+// SendCodeOfConduct asks the proxy to send CodeOfConductPacket to the client
+// and hold configuration completion until the player accepts.
+func (e *PlayerConfigurationStartEvent) SendCodeOfConduct(payload []byte) {
+	e.codeOfConduct = payload
+}
+
+// ShouldSendCodeOfConduct reports whether sending code-of-conduct packet was requested.
+func (e *PlayerConfigurationStartEvent) ShouldSendCodeOfConduct() bool {
+	return e.codeOfConduct != nil
+}
+
+// CodeOfConductPayload returns the payload previously provided via SendCodeOfConduct.
+func (e *PlayerConfigurationStartEvent) CodeOfConductPayload() []byte {
+	return e.codeOfConduct
+}
+
+//
+//
+//
+//
+//
+//
+
+// CodeOfConductAcceptEvent is fired when a player accepts the code of conduct
+// in config state (Minecraft 1.21.9+).
+type CodeOfConductAcceptEvent struct {
+	player Player
+}
+
+// Player returns the player that accepted the code of conduct.
+func (e *CodeOfConductAcceptEvent) Player() Player {
+	return e.player
+}
+
+//
+//
+//
+//
+//
+//
 
 // PlayerChooseInitialServerEvent is fired when a player has finished the login process,
 // and we need to choose the first server to connect to.

--- a/pkg/edition/java/proxy/session_backend_config.go
+++ b/pkg/edition/java/proxy/session_backend_config.go
@@ -26,6 +26,7 @@ type backendConfigSessionHandler struct {
 	serverConn          *serverConnection
 	requestCtx          *connRequestCxt
 	state               backendConfigSessionState
+	codeOfConductHold   bool
 	resourcePackToApply *ResourcePackInfo
 	log                 logr.Logger
 
@@ -66,11 +67,22 @@ func (b *backendConfigSessionHandler) HandlePacket(pc *proto.PacketContext) {
 	if !b.shouldHandle() {
 		return
 	}
+	if b.codeOfConductHold {
+		switch p := pc.Packet.(type) {
+		case *packet.KeepAlive:
+			b.handleKeepAlive(p)
+		case *packet.Disconnect:
+			b.handleDisconnect(p)
+		}
+		return
+	}
 	switch p := pc.Packet.(type) {
 	case *packet.KeepAlive:
 		b.handleKeepAlive(p)
 	case *config.StartUpdate:
 		b.forwardToServer(pc, nil)
+	case *config.CodeOfConductPacket:
+		b.handleCodeOfConductPacket(pc)
 	case *packet.ResourcePackRequest:
 		b.handleResourcePackRequest(p)
 	case *packet.RemoveResourcePack:
@@ -84,17 +96,7 @@ func (b *backendConfigSessionHandler) HandlePacket(pc *proto.PacketContext) {
 	case *plugin.Message:
 		b.handlePluginMessage(pc, p)
 	case *packet.Disconnect:
-		b.serverConn.disconnect()
-		// If the player receives a DisconnectPacket without a connection to a server in progress,
-		// it means that the backend server has kicked the player during reconfiguration
-		if b.serverConn.player.connectionInFlight() != nil {
-			result := disconnectResultForPacket(b.log.V(1), p,
-				b.serverConn.player.Protocol(), b.serverConn.server, true,
-			)
-			b.requestCtx.result(result, nil)
-		} else {
-			b.serverConn.player.handleDisconnect(b.serverConn.server, p, true)
-		}
+		b.handleDisconnect(p)
 	case *packet.Transfer:
 		b.handleTransfer(p)
 	case *cookie.CookieStore:
@@ -122,6 +124,16 @@ func (b *backendConfigSessionHandler) Activated() {
 	if player.Protocol() == version.Minecraft_1_20_2.Protocol {
 		b.resourcePackToApply = player.resourcePackHandler.FirstAppliedPack()
 		player.resourcePackHandler.ClearAppliedResourcePacks()
+	}
+
+	// Emit Configuration event and initiate CoC
+	e := &PlayerConfigurationStartEvent{
+		player: b.serverConn.player,
+		server: b.serverConn.server,
+	}
+	b.proxy().event.Fire(e)
+	if player.Protocol().Greater(version.Minecraft_1_21_9) && e.ShouldSendCodeOfConduct() {
+		b.initiateCodeOfConduct(e.CodeOfConductPayload())
 	}
 }
 
@@ -209,6 +221,48 @@ func (b *backendConfigSessionHandler) handleFinishedUpdate(p *config.FinishedUpd
 			_ = player.resourcePackHandler.QueueResourcePack(b.resourcePackToApply)
 		}
 	})
+}
+
+func (b *backendConfigSessionHandler) handleDisconnect(p *packet.Disconnect) {
+	b.serverConn.disconnect()
+	// If the player receives a DisconnectPacket without a connection to a server in progress,
+	// it means that the backend server has kicked the player during reconfiguration
+	if b.serverConn.player.connectionInFlight() != nil {
+		result := disconnectResultForPacket(b.log.V(1), p,
+			b.serverConn.player.Protocol(), b.serverConn.server, true,
+		)
+		b.requestCtx.result(result, nil)
+	} else {
+		b.serverConn.player.handleDisconnect(b.serverConn.server, p, true)
+	}
+}
+
+func (b *backendConfigSessionHandler) handleCodeOfConductPacket(pc *proto.PacketContext) {
+	b.requireCodeOfConduct()
+	b.forwardToPlayer(pc, nil)
+}
+
+func (b *backendConfigSessionHandler) initiateCodeOfConduct(payload []byte) {
+	b.requireCodeOfConduct()
+	if err := b.serverConn.player.WritePacket(&config.CodeOfConductPacket{Data: payload}); err != nil {
+		b.log.V(1).Error(err, "error writing CodeOfConduct packet")
+	}
+}
+
+func (b *backendConfigSessionHandler) requireCodeOfConduct() {
+	if b.codeOfConductHold {
+		return
+	}
+	b.codeOfConductHold = true
+	b.serverConn.connection.SetAutoReading(false)
+}
+
+func (b *backendConfigSessionHandler) releaseCodeOfConductHold() {
+	if !b.codeOfConductHold {
+		return
+	}
+	b.codeOfConductHold = false
+	b.serverConn.connection.SetAutoReading(true)
 }
 
 func (b *backendConfigSessionHandler) handleTransfer(p *packet.Transfer) {

--- a/pkg/edition/java/proxy/session_client_config.go
+++ b/pkg/edition/java/proxy/session_client_config.go
@@ -53,6 +53,9 @@ func (h *clientConfigSessionHandler) HandlePacket(pc *proto.PacketContext) {
 		forwardKeepAlive(p, h.player)
 	case *packet.ClientSettings:
 		h.player.setClientSettings(p)
+	case *config.CodeOfConductAcceptPacket:
+		h.markCodeOfConductAccepted()
+		forwardToServer(pc, h.player)
 	case *packet.ResourcePackResponse:
 		if !handleResourcePackResponse(p, h.player.resourcePackHandler, h.log) {
 			forwardToServer(pc, h.player)
@@ -102,6 +105,16 @@ func (h *clientConfigSessionHandler) handleBackendFinishUpdate(serverConn *serve
 	h.player.Writer().SetState(state.Play)
 
 	return &h.configSwitchDone
+}
+
+func (h *clientConfigSessionHandler) markCodeOfConductAccepted() {
+	if serverConn := h.player.connectionInFlightOrConnectedServer(); serverConn != nil {
+		if smc, ok := serverConn.ensureConnected(); ok {
+			if backendConfig, ok := smc.ActiveSessionHandler().(*backendConfigSessionHandler); ok {
+				backendConfig.releaseCodeOfConductHold()
+			}
+		}
+	}
 }
 
 func handleResourcePackResponse(p *packet.ResourcePackResponse, handler resourcepack.Handler, log logr.Logger) bool {


### PR DESCRIPTION
This PR introduces a new event-driven mechanism to handle the Code of Conduct (CoC) acceptance flow during the backend configuration stage for Minecraft 1.21.9+ clients.

The main changes add extensibility for sending and handling CoC packets, ensuring the proxy can pause configuration until the player accepts the CoC, and cleanly resume configuration afterward.

I am not entirely sure this is the best way to implement it. Let me know if there's a better way to do it, feedback appreciated!

---
Here is an implementation example on a proxy:
```go
return func(e *proxy.PlayerConfigurationStartEvent) {
  payload, ok := getCodeOfConduct(e.Player().Settings().Locale().String()) // returns []byte, bool
  if !ok {
	return
  }
  e.SendCodeOfConduct(payload)
}
```