### PR TITLE
fix: correct PluginMessageEvent source/target in initial connect handler

### DIFF
--- a/pkg/edition/java/proxy/session_client_initial_connect.go
+++ b/pkg/edition/java/proxy/session_client_initial_connect.go
@@ -53,8 +53,8 @@ func (i *initialConnectSessionHandler) handlePluginMessage(packet *plugin.Messag
 	clone := make([]byte, len(packet.Data))
 	copy(clone, packet.Data)
 	event.FireParallel(i.player.eventMgr, &PluginMessageEvent{
-		source:     serverConn,
-		target:     serverConn.player,
+		source:     i.player,
+		target:     serverConn,
 		identifier: id,
 		data:       clone,
 		forward:    true,


### PR DESCRIPTION
## Summary

In `initialConnectSessionHandler.handlePluginMessage`, plugin messages received from the client during the initial server connect were fired with the `PluginMessageEvent` **source and target swapped**:

```go
source:     serverConn,        // wrong: this is the destination
target:     serverConn.player, // wrong: this is the origin
```

The message actually flows **client → server** (it is forwarded to the backend via `serverMc.WritePacket`), so the source must be the player and the target the server connection — exactly as the play-phase handler (`session_client_play.go`) already does it.

```go
source:     i.player,
target:     serverConn,
```

This means plugin listeners observing `PluginMessageEvent` during the initial connect phase now see correct `Source()`/`Target()` values, consistent with every other phase.

## Upstream

Ports [PaperMC/Velocity#1811](https://github.com/PaperMC/Velocity/pull/1811) ("Fix inverted PluginMessageEvent source/target in InitialConnectSessionHandler").

## Testing

- `go build ./pkg/edition/java/proxy/` — ok
- `go vet ./pkg/edition/java/proxy/` — clean
- `go test ./pkg/edition/java/proxy/` — pass