### PR TITLE
Drop stale backend keepalive replies

### DIFF
--- a/pkg/edition/java/proxy/session_backend_config.go
+++ b/pkg/edition/java/proxy/session_backend_config.go
@@ -3,7 +3,6 @@ package proxy
 import (
 	"errors"
 	"fmt"
-	"time"
 
 	"github.com/go-logr/logr"
 	"github.com/robinbraemer/event"
@@ -248,7 +247,7 @@ func (b *backendConfigSessionHandler) handlePluginMessage(pc *proto.PacketContex
 }
 
 func (b *backendConfigSessionHandler) handleKeepAlive(p *packet.KeepAlive) {
-	b.serverConn.pendingPings.Set(p.RandomID, time.Now())
+	recordBackendKeepAlive(b.serverConn, p)
 	_ = b.serverConn.player.WritePacket(p)
 }
 

--- a/pkg/edition/java/proxy/session_backend_play.go
+++ b/pkg/edition/java/proxy/session_backend_play.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"reflect"
-	"time"
 
 	"github.com/go-logr/logr"
 	"go.minekube.com/gate/pkg/edition/java/proto/packet/chat"
@@ -144,7 +143,7 @@ func (b *backendPlaySessionHandler) Disconnected() {
 }
 
 func (b *backendPlaySessionHandler) handleKeepAlive(p *packet.KeepAlive, pc *proto.PacketContext) {
-	b.serverConn.pendingPings.Set(p.RandomID, time.Now())
+	recordBackendKeepAlive(b.serverConn, p)
 	b.forwardToPlayer(pc, nil) // forward on
 }
 

--- a/pkg/edition/java/proxy/session_client_play.go
+++ b/pkg/edition/java/proxy/session_client_play.go
@@ -316,6 +316,11 @@ func sendKeepAliveToBackend(serverConn *serverConnection, player *connectedPlaye
 	return true
 }
 
+func recordBackendKeepAlive(serverConn *serverConnection, p *packet.KeepAlive) {
+	serverConn.pendingPings.Flush()
+	serverConn.pendingPings.Set(p.RandomID, time.Now())
+}
+
 func (c *clientPlaySessionHandler) handlePluginMessage(packet *plugin.Message) {
 	serverConn := c.player.connectedServer()
 

--- a/pkg/edition/java/proxy/session_client_play_keepalive_test.go
+++ b/pkg/edition/java/proxy/session_client_play_keepalive_test.go
@@ -83,3 +83,28 @@ func TestSendKeepAliveIgnoresUnknownPing(t *testing.T) {
 		t.Fatalf("expected no writes for unknown ping, got %d", len(backend.written))
 	}
 }
+
+// Backends such as Minestom only accept a response to the latest keep-alive
+// they sent. Keep older IDs out of the pending set so late Bedrock/Geyser
+// replies are dropped instead of being forwarded to the backend and causing
+// "Bad Keep Alive packet" kicks after rapid server switches.
+func TestRecordBackendKeepAliveInvalidatesOlderPendingPings(t *testing.T) {
+	player, sc, backend := newKeepAliveFixture(state.Play, state.Play)
+
+	recordBackendKeepAlive(sc, &packet.KeepAlive{RandomID: 1})
+	recordBackendKeepAlive(sc, &packet.KeepAlive{RandomID: 2})
+
+	if sendKeepAliveToBackend(sc, player, &packet.KeepAlive{RandomID: 1}) {
+		t.Fatal("expected stale keep-alive response to be ignored")
+	}
+	if len(backend.written) != 0 {
+		t.Fatalf("expected stale keep-alive not to be forwarded, got %d writes", len(backend.written))
+	}
+
+	if !sendKeepAliveToBackend(sc, player, &packet.KeepAlive{RandomID: 2}) {
+		t.Fatal("expected latest keep-alive response to be consumed")
+	}
+	if len(backend.written) != 1 {
+		t.Fatalf("expected latest keep-alive forwarded once, got %d writes", len(backend.written))
+	}
+}


### PR DESCRIPTION
## Summary
- keep only the latest backend keepalive ID per server connection
- drop late replies to older keepalives instead of forwarding them to a backend that will reject them
- add regression coverage for Minestom-style latest-ID keepalive validation

## Why
Bedrock/Geyser sessions can reply late around rapid server switches. The Connect hub runs Minestom, which kicks on any keepalive response that does not match the latest keepalive ID. Retaining older pending IDs let Gate forward stale replies and caused "Bad Keep Alive packet" disconnects after fallback to hub.

## Verification
- go test ./pkg/edition/java/proxy -run 'Test.*KeepAlive' -count=1
- go test ./pkg/edition/java/proxy -count=1
- go test ./pkg/edition/java/...
- go test ./...