### PR TITLE
fix(docker): support managed geyserlite on arm64

### DIFF
--- a/.examples/bedrock/docker-compose.yml
+++ b/.examples/bedrock/docker-compose.yml
@@ -2,12 +2,13 @@ services:
   gate:
     image: ghcr.io/minekube/gate:latest
     restart: unless-stopped
+    working_dir: /data
     environment:
-      - GATE_CONFIG_PATH=/gate/gate.yml
+      - GATE_CONFIG=/config/gate.yml
     volumes:
-      - ./gate.yml:/gate/gate.yml
-      - gate-cache:/gate/.cache
-      - gate-data:/gate/data
+      - ./gate.yml:/config/gate.yml:ro
+      - gate-cache:/var/cache/gate
+      - gate-data:/data
     ports:
       - '25565:25565' # Java Edition
       - '19132:19132/udp' # Bedrock Edition

--- a/.github/testdata/managed-bedrock.yml
+++ b/.github/testdata/managed-bedrock.yml
@@ -1,0 +1,11 @@
+config:
+  bind: 0.0.0.0:25565
+  onlineMode: false
+  servers:
+    backend: 127.0.0.1:25566
+  try:
+    - backend
+  bedrock:
+    enabled: true
+    floodgateKeyPath: /tmp/floodgate.pem
+    managed: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,9 +54,14 @@ jobs:
   # pulls in github.com/ebitengine/purego, which imports libdl.so.2 via
   # //go:cgo_import_dynamic even with CGO_ENABLED=0) but the runtime base image
   # had no glibc dynamic loader. This job builds the actual images and runs the
-  # binary so a broken runtime base fails CI instead of shipping.
+  # binary and starts managed Bedrock on both architectures so broken runtime
+  # dependencies or cache paths fail CI instead of shipping.
   docker-smoke:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        runner: [ubuntu-latest, ubuntu-24.04-arm]
+    runs-on: ${{ matrix.runner }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -80,6 +85,25 @@ jobs:
           out="$(docker run --rm gate:smoke --version)"
           echo "$out"
           echo "$out" | grep -q "gate version smoke-test"
+
+      - name: Smoke test - managed Bedrock starts in read-only distroless image
+        run: |
+          cid=$(docker run -d --read-only --tmpfs /tmp \
+            -v "$PWD/.github/testdata/managed-bedrock.yml:/config.yml:ro" \
+            gate:smoke --config /config.yml)
+          trap 'docker logs "$cid" 2>&1 || true; docker rm -f "$cid" >/dev/null 2>&1 || true' EXIT
+
+          for _ in $(seq 1 180); do
+            logs=$(docker logs "$cid" 2>&1)
+            if grep -q "geyser integration started" <<<"$logs"; then
+              exit 0
+            fi
+            if [ "$(docker inspect -f '{{.State.Running}}' "$cid")" != "true" ]; then
+              exit 1
+            fi
+            sleep 1
+          done
+          exit 1
 
       - name: Build jre variant image (host arch, load)
         uses: docker/build-push-action@v6

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,13 @@ ARG VERSION=unknown
 RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH \
     go build -ldflags="-s -w -X 'go.minekube.com/gate/pkg/version.Version=${VERSION}'" -a -o gate gate.go
 
+# The arm64 geyserlite executable is dynamically linked and needs zlib.
+# Stage the target-platform library so managed Bedrock also works in the
+# minimal distroless image.
+FROM debian:bookworm-slim AS runtime-deps
+RUN mkdir -p /runtime-libs \
+    && cp -L /usr/lib/*-linux-gnu/libz.so.1 /runtime-libs/libz.so.1
+
 # Move binary into final image (default Gate image - distroless)
 # NOTE: We use distroless/base (glibc) instead of distroless/static because the
 # Gate binary is dynamically linked. The geyserlite dependency (used by the
@@ -29,14 +36,19 @@ RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH \
 # binary to depend on the glibc dynamic loader (/lib64/ld-linux-x86-64.so.2)
 # even with CGO_ENABLED=0, so a static-only base would crash at startup with
 # "exec /gate: no such file or directory".
-FROM --platform=$TARGETPLATFORM gcr.io/distroless/base-debian12 AS gate
+FROM gcr.io/distroless/base-debian12 AS gate
 COPY --from=build /workspace/gate /
+COPY --from=runtime-deps /runtime-libs/libz.so.1 /usr/lib/libz.so.1
+ENV XDG_CACHE_HOME=/var/cache/gate
+VOLUME ["/var/cache/gate"]
 ENTRYPOINT ["/gate"]
 
 # Move binary into final image (jre variant Gate image - temurin-25-jre)
 # Must be a glibc-based JRE (not the alpine/musl variant) for the same reason
 # as above: the dynamically linked Gate binary needs the glibc loader.
-FROM --platform=$TARGETPLATFORM eclipse-temurin:25.0.1_8-jre AS jre
+FROM eclipse-temurin:25.0.1_8-jre AS jre
 COPY --from=build /workspace/gate /usr/local/bin/gate
 ENV PATH=/opt/java/openjdk/bin:$PATH
+ENV XDG_CACHE_HOME=/var/cache/gate
+VOLUME ["/var/cache/gate"]
 ENTRYPOINT ["/usr/local/bin/gate"]


### PR DESCRIPTION
## Summary
- add the zlib runtime required by the dynamically linked arm64 geyserlite executable
- give auto-downloaded managed assets a declared writable/executable cache volume
- run the managed-Bedrock Docker smoke on amd64 and arm64 with a read-only root
- repair the bundled Bedrock Compose example paths and config environment variable

## Root cause
The public arm64 Gate distroless image downloaded geyserlite successfully, then repeatedly exited because `libz.so.1` was absent. Locked-down/read-only images could instead surface the generic `ELF binary not found` message because no writable download cache existed. Existing Docker CI only ran `gate --version`, so neither managed-mode failure was covered.

## Verification
- `go test ./...`
- `go vet ./...`
- `docker compose -f .examples/bedrock/docker-compose.yml config`
- built the arm64 distroless target locally and confirmed managed Bedrock reaches `geyser integration started` with `--read-only --tmpfs /tmp`