### PR TITLE
feat: harden login plugin-message and keep-alive handling

### DIFF
--- a/pkg/edition/java/proto/codec/decoder.go
+++ b/pkg/edition/java/proto/codec/decoder.go
@@ -190,9 +190,15 @@ func (d *Decoder) decompress(claimedUncompressedSize int, rd io.Reader) (decompr
 		return nil, errs.NewSilentErr("uncompressed size %d is less than set threshold %d",
 			claimedUncompressedSize, d.compressionThreshold)
 	}
-	if claimedUncompressedSize > UncompressedCap {
+	// Serverbound (client->proxy) data is untrusted, so cap it tighter than
+	// clientbound (backend->proxy) data.
+	maxSize := UncompressedCap
+	if d.direction == proto.ServerBound {
+		maxSize = ServerboundUncompressedCap
+	}
+	if claimedUncompressedSize > maxSize {
 		return nil, errs.NewSilentErr("uncompressed size %d exceeds hard threshold of %d",
-			claimedUncompressedSize, UncompressedCap)
+			claimedUncompressedSize, maxSize)
 	}
 
 	if d.zrd == nil {

--- a/pkg/edition/java/proto/codec/decoder_decompress_test.go
+++ b/pkg/edition/java/proto/codec/decoder_decompress_test.go
@@ -1,0 +1,35 @@
+package codec
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/require"
+
+	"go.minekube.com/gate/pkg/gate/proto"
+)
+
+// A serverbound packet must not be allowed to claim a decompressed size larger
+// than the serverbound cap, even when it is still within the larger clientbound
+// cap. This limits how much memory a client can force the proxy to allocate,
+// while trusted clientbound (backend->proxy) data keeps the higher limit.
+func TestDecompressServerboundCapTighterThanClientbound(t *testing.T) {
+	claimed := ServerboundUncompressedCap + 1 // over serverbound, under clientbound
+	require.Less(t, claimed, UncompressedCap, "test assumes serverbound cap < clientbound cap")
+
+	sb := NewDecoder(bytes.NewReader(nil), proto.ServerBound, logr.Discard())
+	sb.SetCompressionThreshold(256)
+	_, err := sb.decompress(claimed, bytes.NewReader(nil))
+	require.Error(t, err, "serverbound decompress should reject a claim over the serverbound cap")
+	require.Contains(t, err.Error(), "exceeds")
+
+	cb := NewDecoder(bytes.NewReader(nil), proto.ClientBound, logr.Discard())
+	cb.SetCompressionThreshold(256)
+	_, err = cb.decompress(claimed, bytes.NewReader(nil))
+	// The claim is under the clientbound cap, so it passes the size check (and
+	// then fails on the empty zlib stream — a different error, not the cap).
+	if err != nil {
+		require.NotContains(t, err.Error(), "exceeds")
+	}
+}

--- a/pkg/edition/java/proto/codec/encoder.go
+++ b/pkg/edition/java/proto/codec/encoder.go
@@ -21,6 +21,11 @@ const (
 	VanillaMaximumUncompressedSize = 8 * 1024 * 1024   // 8MiB
 	HardMaximumUncompressedSize    = 128 * 1024 * 1024 // 128MiB
 	UncompressedCap                = VanillaMaximumUncompressedSize
+	// ServerboundUncompressedCap is the maximum claimed decompressed size for a
+	// serverbound packet. It is tighter than UncompressedCap because serverbound
+	// data comes from the (untrusted) client, limiting how much memory a client
+	// can force the proxy to allocate. Clientbound data keeps UncompressedCap.
+	ServerboundUncompressedCap = 2 * 1024 * 1024 // 2MiB
 )
 
 // Encoder is a synchronized packet encoder.

--- a/pkg/edition/java/proto/packet/plugin/message.go
+++ b/pkg/edition/java/proto/packet/plugin/message.go
@@ -1,12 +1,19 @@
 package plugin
 
 import (
+	"fmt"
 	"io"
 
 	"go.minekube.com/gate/pkg/edition/java/proto/util"
 	"go.minekube.com/gate/pkg/edition/java/proto/version"
 	"go.minekube.com/gate/pkg/gate/proto"
 )
