### PR TITLE
fix(bedrock): trust linked Geyser accounts safely

### DIFF
--- a/pkg/edition/bedrock/geyser/geyser.go
+++ b/pkg/edition/bedrock/geyser/geyser.go
@@ -6,6 +6,8 @@ import (
 	"math"
 	"net"
 	"os"
+	"strconv"
+	"strings"
 	"sync"
 
 	"github.com/go-logr/logr"
@@ -15,9 +17,11 @@ import (
 	"go.minekube.com/gate/pkg/edition/bedrock/config"
 	"go.minekube.com/gate/pkg/edition/bedrock/geyser/floodgate"
 	"go.minekube.com/gate/pkg/edition/bedrock/geyser/managed"
+	"go.minekube.com/gate/pkg/edition/java/lite"
 	"go.minekube.com/gate/pkg/edition/java/profile"
 	"go.minekube.com/gate/pkg/edition/java/proxy"
 	"go.minekube.com/gate/pkg/util/errs"
+	"go.minekube.com/gate/pkg/util/netutil"
 	"go.minekube.com/gate/pkg/util/uuid"
 )
 
@@ -87,7 +91,9 @@ type GeyserConnection struct {
 	context.Context
 	net.Conn
 	*floodgate.BedrockData
-	closeCb func()
+	OriginalHost  string
+	LinkedAccount *LinkedAccountResult
+	closeCb       func()
 }
 
 func (c *GeyserConnection) Close() error {
@@ -297,6 +303,8 @@ func (i *Integration) onPreLogin(e *proxy.PreLoginEvent) {
 		}
 
 		geyserConn.BedrockData = bedrockData
+		geyserConn.OriginalHost = originalHost
+		e.SetVirtualHost(cleanedVirtualHost(hostname, originalHost))
 
 		// Force offline mode for Bedrock players (Floodgate handles auth)
 		e.ForceOfflineMode()
@@ -352,6 +360,9 @@ func (i *Integration) onGameProfile(e *proxy.GameProfileRequestEvent) {
 
 	// Check for linked Java account
 	if linkedAccount, err := i.profileManager.GetLinkedAccount(bedrockData.Xuid); err == nil && linkedAccount != nil && linkedAccount.JavaID != uuid.Nil {
+		geyserConn.LinkedAccount = linkedAccount
+		bedrockData.LinkedPlayer = linkedAccount.JavaName
+
 		// Use linked Java account details
 		i.log.Info("bedrock player using linked java account",
 			"bedrock_name", bedrockData.Username,
@@ -364,4 +375,57 @@ func (i *Integration) onGameProfile(e *proxy.GameProfileRequestEvent) {
 	}
 
 	e.SetGameProfile(gameProfile)
+}
+
+func cleanedVirtualHost(current net.Addr, originalHost string) net.Addr {
+	network := "tcp"
+	currentPort := uint16(0)
+	if current != nil {
+		network = current.Network()
+		currentPort = virtualHostPort(current)
+	}
+	host, port := splitOriginalHostPort(originalHost)
+	if port == 0 {
+		port = currentPort
+	}
+	host = lite.ClearVirtualHost(host)
+	if port == 0 {
+		return netutil.NewAddr(host, network)
+	}
+	return netutil.NewAddr(net.JoinHostPort(host, strconv.Itoa(int(port))), network)
+}
+
+func virtualHostPort(addr net.Addr) uint16 {
+	_, port := netutil.HostPort(addr)
+	if port != 0 {
+		return port
+	}
+	host := addr.String()
+	if !strings.Contains(host, "\x00") {
+		return 0
+	}
+	idx := strings.LastIndex(host, ":")
+	if idx == -1 || idx == len(host)-1 {
+		return 0
+	}
+	portInt, err := strconv.Atoi(host[idx+1:])
+	if err != nil || portInt <= 0 || portInt > 65535 {
+		return 0
+	}
+	return uint16(portInt)
+}
+
+func splitOriginalHostPort(originalHost string) (string, uint16) {
+	host, portStr, err := net.SplitHostPort(originalHost)
+	if err == nil {
+		port, err := strconv.Atoi(portStr)
+		if err == nil && port > 0 && port <= 65535 {
+			return host, uint16(port)
+		}
+		return host, 0
+	}
+	if strings.HasPrefix(originalHost, "[") && strings.HasSuffix(originalHost, "]") {
+		return strings.TrimSuffix(strings.TrimPrefix(originalHost, "["), "]"), 0
+	}
+	return originalHost, 0
 }

--- a/pkg/edition/bedrock/geyser/host_test.go
+++ b/pkg/edition/bedrock/geyser/host_test.go
@@ -1,0 +1,58 @@
+package geyser
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.minekube.com/gate/pkg/util/netutil"
+)
+
+func TestCleanedVirtualHostPreservesPort(t *testing.T) {
+	current := netutil.NewAddr("minekube.net\x00^Floodgate^payload:25565", "tcp")
+
+	cleaned := cleanedVirtualHost(current, "minekube.net")
+
+	require.Equal(t, "tcp", cleaned.Network())
+	require.Equal(t, "minekube.net:25565", cleaned.String())
+}
+
+func TestCleanedVirtualHostWithoutPort(t *testing.T) {
+	current := netutil.NewAddr("minekube.net\x00^Floodgate^payload", "tcp")
+
+	cleaned := cleanedVirtualHost(current, "minekube.net")
+
+	require.Equal(t, "tcp", cleaned.Network())
+	require.Equal(t, "minekube.net", cleaned.String())
+}
+
+func TestCleanedVirtualHostKeepsOriginalPort(t *testing.T) {
+	current := netutil.NewAddr("minekube.net\x00^Floodgate^payload:25565", "tcp")
+
+	cleaned := cleanedVirtualHost(current, "minekube.net.:19132")
+
+	require.Equal(t, "minekube.net:19132", cleaned.String())
+}
+
+func TestCleanedVirtualHostUsesLiteCleanup(t *testing.T) {
+	current := netutil.NewAddr("minekube.net\x00^Floodgate^payload:25565", "tcp")
+
+	cleaned := cleanedVirtualHost(current, "minekube.net.///203.0.113.10///123")
+
+	require.Equal(t, "minekube.net:25565", cleaned.String())
+}
+
+func TestCleanedVirtualHostBracketedIPv6(t *testing.T) {
+	current := netutil.NewAddr("[2001:db8::1]\x00^Floodgate^payload:25565", "tcp")
+
+	cleaned := cleanedVirtualHost(current, "[2001:db8::1]")
+
+	require.Equal(t, "[2001:db8::1]:25565", cleaned.String())
+}
+
+func TestCleanedVirtualHostBracketedIPv6WithOriginalPort(t *testing.T) {
+	current := netutil.NewAddr("[2001:db8::1]\x00^Floodgate^payload:25565", "tcp")
+
+	cleaned := cleanedVirtualHost(current, "[2001:db8::1]:19132")
+
+	require.Equal(t, "[2001:db8::1]:19132", cleaned.String())
+}

--- a/pkg/edition/java/proto/packet/disconnect.go
+++ b/pkg/edition/java/proto/packet/disconnect.go
@@ -3,7 +3,6 @@ package packet
 import (
 	"errors"
 	"io"
-	"log/slog"
 
 	"go.minekube.com/common/minecraft/component"
 
@@ -45,7 +44,6 @@ func NewDisconnect(reason component.Component, protocol proto.Protocol, stat sta
 		protocol = version.Minecraft_1_20_2.Protocol
 	}
 	if reason == nil {
-		slog.Error("tried to create a Disconnect packet with a nil reason")
 		reason = &component.Text{Content: ""}
 	}
 	return &Disconnect{

--- a/pkg/edition/java/proto/packet/disconnect_test.go
+++ b/pkg/edition/java/proto/packet/disconnect_test.go
@@ -1,0 +1,39 @@
+package packet
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.minekube.com/common/minecraft/component"
+	"go.minekube.com/gate/pkg/edition/java/proto/state/states"
+	"go.minekube.com/gate/pkg/edition/java/proto/version"
+	"go.minekube.com/gate/pkg/gate/proto"
+)
+
+func TestNewDisconnectNilReasonEncodes(t *testing.T) {
+	p := NewDisconnect(nil, version.Minecraft_1_20_2.Protocol, states.PlayState)
+	require.NotNil(t, p.Reason)
+
+	var buf bytes.Buffer
+	err := p.Encode(&proto.PacketContext{
+		Direction: proto.ClientBound,
+		Protocol:  version.Minecraft_1_20_2.Protocol,
+	}, &buf)
+	require.NoError(t, err)
+	require.NotEmpty(t, buf.Bytes())
+}
+
+func TestNewDisconnectTypedNilReasonEncodes(t *testing.T) {
+	var reason *component.Text
+	p := NewDisconnect(reason, version.Minecraft_1_20_2.Protocol, states.PlayState)
+	require.NotNil(t, p.Reason)
+
+	var buf bytes.Buffer
+	err := p.Encode(&proto.PacketContext{
+		Direction: proto.ClientBound,
+		Protocol:  version.Minecraft_1_20_2.Protocol,
+	}, &buf)
+	require.NoError(t, err)
+	require.NotEmpty(t, buf.Bytes())
+}

--- a/pkg/edition/java/proxy/disconnect_reason.go
+++ b/pkg/edition/java/proxy/disconnect_reason.go
@@ -1,0 +1,18 @@
+package proxy
+
+import (
+	"reflect"
+
+	"go.minekube.com/common/minecraft/component"
+)
+
+func normalizeDisconnectReason(reason component.Component) component.Component {
+	if reason == nil {
+		return &component.Text{Content: ""}
+	}
+	value := reflect.ValueOf(reason)
+	if value.Kind() == reflect.Ptr && value.IsNil() {
+		return &component.Text{Content: ""}
+	}
+	return reason
+}

--- a/pkg/edition/java/proxy/disconnect_reason_test.go
+++ b/pkg/edition/java/proxy/disconnect_reason_test.go
@@ -1,0 +1,30 @@
+package proxy
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.minekube.com/common/minecraft/component"
+	"go.minekube.com/common/minecraft/component/codec/legacy"
+)
+
+func TestNormalizeDisconnectReasonNil(t *testing.T) {
+	reason := normalizeDisconnectReason(nil)
+
+	require.NotNil(t, reason)
+	require.IsType(t, &component.Text{}, reason)
+}
+
+func TestNormalizeDisconnectReasonTypedNilMarshalsLegacy(t *testing.T) {
+	var typedNil *component.Text
+
+	reason := normalizeDisconnectReason(typedNil)
+
+	require.NotNil(t, reason)
+	require.IsType(t, &component.Text{}, reason)
+	require.NotPanics(t, func() {
+		err := (&legacy.Legacy{}).Marshal(new(strings.Builder), reason)
+		require.NoError(t, err)
+	})
+}

--- a/pkg/edition/java/proxy/events.go
+++ b/pkg/edition/java/proxy/events.go
@@ -283,6 +283,22 @@ func (e *PreLoginEvent) Conn() Inbound {
 	return e.connection
 }
 
+// SetVirtualHost replaces the virtual host for the connecting player.
+// It is intended for integrations that decode proxy metadata from the
+// handshake host and need later routing/backend handshakes to see the
+// original clean host.
+func (e *PreLoginEvent) SetVirtualHost(addr net.Addr) bool {
+	type virtualHostSetter interface {
+		setVirtualHost(net.Addr)
+	}
+	setter, ok := e.connection.(virtualHostSetter)
+	if !ok {
+		return false
+	}
+	setter.setVirtualHost(addr)
+	return true
+}
+
 // Result returns the current result of the PreLoginEvent.
 func (e *PreLoginEvent) Result() PreLoginResult {
 	return e.result

--- a/pkg/edition/java/proxy/login_inbound.go
+++ b/pkg/edition/java/proxy/login_inbound.go
@@ -74,6 +74,8 @@ func (l *loginInboundConn) Protocol() proto.Protocol { return l.delegate.Protoco
 
 func (l *loginInboundConn) VirtualHost() net.Addr { return l.delegate.VirtualHost() }
 
+func (l *loginInboundConn) setVirtualHost(addr net.Addr) { l.delegate.setVirtualHost(addr) }
+
 func (l *loginInboundConn) HandshakeIntent() packet.HandshakeIntent {
 	return l.delegate.HandshakeIntent()
 }

--- a/pkg/edition/java/proxy/player.go
+++ b/pkg/edition/java/proxy/player.go
@@ -607,6 +607,7 @@ func (p *connectedPlayer) Disconnect(reason component.Component) {
 	if !p.Active() {
 		return
 	}
+	reason = normalizeDisconnectReason(reason)
 
 	var r string
 	b := new(strings.Builder)

--- a/pkg/edition/java/proxy/session_client_handshake.go
+++ b/pkg/edition/java/proxy/session_client_handshake.go
@@ -227,6 +227,10 @@ func (i *initialInbound) VirtualHost() net.Addr {
 	return i.virtualHost
 }
 
+func (i *initialInbound) setVirtualHost(addr net.Addr) {
+	i.virtualHost = addr
+}
+
 func (i *initialInbound) HandshakeIntent() packet.HandshakeIntent {
 	return i.handshakeIntent
 }
@@ -241,7 +245,7 @@ func (i *initialInbound) String() string {
 
 func (i *initialInbound) disconnect(reason component.Component) error {
 	// TODO add cfg option to log player connections to log "player disconnected"
-	return netmc.CloseWith(i.MinecraftConn, packet.NewDisconnect(reason, i.Protocol(), i.State().State))
+	return netmc.CloseWith(i.MinecraftConn, packet.NewDisconnect(normalizeDisconnectReason(reason), i.Protocol(), i.State().State))
 }
 
 //


### PR DESCRIPTION
## Summary
- expose resolved Geyser linked Java account metadata for downstream trust checks
- clean decoded Floodgate virtual hosts with the existing Lite helper while preserving ports/network
- normalize nil and typed-nil disconnect reasons before proxy-side legacy marshaling

## Verification
- go test ./pkg/edition/bedrock/geyser ./pkg/edition/java/proto/packet ./pkg/edition/java/proxy -count=1
- go test ./...
- go test -race ./pkg/edition/bedrock/geyser ./pkg/edition/java/proxy ./pkg/edition/java/proto/packet
- subagent review PASS after typed-nil follow-up