### PR TITLE
fix(bedrock): document engine-specific managed config

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -279,46 +279,54 @@ config:
       # Default: "geyserlite"
       #engine: "geyserlite"
 
-      # Geyserlite runtime mode. "subprocess" isolates native crashes from Gate.
-      # Set to "embedded" for in-process libgeyserlite.so loading.
-      # Geyserlite only.
-      # Default: "subprocess"
-      #mode: "subprocess"
+      # Geyserlite-specific managed settings.
+      # These fields only affect engine: "geyserlite".
+      geyserlite:
+        # Runtime mode. "subprocess" isolates native crashes from Gate.
+        # Set to "embedded" for in-process shared library loading.
+        # Default: "subprocess"
+        #mode: "subprocess"
 
-      # Download URL for Geyser Standalone JAR file.
-      # Java engine only.
-      # Leave empty to use the latest official release.
-      # Default: https://download.geysermc.org/v2/projects/geyser/versions/latest/builds/latest/downloads/standalone
-      #jarUrl: "https://download.geysermc.org/v2/projects/geyser/versions/latest/builds/latest/downloads/standalone"
+        # Optional binary/library location overrides.
+        # Use the platform shared library path for embedded mode.
+        #libraryPath: "/opt/geyserlite/libgeyserlite.so"
+        #binaryPath: "/opt/geyserlite/geyserlite"
+        #version: "v0.2.1"
+        #mirror: "https://github.com/minekube/geyserlite/releases/download"
+        #offline: false
 
-      # Directory for Geyser data (JAR file, config, logs, etc.).
-      # Default: ".geyser"
-      #dataDir: ".geyser"
+        # Additional subprocess arguments.
+        # Default: []
+        #extraArgs: []
 
-      # Path to Java executable for running Geyser.
-      # Java engine only.
-      # Default: "java" (from PATH)
-      #javaPath: "java"
+      # Java Geyser Standalone-specific managed settings.
+      # These fields only affect engine: "java".
+      java:
+        # Download URL for Geyser Standalone JAR file.
+        # Leave empty to use the latest official release.
+        # Default: https://download.geysermc.org/v2/projects/geyser/versions/latest/builds/latest/downloads/standalone
+        #jarUrl: "https://download.geysermc.org/v2/projects/geyser/versions/latest/builds/latest/downloads/standalone"
 
-      # Optional geyserlite binary/library location overrides.
-      # Geyserlite only.
-      #libraryPath: "/opt/geyserlite/libgeyserlite.so"
-      #binaryPath: "/opt/geyserlite/geyserlite"
-      #version: "v0.2.0"
-      #mirror: "https://github.com/minekube/geyserlite/releases/download"
-      #offline: false
+        # Directory for Geyser data (JAR file, config, logs, etc.).
+        # Default: ".geyser"
+        #dataDir: ".geyser"
 
-      # Whether to automatically download JAR updates on startup.
-      # Java engine only.
-      # Default: true
-      #autoUpdate: true
+        # Path to Java executable for running Geyser.
+        # Default: "java" (from PATH)
+        #javaPath: "java"
 
-      # Additional JVM arguments for running Geyser.
-      # Java engine and geyserlite subprocess mode.
-      # Default: []
-      #extraArgs:
-      #  - "-Xmx1G"
-      #  - "-XX:+UseG1GC"
+        # Whether to automatically download JAR updates on startup.
+        # Default: true
+        #autoUpdate: true
+
+        # Additional JVM arguments for running Geyser.
+        # Default: []
+        #extraArgs:
+        #  - "-Xmx1G"
+        #  - "-XX:+UseG1GC"
+
+      # Backward compatibility: the engine-specific fields above are also still
+      # accepted directly under managed, but the nested form is clearer.
 
       # Custom overrides for the auto-generated Geyser config.
       # This allows you to customize the Geyser config.

--- a/pkg/configs/config.yml
+++ b/pkg/configs/config.yml
@@ -268,46 +268,54 @@ config:
       # Default: "geyserlite"
       #engine: "geyserlite"
 
