### PR TITLE
Stabilize Bedrock keepalive handling

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -350,9 +350,10 @@ config:
         # Enable debug logging (shows packet details)
         # Default: false
         debug-mode: false
-        # Whether to forward player ping to Gate.
-        # Default: true
-        forward-player-ping: true
+        # Whether to forward Bedrock client latency to Gate/backend keepalives.
+        # Keep disabled for stable mobile connections.
+        # Default: false
+        forward-player-ping: false
 
         # Bedrock-specific features
         # Show block break cooldown as title/actionbar

--- a/pkg/configs/config.yml
+++ b/pkg/configs/config.yml
@@ -339,9 +339,10 @@ config:
         # Enable debug logging (shows packet details)
         # Default: false
         debug-mode: false
-        # Whether to forward player ping to Gate.
-        # Default: true
-        forward-player-ping: true
+        # Whether to forward Bedrock client latency to Gate/backend keepalives.
+        # Keep disabled for stable mobile connections.
+        # Default: false
+        forward-player-ping: false
 
         # Bedrock-specific features
         # Show block break cooldown as title/actionbar

--- a/pkg/edition/bedrock/geyser/managed/managed.go
+++ b/pkg/edition/bedrock/geyser/managed/managed.go
@@ -256,7 +256,7 @@ legacy-ping-passthrough: false
 ping-passthrough-interval: 3
 
 # Performance settings
-forward-player-ping: true
+forward-player-ping: false
 max-players: 100
 debug-mode: false
 

--- a/pkg/edition/bedrock/geyser/managed/managed_test.go
+++ b/pkg/edition/bedrock/geyser/managed/managed_test.go
@@ -45,6 +45,38 @@ func TestWriteGeyserConfigForwardsHostnameByDefault(t *testing.T) {
 	}
 }
 
+func TestWriteGeyserConfigDisablesForwardPlayerPingByDefault(t *testing.T) {
+	dataDir := t.TempDir()
+	keyPath := filepath.Join(dataDir, "floodgate.pem")
+	if err := os.WriteFile(keyPath, []byte("test-key"), 0o600); err != nil {
+		t.Fatalf("failed to write key: %v", err)
+	}
+
+	r := &Runner{cfg: &bconfig.Config{
+		GeyserListenAddr: "127.0.0.1:25567",
+		FloodgateKeyPath: keyPath,
+	}}
+
+	configPath, err := r.writeGeyserConfig(bconfig.ManagedGeyser{DataDir: dataDir})
+	if err != nil {
+		t.Fatalf("writeGeyserConfig failed: %v", err)
+	}
+
+	configBytes, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("failed to read config: %v", err)
+	}
+
+	var result map[string]any
+	if err := yaml.Unmarshal(configBytes, &result); err != nil {
+		t.Fatalf("failed to parse generated config: %v", err)
+	}
+
+	if result["forward-player-ping"] != false {
+		t.Fatalf("expected forward-player-ping = false, got %v", result["forward-player-ping"])
+	}
+}
+
 func TestApplyConfigOverrides(t *testing.T) {
 	r := &Runner{}
 


### PR DESCRIPTION
## Summary
- disable Gate-managed Geyser `forward-player-ping` by default
- update sample generated config docs to match the safer default
- add a regression test for the generated managed Geyser config

## Why
Mobile Bedrock sessions through GeyserLite were kicked by Paper with `out-of-order keepalive response`. I tmp-cloned PaperMC/Velocity and compared keepalive handling: Gate already matches the important Velocity behavior of only forwarding client keepalive replies when the ID belongs to a backend connection, and the staging Moxy binary is running the fixed Gate module.

The remaining failing path is Geyser `forward-player-ping`, which turns Java backend keepalives into Bedrock `NetworkStackLatency` round trips. On mobile, stale/delayed latency responses can cause Geyser to emit an old Java keepalive response, which Paper rejects. Keeping backend keepalive management on the Java side avoids that unstable Bedrock latency coupling.

## Testing
- `go test ./pkg/edition/bedrock/... ./pkg/edition/java/proxy/...`

## Staging
Also updated `connect-proxy-staging` with `forward-player-ping: false` in `/connect-proxy.yaml` for live validation.