### PR TITLE
Fix transition keepalive forwarding

### DIFF
--- a/pkg/edition/java/proxy/session_backend_transition.go
+++ b/pkg/edition/java/proxy/session_backend_transition.go
@@ -103,7 +103,8 @@ func (b *backendTransitionSessionHandler) shouldHandle() bool {
 }
 
 func (b *backendTransitionSessionHandler) handleKeepAlive(p *packet.KeepAlive) {
-	_ = b.serverConn.conn().WritePacket(p)
+	recordBackendKeepAlive(b.serverConn, p)
+	_ = b.serverConn.player.WritePacket(p)
 }
 func (b *backendTransitionSessionHandler) handleDisconnect(p *packet.Disconnect) {
 	var connType phase.ConnectionType

--- a/pkg/edition/java/proxy/session_client_play_keepalive_test.go
+++ b/pkg/edition/java/proxy/session_client_play_keepalive_test.go
@@ -140,3 +140,20 @@ func TestForwardKeepAliveFallsBackToInFlightConnection(t *testing.T) {
 		t.Fatalf("expected in-flight backend to receive keep-alive once, got %d writes", len(inFlightBackend.written))
 	}
 }
+
+func TestBackendTransitionKeepAliveTracksAndForwardsToPlayer(t *testing.T) {
+	player, sc, backend := newKeepAliveFixture(state.Play, state.Play)
+	handler := &backendTransitionSessionHandler{serverConn: sc}
+
+	handler.handleKeepAlive(&packet.KeepAlive{RandomID: 1234})
+
+	if len(backend.written) != 0 {
+		t.Fatalf("expected transition keep-alive not to be written back to backend, got %d writes", len(backend.written))
+	}
+	if len(player.MinecraftConn.(*keepAliveTestConn).written) != 1 {
+		t.Fatalf("expected transition keep-alive forwarded to player once, got %d writes", len(player.MinecraftConn.(*keepAliveTestConn).written))
+	}
+	if _, ok := sc.pendingPings.Get(1234); !ok {
+		t.Fatal("expected transition keep-alive to be tracked as pending")
+	}
+}


### PR DESCRIPTION
## Summary
- record backend keepalive challenges while a backend connection is still transitioning
- forward transition keepalives to the player instead of writing them back to the backend
- add a regression test for the transition keepalive path

## Verification
- go test ./pkg/edition/java/proxy -run 'Test.*KeepAlive'
- go test ./pkg/edition/java/proxy ./pkg/edition/bedrock/geyser/...