-      # Geyserlite runtime mode. "subprocess" isolates native crashes from Gate.
-      # Set to "embedded" for in-process libgeyserlite.so loading.
-      # Geyserlite only.
-      # Default: "subprocess"
-      #mode: "subprocess"
+      # Geyserlite-specific managed settings.
+      # These fields only affect engine: "geyserlite".
+      geyserlite:
+        # Runtime mode. "subprocess" isolates native crashes from Gate.
+        # Set to "embedded" for in-process shared library loading.
+        # Default: "subprocess"
+        #mode: "subprocess"
 
-      # Download URL for Geyser Standalone JAR file.
-      # Java engine only.
-      # Leave empty to use the latest official release.
-      # Default: https://download.geysermc.org/v2/projects/geyser/versions/latest/builds/latest/downloads/standalone
-      #jarUrl: "https://download.geysermc.org/v2/projects/geyser/versions/latest/builds/latest/downloads/standalone"
+        # Optional binary/library location overrides.
+        # Use the platform shared library path for embedded mode.
+        #libraryPath: "/opt/geyserlite/libgeyserlite.so"
+        #binaryPath: "/opt/geyserlite/geyserlite"
+        #version: "v0.2.1"
+        #mirror: "https://github.com/minekube/geyserlite/releases/download"
+        #offline: false
 
-      # Directory for Geyser data (JAR file, config, logs, etc.).
-      # Default: ".geyser"
-      #dataDir: ".geyser"
+        # Additional subprocess arguments.
+        # Default: []
+        #extraArgs: []
 
-      # Path to Java executable for running Geyser.
-      # Java engine only.
-      # Default: "java" (from PATH)
-      #javaPath: "java"
+      # Java Geyser Standalone-specific managed settings.
+      # These fields only affect engine: "java".
+      java:
+        # Download URL for Geyser Standalone JAR file.
+        # Leave empty to use the latest official release.
+        # Default: https://download.geysermc.org/v2/projects/geyser/versions/latest/builds/latest/downloads/standalone
+        #jarUrl: "https://download.geysermc.org/v2/projects/geyser/versions/latest/builds/latest/downloads/standalone"
 
-      # Optional geyserlite binary/library location overrides.
-      # Geyserlite only.
-      #libraryPath: "/opt/geyserlite/libgeyserlite.so"
-      #binaryPath: "/opt/geyserlite/geyserlite"
-      #version: "v0.2.0"
-      #mirror: "https://github.com/minekube/geyserlite/releases/download"
-      #offline: false
+        # Directory for Geyser data (JAR file, config, logs, etc.).
+        # Default: ".geyser"
+        #dataDir: ".geyser"
 
-      # Whether to automatically download JAR updates on startup.
-      # Java engine only.
-      # Default: true
-      #autoUpdate: true
+        # Path to Java executable for running Geyser.
+        # Default: "java" (from PATH)
+        #javaPath: "java"
 
-      # Additional JVM arguments for running Geyser.
-      # Java engine and geyserlite subprocess mode.
-      # Default: []
-      #extraArgs:
-      #  - "-Xmx1G"
-      #  - "-XX:+UseG1GC"
+        # Whether to automatically download JAR updates on startup.
+        # Default: true
+        #autoUpdate: true
+
+        # Additional JVM arguments for running Geyser.
+        # Default: []
+        #extraArgs:
+        #  - "-Xmx1G"
+        #  - "-XX:+UseG1GC"
+
+      # Backward compatibility: the engine-specific fields above are also still
+      # accepted directly under managed, but the nested form is clearer.
 
       # Custom overrides for the auto-generated Geyser config.
       # This allows you to customize the Geyser config.

