### PR TITLE
ci: smoke test Geyserlite Windows auto-download

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,10 @@ jobs:
 
       - name: Test
         run: make test
+
+      - name: Smoke test - Geyserlite Windows auto-download starts
+        if: matrix.platform == 'windows-latest'
+        run: go test ./pkg/edition/bedrock/geyser -tags=geyserlite_smoke -run TestLiteManagedRunnerWindowsAutoDownloadSmoke -count=1 -timeout 6m -v
   # Regression test for https://github.com/minekube/gate/issues/697:
   # The published images crashed with "exec /gate: no such file or directory"
   # because the gate binary is dynamically linked (the geyserlite dependency

--- a/pkg/edition/bedrock/geyser/managed_runner_windows_smoke_test.go
+++ b/pkg/edition/bedrock/geyser/managed_runner_windows_smoke_test.go
@@ -1,0 +1,48 @@
+//go:build windows && geyserlite_smoke
+
+package geyser
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"go.minekube.com/gate/pkg/edition/bedrock/config"
+)
+
+func TestLiteManagedRunnerWindowsAutoDownloadSmoke(t *testing.T) {
+	t.Setenv("GEYSERLITE_BINARY", "")
+	t.Setenv("GEYSERLITE_LIBRARY", "")
+
+	tempDir := t.TempDir()
+	keyPath := filepath.Join(tempDir, "floodgate.key")
+	if err := os.WriteFile(keyPath, []byte("0123456789abcdef"), 0o600); err != nil {
+		t.Fatalf("write key: %v", err)
+	}
+
+	cfg := &config.Config{
+		GeyserListenAddr: "127.0.0.1:25567",
+		FloodgateKeyPath: keyPath,
+		Managed: &config.ManagedGeyser{
+			Enabled: true,
+			Engine:  config.ManagedEngineGeyserlite,
+			Mode:    "subprocess",
+			ConfigOverrides: map[string]any{
+				"bedrock": map[string]any{
+					"address": "127.0.0.1",
+					"port":    19142,
+				},
+			},
+		},
+	}
+
+	runner := newLiteManagedRunner(cfg)
+	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Minute)
+	defer cancel()
+	if err := runner.Start(ctx); err != nil {
+		t.Fatalf("start managed geyserlite: %v", err)
+	}
+	t.Cleanup(runner.Stop)
+}


### PR DESCRIPTION
## Summary
- add a Windows-only tagged smoke test for Gate-managed Geyserlite subprocess startup
- run the smoke in the Windows CI matrix after normal tests
- verify the default managed path can auto-download and start the Windows Geyserlite binary

## Verification
- go test ./pkg/edition/bedrock/geyser
- GOOS=windows GOARCH=amd64 go test ./pkg/edition/bedrock/geyser -tags=geyserlite_smoke -run TestLiteManagedRunnerWindowsAutoDownloadSmoke -c -o /tmp/gate-geyser-windows-smoke.test.exe
- go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/ci.yml
- make test