+
+// MaxServerboundPayloadSize is the maximum size (in bytes) of a serverbound
+// plugin message payload. This matches the vanilla client limit; rejecting
+// larger serverbound payloads prevents a client from abusing plugin messages.
+// Clientbound payloads (proxy<-backend) are not subject to this limit.
+const MaxServerboundPayloadSize = 32767
 
 // Message is a Minecraft plugin message packet.
 type Message struct {
@@ -40,7 +47,17 @@ func (p *Message) Decode(c *proto.PacketContext, r io.Reader) (err error) {
 		p.Channel = TransformLegacyToModernChannel(p.Channel)
 	}
 	if c.Protocol.GreaterEqual(version.Minecraft_1_8) {
-		p.Data, err = io.ReadAll(r)
+		if c.Direction == proto.ServerBound {
+			// Reject serverbound payloads larger than the vanilla limit. Read one
+			// byte past the limit so we can detect (rather than silently truncate).
+			p.Data, err = io.ReadAll(io.LimitReader(r, MaxServerboundPayloadSize+1))
+			if err == nil && len(p.Data) > MaxServerboundPayloadSize {
+				return fmt.Errorf("serverbound plugin message payload too large: %d > %d bytes",
+					len(p.Data), MaxServerboundPayloadSize)
+			}
+		} else {
+			p.Data, err = io.ReadAll(r)
+		}
 	} else {
 		p.Data, err = util.ReadBytes17(r)
 	}

--- a/pkg/edition/java/proto/packet/plugin/message_test.go
+++ b/pkg/edition/java/proto/packet/plugin/message_test.go
@@ -1,0 +1,54 @@
+package plugin
+
+import (
+	"bytes"
+	"testing"
+
+	"go.minekube.com/gate/pkg/edition/java/proto/util"
+	"go.minekube.com/gate/pkg/edition/java/proto/version"
+	"go.minekube.com/gate/pkg/gate/proto"
+)
+
+// buildModernMessage encodes a 1.8+ plugin message frame (channel + raw data).
+func buildModernMessage(t *testing.T, channel string, dataLen int) *bytes.Buffer {
+	t.Helper()
+	buf := new(bytes.Buffer)
+	if err := util.WriteString(buf, channel); err != nil {
+		t.Fatal(err)
+	}
+	buf.Write(bytes.Repeat([]byte{0x7f}, dataLen))
+	return buf
+}
+
+func decodeMessage(t *testing.T, dir proto.Direction, data *bytes.Buffer) error {
+	t.Helper()
+	var m Message
+	ctx := &proto.PacketContext{Direction: dir, Protocol: version.Minecraft_1_21.Protocol}
+	return m.Decode(ctx, data)
+}
+
+// A serverbound plugin message larger than the vanilla 32767-byte limit must be
+// rejected so a client cannot abuse it.
+func TestDecodeServerboundPluginMessageRejectsOversized(t *testing.T) {
+	buf := buildModernMessage(t, "minecraft:brand", 32768)
+	if err := decodeMessage(t, proto.ServerBound, buf); err == nil {
+		t.Fatal("expected error decoding oversized serverbound plugin message, got nil")
+	}
+}
+
+// A serverbound plugin message at or below the limit must decode fine.
+func TestDecodeServerboundPluginMessageAllowsWithinLimit(t *testing.T) {
+	buf := buildModernMessage(t, "minecraft:brand", 32767)
+	if err := decodeMessage(t, proto.ServerBound, buf); err != nil {
+		t.Fatalf("unexpected error decoding within-limit serverbound plugin message: %v", err)
+	}
+}
+
+// Clientbound messages (proxy<-backend) may legitimately be large and must not
+// be subject to the serverbound limit.
+func TestDecodeClientboundPluginMessageAllowsLarge(t *testing.T) {
+	buf := buildModernMessage(t, "minecraft:brand", 100000)
+	if err := decodeMessage(t, proto.ClientBound, buf); err != nil {
+		t.Fatalf("unexpected error decoding large clientbound plugin message: %v", err)
+	}
+}

--- a/pkg/edition/java/proto/version/version.go
+++ b/pkg/edition/java/proto/version/version.go
@@ -52,7 +52,7 @@ var (
 	Minecraft_1_21_7  = v(772, "1.21.7", "1.21.8")
 	Minecraft_1_21_9  = v(773, "1.21.9", "1.21.10")
 	Minecraft_1_21_11 = v(774, "1.21.11")
-	Minecraft_26_1    = v(775, "26.1")
+	Minecraft_26_1    = v(775, "26.1", "26.1.1", "26.1.2")
 
 	// Versions ordered from lowest to highest
 	Versions = []*proto.Version{

--- a/pkg/edition/java/proxy/session_client_play.go
+++ b/pkg/edition/java/proxy/session_client_play.go
@@ -54,9 +54,68 @@ type clientPlaySessionHandler struct {
 
 	mu struct {
 		sync.RWMutex
-		loginPluginMessages deque.Deque[*plugin.Message]
-		serverBossBars      map[uuid.UUID]struct{}
+		loginPluginMessages           deque.Deque[*plugin.Message]
+		loginPluginMessagesBytes      int
+		loginPluginMessagesOverflowed bool
+		serverBossBars                map[uuid.UUID]struct{}
 	}
+}
+
+// Caps on the pre-join plugin-message queue (loginPluginMessages). A client that
+// never completes its login/FML handshake phase could otherwise queue plugin
+// messages without bound. The count/byte limits mirror Velocity's.
+const (
+	maxQueuedLoginPluginMessages     = 1024
+	maxQueuedLoginPluginMessageBytes = 4 * 1024 * 1024 // 4 MiB
+)
+
+// enqueueLoginPluginMessage queues a plugin message received before the player
+// has joined a server, enforcing per-connection count and byte caps. It returns
+// true if the message was queued, or false if a cap was exceeded — in which case
+// the queue is dropped, the player disconnected, and the overflow latched so
+// subsequent messages are rejected without further work.
+func (c *clientPlaySessionHandler) enqueueLoginPluginMessage(msg *plugin.Message) bool {
+	c.mu.Lock()
+	if c.mu.loginPluginMessagesOverflowed {
+		c.mu.Unlock()
+		return false
+	}
+	newBytes := c.mu.loginPluginMessagesBytes + len(msg.Data)
+	newCount := c.mu.loginPluginMessages.Len() + 1
+	if newBytes > maxQueuedLoginPluginMessageBytes || newCount > maxQueuedLoginPluginMessages {
+		c.mu.loginPluginMessagesOverflowed = true
+		c.mu.loginPluginMessages.Clear()
+		c.mu.loginPluginMessagesBytes = 0
+		c.mu.Unlock()
+		c.log.Info("disconnecting player: pre-join plugin message queue exceeded its limits",
+			"messages", newCount, "bytes", newBytes)
+		c.player.Disconnect(&component.Text{
+			Content: "Too many plugin messages were sent before joining a server",
+		})
+		return false
+	}
+	c.mu.loginPluginMessages.PushBack(msg)
+	c.mu.loginPluginMessagesBytes = newBytes
+	c.mu.Unlock()
+	return true
+}
+
+// drainQueuedLoginPluginMessages removes and returns all queued pre-join plugin
+// messages, resetting the byte counter so the queue caps start fresh. Returns
+// nil if the queue is empty.
+func (c *clientPlaySessionHandler) drainQueuedLoginPluginMessages() []*plugin.Message {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.mu.loginPluginMessagesBytes = 0
+	n := c.mu.loginPluginMessages.Len()
+	if n == 0 {
+		return nil
+	}
+	msgs := make([]*plugin.Message, 0, n)
+	for c.mu.loginPluginMessages.Len() != 0 {
+		msgs = append(msgs, c.mu.loginPluginMessages.PopFront())
+	}
+	return msgs
 }
 
 func newClientPlaySessionHandler(player *connectedPlayer) *clientPlaySessionHandler {
@@ -128,6 +187,8 @@ func (c *clientPlaySessionHandler) Deactivated() {
 	c.mu.Lock()
 	c.player.discardChatQueue()
 	c.mu.loginPluginMessages.Clear()
+	c.mu.loginPluginMessagesBytes = 0
+	c.mu.loginPluginMessagesOverflowed = false
 	c.mu.Unlock()
 }
 
@@ -177,10 +238,7 @@ func (c *clientPlaySessionHandler) FlushQueuedPluginMessages() {
 	if !ok {
 		return
 	}
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	for c.mu.loginPluginMessages.Len() != 0 {
-		pm := c.mu.loginPluginMessages.PopFront()
+	for _, pm := range c.drainQueuedLoginPluginMessages() {
 		_ = serverMc.BufferPacket(pm)
 	}
 	_ = serverMc.Flush()
@@ -232,16 +290,30 @@ func forwardKeepAlive(p *packet.KeepAlive, player *connectedPlayer) {
 }
 
 func sendKeepAliveToBackend(serverConn *serverConnection, player *connectedPlayer, p *packet.KeepAlive) bool {
-	if serverConn != nil {
-		if sentTime, ok := serverConn.pendingPings.Get(p.RandomID); ok {
-			serverConn.pendingPings.Delete(p.RandomID)
-			if serverMc := serverConn.conn(); serverMc != nil {
-				player.ping.Store(time.Since(sentTime))
-				return serverMc.WritePacket(p) == nil
-			}
-		}
+	if serverConn == nil {
+		return false
 	}
-	return false
+	sentTime, ok := serverConn.pendingPings.Get(p.RandomID)
+	if !ok {
+		return false
+	}
+	// We removed this pending ping, so it is ours: consume it regardless of
+	// whether it can be forwarded, so it is not re-dispatched to another
+	// connection.
+	serverConn.pendingPings.Delete(p.RandomID)
+
+	// Only forward to the backend when it is open and in the same protocol state
+	// as the client. During a server switch the backend may be in CONFIG while
+	// the client is still in PLAY; forwarding then would mis-encode the packet.
+	serverMc := serverConn.conn()
+	clientState := player.State()
+	if serverMc != nil && !netmc.Closed(serverMc) &&
+		clientState == serverMc.State() &&
+		(clientState == state.Config || clientState == state.Play) {
+		player.ping.Store(time.Since(sentTime))
+		_ = serverMc.WritePacket(p)
+	}
+	return true
 }
 
 func (c *clientPlaySessionHandler) handlePluginMessage(packet *plugin.Message) {
@@ -334,10 +406,9 @@ func (c *clientPlaySessionHandler) handlePluginMessage(packet *plugin.Message) {
 		// JoinGame packet has been received by the proxy, whichever comes first.
 		//
 		// We also need to make sure to retain these packets, so they can be flushed
-		// appropriately.
-		c.mu.Lock()
-		c.mu.loginPluginMessages.PushBack(packet)
-		c.mu.Unlock()
+		// appropriately. The queue is bounded to prevent a client that never
+		// completes its handshake phase from growing it without limit.
+		c.enqueueLoginPluginMessage(packet)
 	}
 }
 
@@ -483,8 +554,7 @@ func (c *clientPlaySessionHandler) handleBackendJoinGame(pc *proto.PacketContext
 	}
 
 	// If we had plugin messages queued during login/FML handshake, send them now.
-	for c.mu.loginPluginMessages.Len() != 0 {
-		pm := c.mu.loginPluginMessages.PopFront()
+	for _, pm := range c.drainQueuedLoginPluginMessages() {
 		if err = serverMc.BufferPacket(pm); err != nil {
 			return fmt.Errorf("error buffering %T for backend: %w", pm, err)
 		}

--- a/pkg/edition/java/proxy/session_client_play_keepalive_test.go
+++ b/pkg/edition/java/proxy/session_client_play_keepalive_test.go
@@ -1,0 +1,85 @@
+package proxy
+
+import (
+	"testing"
+	"time"
+
+	"github.com/dboslee/lru"
+	"github.com/go-logr/logr"
+	"go.minekube.com/gate/pkg/edition/java/netmc"
+	"go.minekube.com/gate/pkg/edition/java/proto/packet"
+	"go.minekube.com/gate/pkg/edition/java/proto/state"
+	"go.minekube.com/gate/pkg/gate/proto"
+)
+
+// keepAliveTestConn is a MinecraftConn whose protocol state is configurable and
+// which records written packets.
+type keepAliveTestConn struct {
+	*testMinecraftConn
+	st      *state.Registry
+	written []proto.Packet
+}
+
+func (c *keepAliveTestConn) State() *state.Registry { return c.st }
+func (c *keepAliveTestConn) WritePacket(p proto.Packet) error {
+	c.written = append(c.written, p)
+	return nil
+}
+
+var _ netmc.MinecraftConn = (*keepAliveTestConn)(nil)
+
+func newKeepAliveFixture(clientState, backendState *state.Registry) (*connectedPlayer, *serverConnection, *keepAliveTestConn) {
+	client := &keepAliveTestConn{testMinecraftConn: &testMinecraftConn{}, st: clientState}
+	player := &connectedPlayer{MinecraftConn: client, log: logr.Discard()}
+	backend := &keepAliveTestConn{testMinecraftConn: &testMinecraftConn{}, st: backendState}
+	sc := &serverConnection{
+		player:       player,
+		log:          logr.Discard(),
+		pendingPings: lru.NewSync[int64, time.Time](lru.WithCapacity(5)),
+	}
+	sc.connection = backend
+	return player, sc, backend
+}
+
+// When the client and backend are in the same (PLAY) state, the keep-alive is
+// forwarded to the backend and consumed.
+func TestSendKeepAliveForwardsWhenStatesMatch(t *testing.T) {
+	player, sc, backend := newKeepAliveFixture(state.Play, state.Play)
+	const id = int64(777)
+	sc.pendingPings.Set(id, time.Now().Add(-5*time.Millisecond))
+
+	if !sendKeepAliveToBackend(sc, player, &packet.KeepAlive{RandomID: id}) {
+		t.Fatal("expected keep-alive to be consumed (true)")
+	}
+	if len(backend.written) != 1 {
+		t.Fatalf("expected keep-alive forwarded once, got %d writes", len(backend.written))
+	}
+}
+
+// When the backend is in a different state than the client (e.g. mid server
+// switch the backend is in CONFIG while the client is in PLAY), the keep-alive
+// must NOT be written to the backend (it would mis-encode), but it must still be
+// consumed so it is not re-dispatched to another connection.
+func TestSendKeepAliveDropsOnStateMismatch(t *testing.T) {
+	player, sc, backend := newKeepAliveFixture(state.Play, state.Config)
+	const id = int64(888)
+	sc.pendingPings.Set(id, time.Now())
+
+	if !sendKeepAliveToBackend(sc, player, &packet.KeepAlive{RandomID: id}) {
+		t.Fatal("expected keep-alive to be consumed (true) even on mismatch")
+	}
+	if len(backend.written) != 0 {
+		t.Fatalf("expected no forward on state mismatch, got %d writes", len(backend.written))
+	}
+}
+
+// An unknown random id (no matching pending ping) is not ours: return false.
+func TestSendKeepAliveIgnoresUnknownPing(t *testing.T) {
+	player, sc, backend := newKeepAliveFixture(state.Play, state.Play)
+	if sendKeepAliveToBackend(sc, player, &packet.KeepAlive{RandomID: 999}) {
+		t.Fatal("expected false for unknown ping id")
+	}
+	if len(backend.written) != 0 {
+		t.Fatalf("expected no writes for unknown ping, got %d", len(backend.written))
+	}
+}

--- a/pkg/edition/java/proxy/session_client_play_queue_test.go
+++ b/pkg/edition/java/proxy/session_client_play_queue_test.go
@@ -1,0 +1,78 @@
+package proxy
+
+import (
+	"testing"
+
+	"github.com/go-logr/logr"
+	"go.minekube.com/gate/pkg/edition/java/proto/packet/plugin"
+)
+
+func newTestPlayHandler() *clientPlaySessionHandler {
+	player := &connectedPlayer{
+		MinecraftConn: &testMinecraftConn{},
+		log:           logr.Discard(),
+	}
+	return &clientPlaySessionHandler{player: player, log: logr.Discard()}
+}
+
+// A client that never finishes its login/FML phase can spam pre-join plugin
+// messages. The queue must be bounded by message count and the player kicked
+// once the cap is exceeded.
+func TestEnqueueLoginPluginMessageCountCap(t *testing.T) {
+	h := newTestPlayHandler()
+	small := func() *plugin.Message { return &plugin.Message{Channel: "x", Data: []byte{0x1}} }
+
+	for i := 0; i < maxQueuedLoginPluginMessages; i++ {
+		if !h.enqueueLoginPluginMessage(small()) {
+			t.Fatalf("enqueue %d rejected unexpectedly", i)
+		}
+	}
+	if h.enqueueLoginPluginMessage(small()) {
+		t.Fatal("expected rejection once message-count cap is exceeded")
+	}
+	if got := h.mu.loginPluginMessages.Len(); got > maxQueuedLoginPluginMessages {
+		t.Fatalf("queue grew past cap: len=%d", got)
+	}
+	// Overflow is latched: further enqueues keep failing.
+	if h.enqueueLoginPluginMessage(small()) {
+		t.Fatal("expected rejection after overflow latched")
+	}
+}
+
+// A single oversized batch (by total bytes) must also trip the cap.
+func TestEnqueueLoginPluginMessageByteCap(t *testing.T) {
+	h := newTestPlayHandler()
+	big := &plugin.Message{Channel: "x", Data: make([]byte, maxQueuedLoginPluginMessageBytes+1)}
+	if h.enqueueLoginPluginMessage(big) {
+		t.Fatal("expected rejection when message exceeds the byte cap")
+	}
+}
+
+// Draining the queue (on flush) must reset the byte counter, otherwise the byte
+// cap would trip prematurely for messages queued after a flush and wrongly
+// disconnect a legitimate player.
+func TestDrainQueuedLoginPluginMessagesResetsByteCounter(t *testing.T) {
+	h := newTestPlayHandler()
+	for i := 0; i < 3; i++ {
+		if !h.enqueueLoginPluginMessage(&plugin.Message{Data: make([]byte, 1000)}) {
+			t.Fatalf("enqueue %d rejected unexpectedly", i)
+		}
+	}
+
+	drained := h.drainQueuedLoginPluginMessages()
+	if len(drained) != 3 {
+		t.Fatalf("drained %d messages, want 3", len(drained))
+	}
+
+	h.mu.RLock()
+	gotBytes, gotLen := h.mu.loginPluginMessagesBytes, h.mu.loginPluginMessages.Len()
+	h.mu.RUnlock()
+	if gotBytes != 0 || gotLen != 0 {
+		t.Fatalf("after drain: bytes=%d len=%d, want 0/0", gotBytes, gotLen)
+	}
+
+	// A fresh message just under the byte cap must still be accepted.
+	if !h.enqueueLoginPluginMessage(&plugin.Message{Data: make([]byte, maxQueuedLoginPluginMessageBytes-1)}) {
+		t.Fatal("byte cap tripped early after drain (counter leaked)")
+	}
+}


### PR DESCRIPTION
Hardening fixes for the login / plugin-message / keep-alive / compression paths. Each behavioral change ships with a focused unit test; the full repo test suite is green.

## Changes

| Area | Change | Test |
|------|--------|------|
| **Plugin message** | Reject **serverbound** plugin-message payloads larger than the vanilla `32767`-byte limit (clientbound unchanged) | `message_test.go` |
| **Compression** | Cap a **serverbound** packet's claimed decompressed size at `2 MiB` (clientbound keeps the `8 MiB` vanilla cap) | `decoder_decompress_test.go` |
| **Client play (DoS)** | Bound the pre-join `loginPluginMessages` queue by count (`1024`) and total bytes (`4 MiB`); disconnect on overflow | `session_client_play_queue_test.go` |
| **Keep-alive** | Forward a keep-alive to the backend only when it is open and in the **same protocol state** as the client (CONFIG/PLAY); always consume the pending ping | `session_client_play_keepalive_test.go` |
| **Versions** | The `Minecraft_26_1` entry lists all protocol-775 release names (`26.1`, `26.1.1`, `26.1.2`) | — |

### Why these matter
- **Serverbound payload, decompression, and pre-join queue caps** — serverbound data comes from the untrusted client; these three bounds together limit how much memory a client can force the proxy to allocate (a client that never finishes its login/FML handshake previously had an unbounded queue; decompression was capped at 8 MiB regardless of direction).
- **Keep-alive state guard** — during a server switch the backend may be in CONFIG while the client is still in PLAY; forwarding a PLAY-encoded keep-alive into a CONFIG-state backend would mis-encode the packet. The fix also stops a consumed ping from being re-dispatched to another connection.

The serverbound bounds and keep-alive guard follow the approach Velocity uses for the same paths.

## Related upstream changes intentionally out of scope
- **Packet rate-limiter subsystem** (per-connection bytes/packets-per-second) — large new feature with no direct analog in Gate's `netmc` layer; Gate already has connection/login quotas (`config.quota`). Belongs in its own PR.
- **Backend `disconnected()` result change** — Gate's `result(nil, err)` already yields a graceful, recovery-eligible disconnect via `handleConnectionErr`; the upstream change addresses a Java `CompletableFuture` detail with no Go equivalent.
- **Netty-specific changes** (ByteBuf refcount handling, frame-decoder index handling, backend large-packet flush batching, status player-sample bound, MiniMessage/HTTP-client cleanups) — N/A: Gate's Go codec/forwarding model has no analogous code.

## Verification
- `go build ./...` — clean
- `go vet ./pkg/edition/java/...` — clean
- `go test ./...` — all packages pass (0 failures)
- `gofmt` — clean