### PR TITLE
fix(java): normalize NBT component style booleans

### DIFF
--- a/pkg/edition/java/proto/nbtconv/snbt_json.go
+++ b/pkg/edition/java/proto/nbtconv/snbt_json.go
@@ -187,17 +187,75 @@ func SnbtToJSON(snbt string) (json.RawMessage, error) {
 
 	// Parse non-standard json with yaml, which is a superset of json.
 	// We use YAML parser, since it's a superset of JSON and quotes are optional.
-	type M map[string]any
-	var m M
+	var m map[string]any
 	if err := yaml.Unmarshal([]byte(snbt), &m); err != nil {
 		return nil, fmt.Errorf("error unmarshalling snbt to yaml: %w", err)
 	}
+	normalizeComponentStyleBooleans(m)
 	// Marshal back to JSON
 	j, err := json.Marshal(m)
 	if err != nil {
 		return nil, fmt.Errorf("error marshalling yaml to json: %w", err)
 	}
 	return j, nil
+}
+
+var componentStyleBooleanKeys = map[string]struct{}{
+	"bold":          {},
+	"italic":        {},
+	"underlined":    {},
+	"strikethrough": {},
+	"obfuscated":    {},
+}
+
+func normalizeComponentStyleBooleans(v any) {
+	switch v := v.(type) {
+	case map[string]any:
+		for k, child := range v {
+			if _, ok := componentStyleBooleanKeys[k]; ok {
+				if b, ok := nbtByteBool(child); ok {
+					v[k] = b
+					continue
+				}
+			}
+			normalizeComponentStyleBooleans(child)
+		}
+	case []any:
+		for _, child := range v {
+			normalizeComponentStyleBooleans(child)
+		}
+	}
+}
+
+func nbtByteBool(v any) (bool, bool) {
+	switch v := v.(type) {
+	case bool:
+		return v, true
+	case int:
+		if v == 0 || v == 1 {
+			return v == 1, true
+		}
+	case int64:
+		if v == 0 || v == 1 {
+			return v == 1, true
+		}
+	case uint64:
+		if v == 0 || v == 1 {
+			return v == 1, true
+		}
+	case float64:
+		if v == 0 || v == 1 {
+			return v == 1, true
+		}
+	case string:
+		switch strings.ToLower(strings.TrimSpace(v)) {
+		case "0", "0b", "false":
+			return false, true
+		case "1", "1b", "true":
+			return true, true
+		}
+	}
+	return false, false
 }
 
 // JsonToSNBT converts a JSON to stringified NBT.

--- a/pkg/edition/java/proto/nbtconv/snbt_json_test.go
+++ b/pkg/edition/java/proto/nbtconv/snbt_json_test.go
@@ -357,3 +357,26 @@ func TestSnbtToJSON_EmptyKeys(t *testing.T) {
 	// The empty key should be preserved
 	assert.Contains(t, string(got), `""`)
 }
+
+func TestSnbtToJSON_ComponentStyleByteBooleans(t *testing.T) {
+	// Modern Java chat components encode style booleans as NBT byte tags.
+	// go-mc renders those as 0B/1B in SNBT; they must become JSON booleans
+	// before the component codec sees them.
+	snbt := `{text:"hi",italic:0B,bold:1B,extra:[{text:" child",underlined:1b,strikethrough:0b,obfuscated:1}]}`
+
+	got, err := SnbtToJSON(snbt)
+	if !assert.NoError(t, err) {
+		return
+	}
+	assert.JSONEq(t, `{
+		"text": "hi",
+		"italic": false,
+		"bold": true,
+		"extra": [{
+			"text": " child",
+			"underlined": true,
+			"strikethrough": false,
+			"obfuscated": true
+		}]
+	}`, string(got))
+}

--- a/pkg/edition/java/proto/packet/chat/component_holder_test.go
+++ b/pkg/edition/java/proto/packet/chat/component_holder_test.go
@@ -1,0 +1,29 @@
+package chat
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"go.minekube.com/common/minecraft/component"
+	"go.minekube.com/gate/pkg/edition/java/proto/nbtconv"
+	"go.minekube.com/gate/pkg/edition/java/proto/version"
+)
+
+func TestComponentHolderAsComponentAcceptsNBTStyleByteBooleans(t *testing.T) {
+	tag, err := nbtconv.SnbtToBinaryTag(`{text:"hi",italic:0B,bold:1B}`)
+	require.NoError(t, err)
+
+	holder := &ComponentHolder{
+		Protocol:  version.Minecraft_1_21_5.Protocol,
+		BinaryTag: tag,
+	}
+	got, err := holder.AsComponent()
+	require.NoError(t, err)
+
+	text, ok := got.(*component.Text)
+	require.Truef(t, ok, "got %T", got)
+	require.Equal(t, "hi", text.Content)
+	require.Equal(t, component.False, text.S.Italic)
+	require.Equal(t, component.True, text.S.Bold)
+}


### PR DESCRIPTION
## Summary
- convert NBT byte style flags like `italic:0B`/`bold:1B` into JSON booleans for Java chat components
- add regression coverage for SNBT conversion and ComponentHolder decoding

## Tests
- `go test ./pkg/edition/java/proto/nbtconv ./pkg/edition/java/proto/packet/chat`
- `go test ./pkg/edition/java/proto/... ./pkg/edition/java/proxy/... ./pkg/edition/java/ping/...`
- `go test ./...`