--- a/pkg/edition/bedrock/config/config.go
+++ b/pkg/edition/bedrock/config/config.go
@@ -80,6 +80,8 @@ type Config struct {
 type ManagedGeyser struct {
 	Enabled         bool           `yaml:"enabled,omitempty" json:"enabled,omitempty"`                 // Enable managed Geyser mode (Gate handles Geyser process)
 	Engine          ManagedEngine  `yaml:"engine,omitempty" json:"engine,omitempty"`                   // Managed engine: "geyserlite" (default) or "java"
+	Geyserlite      *Geyserlite    `yaml:"geyserlite,omitempty" json:"geyserlite,omitempty"`           // Geyserlite-specific managed settings
+	Java            *JavaGeyser    `yaml:"java,omitempty" json:"java,omitempty"`                       // Java Geyser Standalone-specific managed settings
 	Mode            string         `yaml:"mode,omitempty" json:"mode,omitempty"`                       // Geyserlite mode: "subprocess" (default) or "embedded"
 	JarURL          string         `yaml:"jarUrl,omitempty" json:"jarUrl,omitempty"`                   // Download URL for Geyser Standalone JAR
 	DataDir         string         `yaml:"dataDir,omitempty" json:"dataDir,omitempty"`                 // Directory for JAR and runtime data
@@ -90,8 +92,28 @@ type ManagedGeyser struct {
 	Version         string         `yaml:"version,omitempty" json:"version,omitempty"`                 // Geyserlite release version for auto-download
 	Offline         bool           `yaml:"offline,omitempty" json:"offline,omitempty"`                 // Disable geyserlite auto-download lookup
 	AutoUpdate      bool           `yaml:"autoUpdate,omitempty" json:"autoUpdate,omitempty"`           // Download latest JAR on startup
-	ExtraArgs       []string       `yaml:"extraArgs,omitempty" json:"extraArgs,omitempty"`             // Additional JVM arguments
+	ExtraArgs       []string       `yaml:"extraArgs,omitempty" json:"extraArgs,omitempty"`             // Legacy additional process/JVM arguments
 	ConfigOverrides map[string]any `yaml:"configOverrides,omitempty" json:"configOverrides,omitempty"` // Custom overrides for auto-generated Geyser config
+}
+
+// Geyserlite configures the native geyserlite managed engine.
+type Geyserlite struct {
+	Mode        string   `yaml:"mode,omitempty" json:"mode,omitempty"`               // "subprocess" (default) or "embedded"
+	LibraryPath string   `yaml:"libraryPath,omitempty" json:"libraryPath,omitempty"` // Shared library path for embedded mode
+	BinaryPath  string   `yaml:"binaryPath,omitempty" json:"binaryPath,omitempty"`   // Binary path for subprocess mode
+	Mirror      string   `yaml:"mirror,omitempty" json:"mirror,omitempty"`           // Release mirror base URL
+	Version     string   `yaml:"version,omitempty" json:"version,omitempty"`         // Release version for auto-download
+	Offline     bool     `yaml:"offline,omitempty" json:"offline,omitempty"`         // Disable auto-download lookup
+	ExtraArgs   []string `yaml:"extraArgs,omitempty" json:"extraArgs,omitempty"`     // Additional subprocess arguments
+}
+
+// JavaGeyser configures the Java Geyser Standalone managed engine.
+type JavaGeyser struct {
+	JarURL     string   `yaml:"jarUrl,omitempty" json:"jarUrl,omitempty"`         // Download URL for Geyser Standalone JAR
+	DataDir    string   `yaml:"dataDir,omitempty" json:"dataDir,omitempty"`       // Directory for JAR and runtime data
+	JavaPath   string   `yaml:"javaPath,omitempty" json:"javaPath,omitempty"`     // Path to Java executable
+	AutoUpdate *bool    `yaml:"autoUpdate,omitempty" json:"autoUpdate,omitempty"` // Download latest JAR on startup
+	ExtraArgs  []string `yaml:"extraArgs,omitempty" json:"extraArgs,omitempty"`   // Additional JVM arguments
 }
 
 // GetManaged returns the managed config with defaults applied.
@@ -106,48 +128,7 @@ func (c *Config) GetManaged() ManagedGeyser {
 
 	// Override with user-specified values (only non-zero values override defaults)
 	managed.Enabled = c.Managed.Enabled // Always take user's enabled value
-	if c.Managed.Engine != "" {
-		managed.Engine = normalizeManagedEngine(c.Managed.Engine)
-	}
-	if c.Managed.Mode != "" {
-		managed.Mode = c.Managed.Mode
-	}
-	if c.Managed.JarURL != "" {
-		managed.JarURL = c.Managed.JarURL
-	}
-	if c.Managed.DataDir != "" {
-		managed.DataDir = c.Managed.DataDir
-	}
-	if c.Managed.JavaPath != "" {
-		managed.JavaPath = c.Managed.JavaPath
-	}
-	if c.Managed.LibraryPath != "" {
-		managed.LibraryPath = c.Managed.LibraryPath
-	}
-	if c.Managed.BinaryPath != "" {
-		managed.BinaryPath = c.Managed.BinaryPath
-	}
-	if c.Managed.Mirror != "" {
-		managed.Mirror = c.Managed.Mirror
-	}
-	if c.Managed.Version != "" {
-		managed.Version = c.Managed.Version
-	}
-	managed.Offline = c.Managed.Offline
-	// AutoUpdate: only override if user has non-zero ExtraArgs (indicating they set other fields)
-	// This is a heuristic since we can't distinguish unset bool from explicit false
-	if len(c.Managed.ExtraArgs) > 0 || c.Managed.JarURL != "" || c.Managed.DataDir != "" || c.Managed.JavaPath != "" {
-		// User specified other fields, so they might have intentionally set AutoUpdate
-		managed.AutoUpdate = c.Managed.AutoUpdate
-	}
-	// Otherwise keep default AutoUpdate = true
-
-	if c.Managed.ExtraArgs != nil {
-		managed.ExtraArgs = c.Managed.ExtraArgs
-	}
-	if c.Managed.ConfigOverrides != nil {
-		managed.ConfigOverrides = c.Managed.ConfigOverrides
-	}
+	applyManagedOverrides(&managed, c.Managed)
 
 	return managed
 }
@@ -232,51 +213,104 @@ func (bc *BedrockConfig) GetManagedConfig() ManagedGeyser {
 	// Start with defaults and apply user values using the original logic
 	managed := DefaultManaged
 	managed.Enabled = managedStruct.Enabled // Always take user's enabled value
+	applyManagedOverrides(&managed, &managedStruct)
 
-	if managedStruct.Engine != "" {
-		managed.Engine = normalizeManagedEngine(managedStruct.Engine)
+	return managed
+}
+
+func applyManagedOverrides(managed *ManagedGeyser, user *ManagedGeyser) {
+	if user.Engine != "" {
+		managed.Engine = normalizeManagedEngine(user.Engine)
 	}
-	if managedStruct.Mode != "" {
-		managed.Mode = managedStruct.Mode
+	if user.Mode != "" {
+		managed.Mode = user.Mode
 	}
-	if managedStruct.JarURL != "" {
-		managed.JarURL = managedStruct.JarURL
+	if user.JarURL != "" {
+		managed.JarURL = user.JarURL
 	}
-	if managedStruct.DataDir != "" {
-		managed.DataDir = managedStruct.DataDir
+	if user.DataDir != "" {
+		managed.DataDir = user.DataDir
 	}
-	if managedStruct.JavaPath != "" {
-		managed.JavaPath = managedStruct.JavaPath
+	if user.JavaPath != "" {
+		managed.JavaPath = user.JavaPath
 	}
-	if managedStruct.LibraryPath != "" {
-		managed.LibraryPath = managedStruct.LibraryPath
+	if user.LibraryPath != "" {
+		managed.LibraryPath = user.LibraryPath
 	}
-	if managedStruct.BinaryPath != "" {
-		managed.BinaryPath = managedStruct.BinaryPath
+	if user.BinaryPath != "" {
+		managed.BinaryPath = user.BinaryPath
 	}
-	if managedStruct.Mirror != "" {
-		managed.Mirror = managedStruct.Mirror
+	if user.Mirror != "" {
+		managed.Mirror = user.Mirror
 	}
-	if managedStruct.Version != "" {
-		managed.Version = managedStruct.Version
+	if user.Version != "" {
+		managed.Version = user.Version
 	}
-	managed.Offline = managedStruct.Offline
+	managed.Offline = user.Offline
 	// AutoUpdate: only override if user has non-zero ExtraArgs (indicating they set other fields)
 	// This is a heuristic since we can't distinguish unset bool from explicit false
-	if len(managedStruct.ExtraArgs) > 0 || managedStruct.JarURL != "" || managedStruct.DataDir != "" || managedStruct.JavaPath != "" {
+	if len(user.ExtraArgs) > 0 || user.JarURL != "" || user.DataDir != "" || user.JavaPath != "" {
 		// User specified other fields, so they might have intentionally set AutoUpdate
-		managed.AutoUpdate = managedStruct.AutoUpdate
+		managed.AutoUpdate = user.AutoUpdate
 	}
 	// Otherwise keep default AutoUpdate = true
 
-	if managedStruct.ExtraArgs != nil {
-		managed.ExtraArgs = managedStruct.ExtraArgs
+	if user.ExtraArgs != nil {
+		managed.ExtraArgs = user.ExtraArgs
 	}
-	if managedStruct.ConfigOverrides != nil {
-		managed.ConfigOverrides = managedStruct.ConfigOverrides
+	switch managed.Engine {
+	case ManagedEngineJava:
+		if user.Java != nil {
+			applyJavaOverrides(managed, user.Java)
+		}
+	default:
+		if user.Geyserlite != nil {
+			applyGeyserliteOverrides(managed, user.Geyserlite)
+		}
 	}
+	if user.ConfigOverrides != nil {
+		managed.ConfigOverrides = user.ConfigOverrides
+	}
+}
 
-	return managed
+func applyGeyserliteOverrides(managed *ManagedGeyser, user *Geyserlite) {
+	if user.Mode != "" {
+		managed.Mode = user.Mode
+	}
+	if user.LibraryPath != "" {
+		managed.LibraryPath = user.LibraryPath
+	}
+	if user.BinaryPath != "" {
+		managed.BinaryPath = user.BinaryPath
+	}
+	if user.Mirror != "" {
+		managed.Mirror = user.Mirror
+	}
+	if user.Version != "" {
+		managed.Version = user.Version
+	}
+	managed.Offline = user.Offline
+	if user.ExtraArgs != nil {
+		managed.ExtraArgs = user.ExtraArgs
+	}
+}
+
+func applyJavaOverrides(managed *ManagedGeyser, user *JavaGeyser) {
+	if user.JarURL != "" {
+		managed.JarURL = user.JarURL
+	}
+	if user.DataDir != "" {
+		managed.DataDir = user.DataDir
+	}
+	if user.JavaPath != "" {
+		managed.JavaPath = user.JavaPath
+	}
+	if user.AutoUpdate != nil {
+		managed.AutoUpdate = *user.AutoUpdate
+	}
+	if user.ExtraArgs != nil {
+		managed.ExtraArgs = user.ExtraArgs
+	}
 }
 
 // UnmarshalYAML implements custom YAML unmarshaling to handle managed: true shorthand

--- a/pkg/edition/bedrock/config/config_test.go
+++ b/pkg/edition/bedrock/config/config_test.go
@@ -4,6 +4,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"gopkg.in/yaml.v3"
 )
 
 func TestGetManaged(t *testing.T) {
@@ -229,6 +231,126 @@ func TestValidateGeyserliteManagedSkipsJavaWarnings(t *testing.T) {
 		if strings.Contains(warn.Error(), "jarUrl") || strings.Contains(warn.Error(), "javaPath") {
 			t.Fatalf("Validate() emitted Java warning for geyserlite engine: %v", warn)
 		}
+	}
+}
+
+func TestManagedNestedGeyserliteConfig(t *testing.T) {
+	yamlConfig := `
+managed:
+  enabled: true
+  engine: geyserlite
+  geyserlite:
+    mode: embedded
+    libraryPath: /opt/geyserlite/libgeyserlite.so
+    binaryPath: /opt/geyserlite/geyserlite
+    mirror: https://mirror.example.com/geyserlite
+    version: v0.2.1
+    offline: true
+    extraArgs:
+      - --trace
+  configOverrides:
+    bedrock:
+      port: 19133
+`
+
+	var cfg Config
+	if err := yaml.Unmarshal([]byte(yamlConfig), &cfg); err != nil {
+		t.Fatalf("yaml.Unmarshal() error = %v", err)
+	}
+
+	managed := cfg.GetManaged()
+	if !managed.Enabled {
+		t.Fatal("Enabled = false, want true")
+	}
+	if managed.Engine != ManagedEngineGeyserlite {
+		t.Fatalf("Engine = %q, want %q", managed.Engine, ManagedEngineGeyserlite)
+	}
+	if managed.Mode != "embedded" {
+		t.Fatalf("Mode = %q, want embedded", managed.Mode)
+	}
+	if managed.LibraryPath != "/opt/geyserlite/libgeyserlite.so" {
+		t.Fatalf("LibraryPath = %q", managed.LibraryPath)
+	}
+	if managed.BinaryPath != "/opt/geyserlite/geyserlite" {
+		t.Fatalf("BinaryPath = %q", managed.BinaryPath)
+	}
+	if managed.Mirror != "https://mirror.example.com/geyserlite" {
+		t.Fatalf("Mirror = %q", managed.Mirror)
+	}
+	if managed.Version != "v0.2.1" {
+		t.Fatalf("Version = %q", managed.Version)
+	}
+	if !managed.Offline {
+		t.Fatal("Offline = false, want true")
+	}
+	if len(managed.ExtraArgs) != 1 || managed.ExtraArgs[0] != "--trace" {
+		t.Fatalf("ExtraArgs = %#v, want --trace", managed.ExtraArgs)
+	}
+	if managed.ConfigOverrides == nil {
+		t.Fatal("ConfigOverrides = nil")
+	}
+}
+
+func TestManagedNestedJavaConfig(t *testing.T) {
+	yamlConfig := `
+managed:
+  enabled: true
+  engine: java
+  java:
+    jarUrl: https://custom.example.com/geyser.jar
+    dataDir: /srv/geyser
+    javaPath: /usr/bin/java
+    autoUpdate: false
+    extraArgs:
+      - -Xmx2G
+`
+
+	var cfg Config
+	if err := yaml.Unmarshal([]byte(yamlConfig), &cfg); err != nil {
+		t.Fatalf("yaml.Unmarshal() error = %v", err)
+	}
+
+	managed := cfg.GetManaged()
+	if managed.Engine != ManagedEngineJava {
+		t.Fatalf("Engine = %q, want %q", managed.Engine, ManagedEngineJava)
+	}
+	if managed.JarURL != "https://custom.example.com/geyser.jar" {
+		t.Fatalf("JarURL = %q", managed.JarURL)
+	}
+	if managed.DataDir != "/srv/geyser" {
+		t.Fatalf("DataDir = %q", managed.DataDir)
+	}
+	if managed.JavaPath != "/usr/bin/java" {
+		t.Fatalf("JavaPath = %q", managed.JavaPath)
+	}
+	if managed.AutoUpdate {
+		t.Fatal("AutoUpdate = true, want false")
+	}
+	if len(managed.ExtraArgs) != 1 || managed.ExtraArgs[0] != "-Xmx2G" {
+		t.Fatalf("ExtraArgs = %#v, want -Xmx2G", managed.ExtraArgs)
+	}
+}
+
+func TestManagedNestedConfigOverridesLegacyFlatFields(t *testing.T) {
+	cfg := Config{
+		Managed: &ManagedGeyser{
+			Enabled:     true,
+			Engine:      ManagedEngineGeyserlite,
+			Mode:        "subprocess",
+			LibraryPath: "/legacy/libgeyserlite.so",
+			Geyserlite: &Geyserlite{
+				Mode:        "embedded",
+				LibraryPath: "/nested/libgeyserlite.so",
+			},
+		},
+	}
+
+	managed := cfg.GetManaged()
+	if managed.Mode != "embedded" {
+		t.Fatalf("Mode = %q, want nested value embedded", managed.Mode)
+	}
+	if managed.LibraryPath != "/nested/libgeyserlite.so" {
+		t.Fatalf("LibraryPath = %q, want nested value", managed.LibraryPath)
 	}
 }
 

--- a/pkg/edition/bedrock/geyser/managed_runner_test.go
+++ b/pkg/edition/bedrock/geyser/managed_runner_test.go
@@ -81,7 +81,7 @@ func TestLiteManagedRunnerOptionsMapManagedConfig(t *testing.T) {
 			LibraryPath: "/opt/geyserlite/libgeyserlite.so",
 			BinaryPath:  "/opt/geyserlite/geyserlite",
 			Mirror:      "https://mirror.example.com/geyserlite",
-			Version:     "v0.2.0",
+			Version:     "v0.2.1",
 			Offline:     true,
 			ExtraArgs:   []string{"-Xmx512m"},
 			ConfigOverrides: map[string]any{
@@ -117,7 +117,7 @@ func TestLiteManagedRunnerOptionsMapManagedConfig(t *testing.T) {
 	if opts.Mirror != "https://mirror.example.com/geyserlite" {
 		t.Fatalf("Mirror = %q", opts.Mirror)
 	}
-	if opts.Version != "v0.2.0" {
+	if opts.Version != "v0.2.1" {
 		t.Fatalf("Version = %q", opts.Version)
 	}
 	if !opts.Offline {

--- a/pkg/edition/java/config/config_test.go
+++ b/pkg/edition/java/config/config_test.go
@@ -103,6 +103,48 @@ bedrock:
 	}
 }
 
+func TestBedrockConfig_ManagedNestedEngineConfig(t *testing.T) {
+	yamlConfig := `
+bedrock:
+  managed:
+    enabled: true
+    engine: geyserlite
+    geyserlite:
+      mode: embedded
+      version: v0.2.1
+    java:
+      dataDir: /srv/geyser
+      autoUpdate: false
+`
+
+	type testConfig struct {
+		Bedrock bconfig.BedrockConfig `yaml:"bedrock"`
+	}
+
+	var cfg testConfig
+	if err := yaml.Unmarshal([]byte(yamlConfig), &cfg); err != nil {
+		t.Fatalf("Failed to unmarshal config: %v", err)
+	}
+
+	bedrockConfig := cfg.Bedrock.ToConfig()
+	managedConfig := bedrockConfig.GetManaged()
+	if managedConfig.Engine != bconfig.ManagedEngineGeyserlite {
+		t.Fatalf("Expected managed engine geyserlite, got %q", managedConfig.Engine)
+	}
+	if managedConfig.Mode != "embedded" {
+		t.Fatalf("Expected geyserlite mode embedded, got %q", managedConfig.Mode)
+	}
+	if managedConfig.Version != "v0.2.1" {
+		t.Fatalf("Expected geyserlite version v0.2.1, got %q", managedConfig.Version)
+	}
+	if managedConfig.DataDir != bconfig.DefaultManaged.DataDir {
+		t.Fatalf("Expected inactive java dataDir to be ignored, got %q", managedConfig.DataDir)
+	}
+	if !managedConfig.AutoUpdate {
+		t.Fatal("Expected inactive java autoUpdate false to be ignored")
+	}
+}
+
 func TestBedrockConfig_FlattenedStructure(t *testing.T) {
 	yamlConfig := `
 bedrock:


### PR DESCRIPTION
## Summary
- add nested managed.geyserlite and managed.java config structs while keeping legacy flat fields compatible
- make nested engine config apply only for the selected managed engine
- update sample configs to show engine-specific sections and geyserlite v0.2.1

## Verification
- env -u GOROOT go test ./pkg/edition/bedrock/config ./pkg/edition/java/config ./pkg/edition/bedrock/geyser ./pkg/edition/bedrock/proxy
- env -u GOROOT go test ./...
- env -u GOROOT go run github.com/golangci/golangci-lint/cmd/golangci-lint@latest run --timeout 3m0s
- env -u GOROOT GOOS=windows GOARCH=amd64 go test -exec=echo ./pkg/edition/bedrock/config ./pkg/edition/java/config ./pkg/edition/bedrock/geyser ./pkg/edition/bedrock/proxy