### PR TITLE
fix(docker): use glibc base images so dynamically linked gate binary execs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,11 +48,61 @@ jobs:
 
       - name: Test
         run: make test
+  # Regression test for https://github.com/minekube/gate/issues/697:
+  # The published images crashed with "exec /gate: no such file or directory"
+  # because the gate binary is dynamically linked (the geyserlite dependency
+  # pulls in github.com/ebitengine/purego, which imports libdl.so.2 via
+  # //go:cgo_import_dynamic even with CGO_ENABLED=0) but the runtime base image
+  # had no glibc dynamic loader. This job builds the actual images and runs the
+  # binary so a broken runtime base fails CI instead of shipping.
+  docker-smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up docker buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build gate image (host arch, load)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          load: true
+          target: gate
+          build-args: |
+            VERSION=smoke-test
+          tags: gate:smoke
+
+      - name: Smoke test - gate binary execs in distroless image
+        run: |
+          out="$(docker run --rm gate:smoke --version)"
+          echo "$out"
+          echo "$out" | grep -q "gate version smoke-test"
+
+      - name: Build jre variant image (host arch, load)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          load: true
+          target: jre
+          build-args: |
+            VERSION=smoke-test
+          tags: gate-jre:smoke
+
+      - name: Smoke test - gate binary execs in jre image
+        run: |
+          out="$(docker run --rm gate-jre:smoke --version)"
+          echo "$out"
+          echo "$out" | grep -q "gate version smoke-test"
   build:
     if: ( github.event_name == 'workflow_dispatch' && startsWith(github.ref, 'refs/tags/') ) || ( github.event_name == 'push' && ( github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/') ) )
     needs:
       - lint
       - test
+      - docker-smoke
     runs-on: ubuntu-latest
     outputs:
       image: ${{ steps.image-ref.outputs.image }}

--- a/.web/docs/guide/install/docker.md
+++ b/.web/docs/guide/install/docker.md
@@ -24,7 +24,7 @@ The standard Gate image is based on a minimal distroless base image. This is the
 
 ### JRE Variant (`ghcr.io/minekube/gate/jre:latest`)
 
-The JRE variant includes Java Runtime Environment (JRE) and is **required for [Bedrock Edition support](../bedrock)**. This image is based on `eclipse-temurin:25-jre-alpine` and includes Java necessary to run Geyser for Bedrock cross-play.
+The JRE variant includes Java Runtime Environment (JRE) and is **required for [Bedrock Edition support](../bedrock)**. This image is based on `eclipse-temurin:25-jre` (glibc) and includes Java necessary to run Geyser for Bedrock cross-play.
 
 ::: tip When to Use the JRE Variant
 Use `ghcr.io/minekube/gate/jre:latest` if you:

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,12 +22,21 @@ RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH \
     go build -ldflags="-s -w -X 'go.minekube.com/gate/pkg/version.Version=${VERSION}'" -a -o gate gate.go
 
 # Move binary into final image (default Gate image - distroless)
-FROM --platform=$TARGETPLATFORM gcr.io/distroless/static-debian12 AS gate
+# NOTE: We use distroless/base (glibc) instead of distroless/static because the
+# Gate binary is dynamically linked. The geyserlite dependency (used by the
+# managed Bedrock mode) pulls in github.com/ebitengine/purego, whose no-cgo
+# Linux path declares //go:cgo_import_dynamic for libdl.so.2. That forces the
+# binary to depend on the glibc dynamic loader (/lib64/ld-linux-x86-64.so.2)
+# even with CGO_ENABLED=0, so a static-only base would crash at startup with
+# "exec /gate: no such file or directory".
+FROM --platform=$TARGETPLATFORM gcr.io/distroless/base-debian12 AS gate
 COPY --from=build /workspace/gate /
 ENTRYPOINT ["/gate"]
 
-# Move binary into final image (jre variant Gate image - temurin-25-jre-alpine)
-FROM --platform=$TARGETPLATFORM eclipse-temurin:25.0.1_8-jre-alpine AS jre
+# Move binary into final image (jre variant Gate image - temurin-25-jre)
+# Must be a glibc-based JRE (not the alpine/musl variant) for the same reason
+# as above: the dynamically linked Gate binary needs the glibc loader.
+FROM --platform=$TARGETPLATFORM eclipse-temurin:25.0.1_8-jre AS jre
 COPY --from=build /workspace/gate /usr/local/bin/gate
 ENV PATH=/opt/java/openjdk/bin:$PATH
 ENTRYPOINT ["/usr/local/bin/gate"]


### PR DESCRIPTION
The published images crashed at startup with
"exec /gate: no such file or directory" (#697).

Root cause: the binary is dynamically linked, not static. The geyserlite
dependency (pulled in by the default managed Bedrock mode) imports
github.com/ebitengine/purego, whose no-cgo Linux path declares
//go:cgo_import_dynamic for libdl.so.2. That makes the binary depend on the
glibc dynamic loader (/lib64/ld-linux-x86-64.so.2) even with CGO_ENABLED=0.

The runtime bases had no glibc loader:
- gcr.io/distroless/static-debian12 (no dynamic loader at all)
- eclipse-temurin:25.0.1_8-jre-alpine (musl, not glibc)

so exec failed with ENOENT before main() ran.

Switch to glibc-capable bases:
- distroless/static-debian12 -> distroless/base-debian12
- temurin 25-jre-alpine -> temurin 25-jre (glibc)

Add a docker-smoke CI job (regression test for #697) that builds both images
and runs the binary (gate --version) so a runtime base that cannot exec the
binary fails CI instead of shipping. The publish job now depends on it.

https://claude.ai/code/session_01SpBB997Y46mW7hJ2EqTiYv