### PR TITLE
feat: per-connection serverbound packet rate limiter

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -134,6 +134,17 @@ config:
       burst: 3
       ops: 0.4
       maxEntries: 1000
+  # Per-connection serverbound packet rate limiting. Unlike quota (which limits
+  # new connections/logins per IP), this bounds how many packets/bytes a single
+  # already-connected client may send, mitigating packet floods. The connection
+  # is closed when a limit is exceeded.
+  packetLimiter:
+    # The sliding window the rates are measured over.
+    interval: 7s
+    # Max serverbound packets per second per connection. Set to 0 (or below) to disable.
+    packetsPerSecond: 500
+    # Max serverbound bytes per second per connection. Set to 0 (or below) to disable.
+    bytesPerSecond: -1
   # Whether and how Gate should reply to GameSpy 4 (Minecraft query protocol on UDP) requests.
   query:
     enabled: false

--- a/pkg/edition/java/config/config.go
+++ b/pkg/edition/java/config/config.go
@@ -57,6 +57,11 @@ var DefaultConfig = Config{
 			MaxEntries: 1000,
 		},
 	},
+	PacketLimiter: PacketLimiter{
+		Interval:         configutil.Duration(7 * time.Second),
+		PacketsPerSecond: 500,
+		BytesPerSecond:   -1, // disabled by default; packet-rate limiting is enough for most setups
+	},
 	Compression: Compression{
 		Threshold: 256,
 		Level:     -1,
@@ -105,10 +110,11 @@ type Config struct { // TODO use https://github.com/projectdiscovery/yamldoc-go 
 	ConnectionTimeout configutil.Duration `yaml:"connectionTimeout,omitempty" json:"connectionTimeout,omitempty"` // Write timeout
 	ReadTimeout       configutil.Duration `yaml:"readTimeout,omitempty" json:"readTimeout,omitempty"`             // Read timeout
 
-	Quota                Quota       `yaml:"quota,omitempty" json:"quota,omitempty"` // Rate limiting settings
-	Compression          Compression `yaml:"compression,omitempty" json:"compression,omitempty"`
-	ProxyProtocol        bool        `yaml:"proxyProtocol,omitempty" json:"proxyProtocol,omitempty"`     // Enable HA-Proxy protocol mode
-	ProxyProtocolBackend bool        `yaml:"proxyProtocolBackend" json:"proxyProtocolBackend,omitempty"` // Enable HA-Proxy protocol mode for backend servers
+	Quota                Quota         `yaml:"quota,omitempty" json:"quota,omitempty"`                 // Rate limiting settings
+	PacketLimiter        PacketLimiter `yaml:"packetLimiter,omitempty" json:"packetLimiter,omitempty"` // Per-connection serverbound packet rate limiting
+	Compression          Compression   `yaml:"compression,omitempty" json:"compression,omitempty"`
+	ProxyProtocol        bool          `yaml:"proxyProtocol,omitempty" json:"proxyProtocol,omitempty"`     // Enable HA-Proxy protocol mode
+	ProxyProtocolBackend bool          `yaml:"proxyProtocolBackend" json:"proxyProtocolBackend,omitempty"` // Enable HA-Proxy protocol mode for backend servers
 
 	ShouldPreventClientProxyConnections bool `yaml:"shouldPreventClientProxyConnections" json:"shouldPreventClientProxyConnections,omitempty"` // Sends player IP to Mojang on login
 
@@ -154,7 +160,15 @@ type (
 	Quota struct {
 		Connections QuotaSettings `yaml:"connections"` // Limits new connections per second, per IP block.
 		Logins      QuotaSettings `yaml:"logins"`      // Limits logins per second, per IP block.
-		// Maybe add a bytes-per-sec limiter, or should be managed by a higher layer.
+	}
+	// PacketLimiter limits how many serverbound packets/bytes a single connection
+	// may send over a sliding window, mitigating packet floods from already
+	// connected clients (the Quota limits only apply at connect/login time).
+	// A limit <= 0 disables that dimension; if both are <= 0 the limiter is off.
+	PacketLimiter struct {
+		Interval         configutil.Duration `yaml:"interval"`         // Sliding window the rates are measured over.
+		PacketsPerSecond int                 `yaml:"packetsPerSecond"` // Max serverbound packets/s per connection (<=0 disables).
+		BytesPerSecond   int                 `yaml:"bytesPerSecond"`   // Max serverbound bytes/s per connection (<=0 disables).
 	}
 	QuotaSettings struct {
 		Enabled    bool    `yaml:"enabled"`    // If false, there is no such limiting.
@@ -213,6 +227,10 @@ func (c *Config) Validate() (warns []error, errs []error) {
 				e("Invalid quota max entries %d, use a number >= 1", quota.Burst)
 			}
 		}
+	}
+
+	if pl := c.PacketLimiter; (pl.PacketsPerSecond > 0 || pl.BytesPerSecond > 0) && pl.Interval <= 0 {
+		w("Packet limiter has a rate set but interval <= 0; the limiter is disabled. Set packetLimiter.interval > 0 to enable it.")
 	}
 
 	if c.Lite.Enabled {

--- a/pkg/edition/java/netmc/connection.go
+++ b/pkg/edition/java/netmc/connection.go
@@ -27,6 +27,7 @@ import (
 	"go.minekube.com/gate/pkg/edition/java/proto/state"
 	"go.minekube.com/gate/pkg/edition/java/proto/version"
 	"go.minekube.com/gate/pkg/gate/proto"
+	"go.minekube.com/gate/pkg/internal/packetlimiter"
 	"go.minekube.com/gate/pkg/util/errs"
 )
 
@@ -141,6 +142,7 @@ func NewMinecraftConn(
 	readTimeout time.Duration,
 	writeTimeout time.Duration,
 	compressionLevel int,
+	packetLimiter *packetlimiter.Limiter,
 ) (conn MinecraftConn, startReadLoop func()) {
 	in := proto.ServerBound  // reads from client are server bound (proxy <- client)
 	out := proto.ClientBound // writes to client are client bound (proxy -> client)
@@ -156,17 +158,18 @@ func NewMinecraftConn(
 
 	ctx, cancel := context.WithCancel(ctx)
 	c := &minecraftConn{
-		log:         log,
-		c:           base,
-		ctx:         ctx,
-		cancelCtx:   cancel,
-		rd:          NewReader(base, in, readTimeout, log),
-		wr:          NewWriter(base, out, writeTimeout, compressionLevel, log),
-		state:       state.Handshake,
-		protocol:    version.Minecraft_1_7_2.Protocol,
-		connType:    phase.Undetermined,
-		direction:   direction,
-		autoReading: newStateControl(true),
+		log:           log,
+		c:             base,
+		ctx:           ctx,
+		cancelCtx:     cancel,
+		rd:            NewReader(base, in, readTimeout, log),
+		wr:            NewWriter(base, out, writeTimeout, compressionLevel, log),
+		state:         state.Handshake,
+		protocol:      version.Minecraft_1_7_2.Protocol,
+		connType:      phase.Undetermined,
+		direction:     direction,
+		autoReading:   newStateControl(true),
+		packetLimiter: packetLimiter,
 	}
 	c.sessionHandlerMu.sessionHandlers = make(map[*state.Registry]SessionHandler)
 	return c, c.startReadLoop
@@ -182,7 +185,8 @@ type minecraftConn struct {
 	rd Reader
 	wr Writer
 
-	autoReading *stateControl // Whether the connection should automatically read packets from the underlying connection.
+	autoReading   *stateControl          // Whether the connection should automatically read packets from the underlying connection.
+	packetLimiter *packetlimiter.Limiter // Per-connection serverbound rate limiter; nil disables it (e.g. backend connections).
 
 	ctx             context.Context // is canceled when connection closed
 	cancelCtx       context.CancelFunc
@@ -238,6 +242,14 @@ func (c *minecraftConn) startReadLoop() {
 			return false
 		}
 		bytesRead += int64(packetCtx.BytesRead)
+
+		// Enforce the per-connection serverbound packet rate limit (nil/disabled
+		// for backend connections and when not configured).
+		if !c.packetLimiter.Account(packetCtx.BytesRead) {
+			c.log.Info("serverbound packet rate limit exceeded, closing connection",
+				"remoteAddr", c.c.RemoteAddr())
+			return false
+		}
 
 		// TODO wrap packetCtx into struct with source info
 		// (minecraftConn) and chain into packet interceptor to...

--- a/pkg/edition/java/netmc/connection_limiter_test.go
+++ b/pkg/edition/java/netmc/connection_limiter_test.go
@@ -1,0 +1,104 @@
+package netmc
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+
+	"go.minekube.com/gate/pkg/edition/java/proto/codec"
+	"go.minekube.com/gate/pkg/edition/java/proto/packet"
+	"go.minekube.com/gate/pkg/edition/java/proto/state"
+	"go.minekube.com/gate/pkg/edition/java/proto/version"
+	"go.minekube.com/gate/pkg/gate/proto"
+	"go.minekube.com/gate/pkg/internal/packetlimiter"
+)
+
+type noopSessionHandler struct{}
+
+func (noopSessionHandler) HandlePacket(*proto.PacketContext) {}
+func (noopSessionHandler) Disconnected()                     {}
+func (noopSessionHandler) Activated()                        {}
+func (noopSessionHandler) Deactivated()                      {}
+
+// A client that floods serverbound packets past its rate limit must have its
+// connection closed by the read loop.
+func TestReadLoopClosesConnectionOnPacketFlood(t *testing.T) {
+	client, server := net.Pipe()
+	defer client.Close()
+
+	// 1 packet/s over a 1s window: the 2nd packet in the window trips the limit.
+	limiter := packetlimiter.New(1, -1, time.Second)
+	conn, startReadLoop := NewMinecraftConn(
+		context.Background(), server, proto.ServerBound,
+		5*time.Second, 5*time.Second, 0, limiter,
+	)
+	conn.SetActiveSessionHandler(state.Handshake, noopSessionHandler{})
+
+	done := make(chan struct{})
+	go func() { startReadLoop(); close(done) }()
+
+	// Flood handshake packets from the client side.
+	go func() {
+		enc := codec.NewEncoder(client, proto.ServerBound, logr.Discard())
+		hs := &packet.Handshake{
+			ProtocolVersion: int(version.Minecraft_1_21.Protocol),
+			ServerAddress:   "localhost",
+			Port:            25565,
+			NextStatus:      1,
+		}
+		for i := 0; i < 10; i++ {
+			if _, err := enc.WritePacket(hs); err != nil {
+				return // pipe closed once the limiter kicked in
+			}
+		}
+	}()
+
+	select {
+	case <-done:
+		if !Closed(conn) {
+			t.Fatal("read loop returned but connection is not closed")
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("connection was not closed after packet flood")
+	}
+}
+
+// Without a limiter, the same packet stream must NOT close the connection — this
+// guards against the flood test passing for an unrelated reason (e.g. a framing
+// or decode error).
+func TestReadLoopKeepsConnectionWithoutLimiter(t *testing.T) {
+	client, server := net.Pipe()
+	defer client.Close()
+
+	conn, startReadLoop := NewMinecraftConn(
+		context.Background(), server, proto.ServerBound,
+		5*time.Second, 5*time.Second, 0, nil, // no limiter
+	)
+	conn.SetActiveSessionHandler(state.Handshake, noopSessionHandler{})
+
+	done := make(chan struct{})
+	go func() { startReadLoop(); close(done) }()
+
+	enc := codec.NewEncoder(client, proto.ServerBound, logr.Discard())
+	hs := &packet.Handshake{
+		ProtocolVersion: int(version.Minecraft_1_21.Protocol),
+		ServerAddress:   "localhost",
+		Port:            25565,
+		NextStatus:      1,
+	}
+	for i := 0; i < 10; i++ {
+		if _, err := enc.WritePacket(hs); err != nil {
+			t.Fatalf("write %d failed (connection closed unexpectedly): %v", i, err)
+		}
+	}
+
+	select {
+	case <-done:
+		t.Fatal("connection closed without a limiter configured")
+	case <-time.After(200 * time.Millisecond):
+		// Still open after processing the flood, as expected.
+	}
+}

--- a/pkg/edition/java/proxy/proxy.go
+++ b/pkg/edition/java/proxy/proxy.go
@@ -32,6 +32,7 @@ import (
 	"go.minekube.com/gate/pkg/gate/proto"
 	"go.minekube.com/gate/pkg/internal/addrquota"
 	"go.minekube.com/gate/pkg/internal/connwrap"
+	"go.minekube.com/gate/pkg/internal/packetlimiter"
 	"go.minekube.com/gate/pkg/internal/reload"
 	"go.minekube.com/gate/pkg/util/errs"
 	"go.minekube.com/gate/pkg/util/netutil"
@@ -621,12 +622,16 @@ func (p *Proxy) HandleConn(raw net.Conn) {
 		raw = e.Connection()
 	}
 
-	// Create client connection
+	// Create client connection. Client connections are serverbound (untrusted),
+	// so apply the configured per-connection packet rate limiter.
+	pl := p.cfg.PacketLimiter
+	limiter := packetlimiter.New(pl.PacketsPerSecond, pl.BytesPerSecond, time.Duration(pl.Interval))
 	conn, readLoop := netmc.NewMinecraftConn(
 		ctx, raw, proto.ServerBound,
 		time.Duration(p.cfg.ReadTimeout)*time.Millisecond,
 		time.Duration(p.cfg.ConnectionTimeout)*time.Millisecond,
 		p.cfg.Compression.Level,
+		limiter,
 	)
 	conn.SetActiveSessionHandler(state.Handshake, newHandshakeSessionHandler(conn, &sessionHandlerDeps{
 		proxy:          p,

--- a/pkg/edition/java/proxy/server.go
+++ b/pkg/edition/java/proxy/server.go
@@ -410,6 +410,7 @@ func (s *serverConnection) connect(ctx context.Context) (result *connectionResul
 		time.Duration(s.config().ReadTimeout)*time.Millisecond,
 		time.Duration(s.config().ConnectionTimeout)*time.Millisecond,
 		s.config().Compression.Level,
+		nil, // backend connections are trusted; no serverbound rate limit
 	)
 	resultChan := make(chan *connResponse, 1)
 

--- a/pkg/internal/packetlimiter/counter.go
+++ b/pkg/internal/packetlimiter/counter.go
@@ -1,0 +1,98 @@
+package packetlimiter
+
+import "time"
+
+// counter is a sliding-window counter over a fixed interval. It keeps
+// (time, count) data points in a growable ring buffer, expiring entries older
+// than the interval and maintaining a running sum. Times are nanoseconds.
+//
+// It is a Go port of the IntervalledCounter approach used by Velocity/Paper.
+// Not safe for concurrent use; callers synchronize.
+type counter struct {
+	interval int64 // window length in nanoseconds
+	times    []int64
+	counts   []int64
+	head     int // inclusive
+	tail     int // exclusive
+	total    int64
+	minTime  int64
+}
+
+const initialCounterSize = 8
+
+func newCounter(interval time.Duration) *counter {
+	return &counter{
+		interval: int64(interval),
+		times:    make([]int64, initialCounterSize),
+		counts:   make([]int64, initialCounterSize),
+	}
+}
+
+// updateAndAdd expires entries older than the window relative to now, then
+// records count at now.
+func (c *counter) updateAndAdd(count, now int64) {
+	c.expire(now)
+	c.add(now, count)
+}
+
+// expire drops entries older than now-interval. Subtraction is used for the
+// comparison to stay correct across clock wraparound.
+func (c *counter) expire(now int64) {
+	minTime := now - c.interval
+	arrayLen := len(c.times)
+	for c.head != c.tail && c.times[c.head]-minTime < 0 {
+		c.total -= c.counts[c.head]
+		c.counts[c.head] = 0
+		c.head++
+		if c.head >= arrayLen {
+			c.head = 0
+		}
+	}
+	c.minTime = minTime
+}
+
+func (c *counter) add(now, count int64) {
+	if now-c.minTime < 0 {
+		return // older than the current window, ignore
+	}
+	nextTail := (c.tail + 1) % len(c.times)
+	if nextTail == c.head {
+		c.resize()
+		nextTail = (c.tail + 1) % len(c.times)
+	}
+	c.times[c.tail] = now
+	c.counts[c.tail] += count
+	c.total += count
+	c.tail = nextTail
+}
+
+func (c *counter) resize() {
+	oldTimes, oldCounts := c.times, c.counts
+	oldLen := len(oldTimes)
+	size := c.tail - c.head
+	if size < 0 {
+		size += oldLen
+	}
+	newTimes := make([]int64, oldLen*2)
+	newCounts := make([]int64, oldLen*2)
+	if c.tail >= c.head {
+		copy(newTimes, oldTimes[c.head:c.tail])
+		copy(newCounts, oldCounts[c.head:c.tail])
+	} else {
+		n := copy(newTimes, oldTimes[c.head:])
+		copy(newTimes[n:], oldTimes[:c.tail])
+		n = copy(newCounts, oldCounts[c.head:])
+		copy(newCounts[n:], oldCounts[:c.tail])
+	}
+	c.times, c.counts = newTimes, newCounts
+	c.head = 0
+	c.tail = size
+}
+
+// sum returns the total count currently within the window.
+func (c *counter) sum() int64 { return c.total }
+
+// rate returns the per-second rate over the window.
+func (c *counter) rate() float64 {
+	return float64(c.total) / (float64(c.interval) * 1e-9)
+}

--- a/pkg/internal/packetlimiter/counter_test.go
+++ b/pkg/internal/packetlimiter/counter_test.go
@@ -1,0 +1,54 @@
+package packetlimiter
+
+import (
+	"testing"
+	"time"
+)
+
+func TestCounterAccumulatesWithinWindow(t *testing.T) {
+	c := newCounter(time.Second)
+	base := int64(1_000_000_000)
+	c.updateAndAdd(10, base)
+	if got := c.sum(); got != 10 {
+		t.Fatalf("sum after first add = %d, want 10", got)
+	}
+	c.updateAndAdd(5, base+int64(500*time.Millisecond))
+	if got := c.sum(); got != 15 {
+		t.Fatalf("sum within window = %d, want 15", got)
+	}
+}
+
+func TestCounterExpiresOldEntries(t *testing.T) {
+	c := newCounter(time.Second)
+	base := int64(1_000_000_000)
+	c.updateAndAdd(10, base)                             // expires at base+1s
+	c.updateAndAdd(5, base+int64(500*time.Millisecond))  // still in window at base+1.5s
+	c.updateAndAdd(1, base+int64(1500*time.Millisecond)) // drops the base(10) entry
+	if got := c.sum(); got != 6 {                        // 5 + 1
+		t.Fatalf("sum after expiry = %d, want 6", got)
+	}
+}
+
+func TestCounterRatePerSecond(t *testing.T) {
+	c := newCounter(7 * time.Second)
+	now := int64(10_000_000_000)
+	for i := 0; i < 700; i++ {
+		c.updateAndAdd(1, now)
+	}
+	// rate = sum / windowSeconds = 700 / 7 = 100 per second
+	if got := c.rate(); got != 100 {
+		t.Fatalf("rate = %v, want 100", got)
+	}
+}
+
+// Many entries beyond the initial backing size must not corrupt the ring buffer.
+func TestCounterResizeKeepsSum(t *testing.T) {
+	c := newCounter(time.Hour) // huge window so nothing expires
+	now := int64(1_000_000_000)
+	for i := 0; i < 1000; i++ {
+		c.updateAndAdd(2, now+int64(i)) // distinct timestamps
+	}
+	if got := c.sum(); got != 2000 {
+		t.Fatalf("sum after 1000 adds = %d, want 2000", got)
+	}
+}

--- a/pkg/internal/packetlimiter/limiter.go
+++ b/pkg/internal/packetlimiter/limiter.go
@@ -1,0 +1,66 @@
+// Package packetlimiter provides a per-connection serverbound packet rate
+// limiter. It bounds how many packets and/or bytes a single connection may send
+// to the proxy over a sliding time window, mitigating packet-flood abuse from
+// already-connected clients (Gate's other quotas only apply at connect/login).
+package packetlimiter
+
+import (
+	"sync"
+	"time"
+)
+
+// Limiter enforces a per-connection limit on packets and/or bytes over a
+// sliding window. A nil *Limiter allows everything (disabled). Safe for
+// concurrent use.
+type Limiter struct {
+	mu               sync.Mutex
+	packets          *counter // nil if packet limiting is disabled
+	bytes            *counter // nil if byte limiting is disabled
+	packetsPerSecond int
+	bytesPerSecond   int
+}
+
+// New returns a Limiter for the given per-second limits over window, or nil if
+// limiting is effectively disabled (both limits <= 0, or window <= 0). A limit
+// <= 0 disables that dimension while the other stays active.
+func New(packetsPerSecond, bytesPerSecond int, window time.Duration) *Limiter {
+	if window <= 0 || (packetsPerSecond <= 0 && bytesPerSecond <= 0) {
+		return nil
+	}
+	l := &Limiter{
+		packetsPerSecond: packetsPerSecond,
+		bytesPerSecond:   bytesPerSecond,
+	}
+	if packetsPerSecond > 0 {
+		l.packets = newCounter(window)
+	}
+	if bytesPerSecond > 0 {
+		l.bytes = newCounter(window)
+	}
+	return l
+}
+
+// Account records one packet of the given size and reports whether the
+// connection is still within its limits. It returns false once a configured
+// rate is exceeded, signalling the caller to drop the connection.
+func (l *Limiter) Account(bytes int) bool {
+	if l == nil {
+		return true
+	}
+	now := time.Now().UnixNano()
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.packets != nil {
+		l.packets.updateAndAdd(1, now)
+		if l.packets.rate() > float64(l.packetsPerSecond) {
+			return false
+		}
+	}
+	if l.bytes != nil {
+		l.bytes.updateAndAdd(int64(bytes), now)
+		if l.bytes.rate() > float64(l.bytesPerSecond) {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/internal/packetlimiter/limiter_test.go
+++ b/pkg/internal/packetlimiter/limiter_test.go
@@ -1,0 +1,58 @@
+package packetlimiter
+
+import (
+	"testing"
+	"time"
+)
+
+func TestLimiterAllowsUnderPacketRate(t *testing.T) {
+	l := New(500, -1, 7*time.Second)
+	// 100 packets in a burst: rate = 100/7 ≈ 14/s, well under 500/s.
+	for i := 0; i < 100; i++ {
+		if !l.Account(10) {
+			t.Fatalf("packet %d rejected while under the limit", i)
+		}
+	}
+}
+
+func TestLimiterRejectsOverPacketRate(t *testing.T) {
+	l := New(500, -1, 7*time.Second)
+	// rate exceeds 500/s once sum/7 > 500, i.e. > 3500 packets in the window.
+	rejected := false
+	for i := 0; i < 6000; i++ {
+		if !l.Account(10) {
+			rejected = true
+			break
+		}
+	}
+	if !rejected {
+		t.Fatal("expected rejection once the packet rate was exceeded")
+	}
+}
+
+func TestLimiterRejectsOverByteRate(t *testing.T) {
+	l := New(0, 1000, 7*time.Second) // packets disabled, 1000 bytes/s
+	rejected := false
+	for i := 0; i < 1000; i++ {
+		if !l.Account(100) { // bytes accumulate; rate > 1000/s once sum > 7000
+			rejected = true
+			break
+		}
+	}
+	if !rejected {
+		t.Fatal("expected rejection once the byte rate was exceeded")
+	}
+}
+
+func TestNewDisabledReturnsNilAndAccountsTrue(t *testing.T) {
+	if l := New(0, 0, 7*time.Second); l != nil {
+		t.Fatal("expected nil limiter when both rates are disabled")
+	}
+	if l := New(500, -1, 0); l != nil {
+		t.Fatal("expected nil limiter when window is non-positive")
+	}
+	var nilLimiter *Limiter
+	if !nilLimiter.Account(123456) {
+		t.Fatal("nil limiter must allow everything")
+	}
+}


### PR DESCRIPTION
## Gap
Gate's existing rate limiting (`config.quota`) only applies at **connect time** and **login time** per IP. Once a client is connected, it can send packets unthrottled — there's no per-connection packet/bytes-per-second limit during play. This PR closes that gap.

(The acute payload/decompression/pre-join-queue DoS vectors are addressed separately in #689; this adds the missing per-connection flood limit. There's even a long-standing TODO in `config.Quota` anticipating a bytes-per-sec limiter.)

## What it does
A per-connection limiter accounts every **serverbound** packet (client→proxy) and closes the connection when a configured rate is exceeded. Backend connections are trusted and pass no limiter.

| Piece | File |
|------|------|
| Sliding-window counter (ring buffer) | `pkg/internal/packetlimiter/counter.go` |
| `Limiter` with `Account(bytes) bool` (nil = disabled) | `pkg/internal/packetlimiter/limiter.go` |
| Config: `packetLimiter` section + defaults + validation | `pkg/edition/java/config/config.go`, `config.yml` |
| Read-loop hook on client connections | `pkg/edition/java/netmc/connection.go` |
| Caller wiring (client = configured, backend = nil) | `pkg/edition/java/proxy/{proxy,server}.go` |

## Config (defaults)
```yaml
config:
  packetLimiter:
    interval: 7s            # sliding window
    packetsPerSecond: 500   # <=0 disables this dimension
    bytesPerSecond: -1      # disabled by default
```
A limit `<= 0` disables that dimension; both `<= 0` (or `interval <= 0`) disables the limiter entirely. **Defaults match Velocity's vetted values** (7s / 500 pps). 500 pps sustained is far above normal play (movement is ~20/s), so legitimate clients are unaffected; the value is tunable.

> Note: this is **on by default**. If you'd prefer it off-by-default for backwards-compatibility, that's a one-line change to the default — happy to flip it.

## Tests (TDD)
- `counter_test.go` — window accumulation, expiry, per-second rate, ring-buffer resize.
- `limiter_test.go` — allows under limit, rejects over packet rate, rejects over byte rate, nil/disabled is a no-op (race-clean).
- `connection_limiter_test.go` — drives real handshake frames through a `net.Pipe` read loop: a flood **closes** the connection, and a **negative control** confirms an unlimited connection is **not** closed (so the flood test can't pass for an unrelated reason).

## Design note
This adopts the rate-limiting approach Velocity uses, fit to Gate's Go read loop (accounting `packetCtx.BytesRead` per packet) rather than a Netty pipeline handler. The sliding-window counter mirrors the Velocity/Paper `IntervalledCounter`.

## Verification
- `go build ./...` — clean
- `go vet` (touched packages) — clean
- `go test ./...` — all packages pass (0 failures); limiter + netmc tests pass under `-race`
- `gofmt` — clean

Independent of #689 and #690 (all branch from `master`).