### PR TITLE
fix(bedrock): wait for managed geyserlite readiness

### DIFF
--- a/pkg/edition/bedrock/geyser/geyser.go
+++ b/pkg/edition/bedrock/geyser/geyser.go
@@ -160,20 +160,23 @@ func (i *Integration) Start() error {
 	unsubProf := event.Subscribe(eventMgr, priority, i.onGameProfile)
 	i.unsubs = append(i.unsubs, unsubPre, unsubProf)
 
-	// If managed mode enabled, ensure and start Geyser Standalone
-	if i.manager != nil {
-		if err := i.manager.Start(i.ctx); err != nil {
-			return fmt.Errorf("managed geyser start failed: %w", err)
-		}
-		// Start method now waits for Geyser to be ready internally
+	ln, err := i.listen()
+	if err != nil {
+		return err
 	}
-
-	// Start listening for Geyser connections
 	go func() {
-		if err := i.listenAndServe(); err != nil {
+		if err := i.serve(ln); err != nil {
 			i.log.Error(err, "geyser listener failed")
 		}
 	}()
+
+	// If managed mode enabled, ensure and start Geyser Standalone
+	if i.manager != nil {
+		if err := i.manager.Start(i.ctx); err != nil {
+			_ = ln.Close()
+			return fmt.Errorf("managed geyser start failed: %w", err)
+		}
+	}
 
 	i.log.Info("geyser integration started", "addr", i.config.GeyserListenAddr)
 	return nil
@@ -205,16 +208,20 @@ func (i *Integration) Stop() {
 	}
 }
 
-func (i *Integration) listenAndServe() error {
+func (i *Integration) listen() (net.Listener, error) {
 	if i.ctx.Err() != nil {
-		return i.ctx.Err()
+		return nil, i.ctx.Err()
 	}
 
 	var lc net.ListenConfig
 	ln, err := lc.Listen(i.ctx, "tcp", i.config.GeyserListenAddr)
 	if err != nil {
-		return fmt.Errorf("failed to listen on %s: %w", i.config.GeyserListenAddr, err)
+		return nil, fmt.Errorf("failed to listen on %s: %w", i.config.GeyserListenAddr, err)
 	}
+	return ln, nil
+}
+
+func (i *Integration) serve(ln net.Listener) error {
 	defer func() { _ = ln.Close() }()
 
 	ctx, cancel := context.WithCancel(i.ctx)

--- a/pkg/edition/bedrock/geyser/managed_lite.go
+++ b/pkg/edition/bedrock/geyser/managed_lite.go
@@ -15,16 +15,33 @@ import (
 )
 
 type liteManagedRunner struct {
-	cfg    *config.Config
-	server *geyserlite.Server
-	cancel context.CancelFunc
-	done   chan error
-	mu     sync.Mutex
+	cfg       *config.Config
+	newServer func(geyserlite.Options) (geyserliteServer, error)
+	server    geyserliteServer
+	cancel    context.CancelFunc
+	done      chan error
+	mu        sync.Mutex
 }
 
 func newLiteManagedRunner(cfg *config.Config) *liteManagedRunner {
-	return &liteManagedRunner{cfg: cfg}
+	return &liteManagedRunner{
+		cfg: cfg,
+		newServer: func(opts geyserlite.Options) (geyserliteServer, error) {
+			return geyserlite.New(opts)
+		},
+	}
 }
+
+type geyserliteServer interface {
+	Start(context.Context) error
+	Stop(context.Context) error
+	Healthy() bool
+}
+
+const (
+	liteManagedStartupTimeout = 10 * time.Minute
+	liteManagedReadyPoll      = 100 * time.Millisecond
+)
 
 func (r *liteManagedRunner) EnsureKey(ctx context.Context) error {
 	log := slog.Default().With("component", "geyserlite.managed")
@@ -54,7 +71,7 @@ func (r *liteManagedRunner) Start(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	server, err := geyserlite.New(opts)
+	server, err := r.newServer(opts)
 	if err != nil {
 		return err
 	}
@@ -73,17 +90,38 @@ func (r *liteManagedRunner) Start(ctx context.Context) error {
 		done <- err
 	}()
 
-	select {
-	case err := <-done:
-		r.server = nil
-		r.cancel = nil
-		r.done = nil
-		return err
-	case <-time.After(250 * time.Millisecond):
-		return nil
-	case <-ctx.Done():
-		cancel()
-		return ctx.Err()
+	ticker := time.NewTicker(liteManagedReadyPoll)
+	defer ticker.Stop()
+	timeout := time.NewTimer(liteManagedStartupTimeout)
+	defer timeout.Stop()
+
+	for {
+		select {
+		case err := <-done:
+			r.server = nil
+			r.cancel = nil
+			r.done = nil
+			if err != nil {
+				return err
+			}
+			return fmt.Errorf("geyserlite exited before becoming healthy")
+		case <-ticker.C:
+			if server.Healthy() {
+				return nil
+			}
+		case <-timeout.C:
+			cancel()
+			r.server = nil
+			r.cancel = nil
+			r.done = nil
+			return fmt.Errorf("timed out after %s waiting for geyserlite to become healthy", liteManagedStartupTimeout)
+		case <-ctx.Done():
+			cancel()
+			r.server = nil
+			r.cancel = nil
+			r.done = nil
+			return ctx.Err()
+		}
 	}
 }
 

--- a/pkg/edition/bedrock/geyser/managed_runner_test.go
+++ b/pkg/edition/bedrock/geyser/managed_runner_test.go
@@ -1,9 +1,12 @@
 package geyser
 
 import (
+	"context"
 	"os"
 	"path/filepath"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"go.minekube.com/gate/pkg/edition/bedrock/config"
 	geyserlite "go.minekube.com/geyserlite"
@@ -130,3 +133,70 @@ func TestLiteManagedRunnerOptionsMapManagedConfig(t *testing.T) {
 		t.Fatalf("ConfigOverrides = %#v, want bedrock override", opts.ConfigOverrides)
 	}
 }
+
+func TestLiteManagedRunnerStartWaitsUntilHealthy(t *testing.T) {
+	tempDir := t.TempDir()
+	keyPath := filepath.Join(tempDir, "floodgate.key")
+	if err := os.WriteFile(keyPath, []byte("0123456789abcdef"), 0o600); err != nil {
+		t.Fatalf("write key: %v", err)
+	}
+
+	cfg := &config.Config{
+		GeyserListenAddr: "localhost:25567",
+		FloodgateKeyPath: keyPath,
+		Managed: &config.ManagedGeyser{
+			Enabled: true,
+			Engine:  config.ManagedEngineGeyserlite,
+		},
+	}
+
+	fake := &fakeGeyserliteServer{started: make(chan struct{})}
+	runner := newLiteManagedRunner(cfg)
+	runner.newServer = func(geyserlite.Options) (geyserliteServer, error) {
+		return fake, nil
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	errCh := make(chan error, 1)
+	go func() { errCh <- runner.Start(ctx) }()
+
+	select {
+	case <-fake.started:
+	case <-time.After(time.Second):
+		t.Fatal("geyserlite server did not start")
+	}
+
+	select {
+	case err := <-errCh:
+		t.Fatalf("Start returned before Healthy: %v", err)
+	case <-time.After(2 * liteManagedReadyPoll):
+	}
+
+	fake.healthy.Store(true)
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatalf("Start returned error after Healthy: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Start did not return after Healthy")
+	}
+
+	runner.Stop()
+}
+
+type fakeGeyserliteServer struct {
+	healthy atomic.Bool
+	started chan struct{}
+}
+
+func (f *fakeGeyserliteServer) Start(ctx context.Context) error {
+	close(f.started)
+	<-ctx.Done()
+	return ctx.Err()
+}
+
+func (f *fakeGeyserliteServer) Stop(context.Context) error { return nil }
+
+func (f *fakeGeyserliteServer) Healthy() bool { return f.healthy.Load() }


### PR DESCRIPTION
## Summary
- bind the Gate↔Geyser loopback listener before starting managed Geyserlite
- make managed Geyserlite startup wait for `Healthy()` instead of returning after 250ms
- add a regression test that `Start` does not return before Geyserlite is healthy

## Test
- `env -u GOROOT go test ./pkg/edition/bedrock/geyser ./pkg/edition/bedrock/proxy ./pkg/edition/bedrock/config`
- `env -u GOROOT go test ./...`

## Context
Moxy switched from the old co-located sidecar to Gate-managed Geyserlite. The managed runner was still returning after a fixed 250ms while Geyserlite readiness is based on the `Done (...)` signal exposed by `Healthy()`, so Fly could mark connect-proxy healthy before Bedrock was actually ready.