### PR TITLE
fix: resolve architecture mismatch for multi-arch docker builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,9 +55,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
-
       - name: Set up docker buildx
         uses: docker/setup-buildx-action@v3
 
@@ -109,7 +106,7 @@ jobs:
           context: .
           file: ./Dockerfile
           push: true
-          platforms: linux/amd64,linux/arm64,linux/arm/v8
+          platforms: linux/amd64,linux/arm64
           cache-from: type=registry,ref=${{ steps.image-ref.outputs.image_latest }}
           cache-to: type=inline
           build-args: |
@@ -126,7 +123,7 @@ jobs:
           context: .
           file: ./Dockerfile
           push: true
-          platforms: linux/amd64,linux/arm64,linux/arm/v8
+          platforms: linux/amd64,linux/arm64
           cache-from: type=registry,ref=${{ steps.image-ref.outputs.image_jre_latest }}
           cache-to: type=inline
           build-args: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
+
       - name: Set up docker buildx
         uses: docker/setup-buildx-action@v3
 
@@ -106,7 +109,7 @@ jobs:
           context: .
           file: ./Dockerfile
           push: true
-          platforms: linux/amd64,linux/arm64,windows/amd64,windows/arm64,darwin/amd64,darwin/arm64,linux/arm/v7,linux/arm/v8,linux/s390x
+          platforms: linux/amd64,linux/arm64,linux/arm/v8
           cache-from: type=registry,ref=${{ steps.image-ref.outputs.image_latest }}
           cache-to: type=inline
           build-args: |
@@ -123,7 +126,7 @@ jobs:
           context: .
           file: ./Dockerfile
           push: true
-          platforms: linux/amd64,linux/arm64,windows/amd64,windows/arm64,darwin/amd64,darwin/arm64,linux/arm/v7,linux/arm/v8,linux/s390x
+          platforms: linux/amd64,linux/arm64,linux/arm/v8
           cache-from: type=registry,ref=${{ steps.image-ref.outputs.image_jre_latest }}
           cache-to: type=inline
           build-args: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,12 +22,12 @@ RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH \
     go build -ldflags="-s -w -X 'go.minekube.com/gate/pkg/version.Version=${VERSION}'" -a -o gate gate.go
 
 # Move binary into final image (default Gate image - distroless)
-FROM --platform=$BUILDPLATFORM gcr.io/distroless/static-debian12 AS gate
+FROM --platform=$TARGETPLATFORM gcr.io/distroless/static-debian12 AS gate
 COPY --from=build /workspace/gate /
 ENTRYPOINT ["/gate"]
 
 # Move binary into final image (jre variant Gate image - temurin-25-jre-alpine)
-FROM --platform=$BUILDPLATFORM eclipse-temurin:25.0.1_8-jre-alpine AS jre
+FROM --platform=$TARGETPLATFORM eclipse-temurin:25.0.1_8-jre-alpine AS jre
 COPY --from=build /workspace/gate /usr/local/bin/gate
 ENV PATH=/opt/java/openjdk/bin:$PATH
 ENTRYPOINT ["/usr/local/bin/gate"]


### PR DESCRIPTION
The build failed on arm64 systems with an exec format error because using $BUILDPLATFORM forced the final stages to pull x86-based images instead of those matching the target architecture.To fix this, the Dockerfile now uses $TARGETPLATFORM for the final stages to ensure the correct native JRE and Distroless base images are pulled for each architecture. Additionally, the CI workflow now includes QEMU to enable proper emulation and multi-arch support for both amd64 and arm64 during the build process.

should resolve #681 