### PR TITLE
web: fetch community stats at build time

### DIFF
--- a/.web/docs/.vitepress/config.ts
+++ b/.web/docs/.vitepress/config.ts
@@ -12,11 +12,25 @@ const ogUrl = 'https://gate.minekube.com';
 const ogImage = `${ogUrl}/og-image.png`;
 const ogTitle = 'Gate Proxy';
 const ogDescription = 'Next Generation Minecraft Proxy';
+const numberFromEnv = (value: string | undefined, fallback: number) => {
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed >= 0 ? parsed : fallback;
+};
+const communityStats = {
+  discordMembers: numberFromEnv(process.env.GATE_DOCS_DISCORD_MEMBERS, 1650),
+  githubStars: numberFromEnv(process.env.GATE_DOCS_GITHUB_STARS, 1050),
+};
 
 export default defineConfig({
   title: `Gate Proxy${additionalTitle}`,
   description: ogDescription,
   appearance: 'dark',
+
+  vite: {
+    define: {
+      __COMMUNITY_STATS__: communityStats,
+    },
+  },
 
   sitemap: {
     hostname: ogUrl,

--- a/.web/docs/shared/index.ts
+++ b/.web/docs/shared/index.ts
@@ -4,9 +4,22 @@ export const discordLink = 'https://minekube.com/discord';
 export const gitHubLink = 'https://github.com/minekube';
 
 // Community stats
+declare const __COMMUNITY_STATS__:
+  | {
+      discordMembers: number;
+      githubStars: number;
+    }
+  | undefined;
+
 export const communityStats = {
-  discordMembers: 1350,
-  githubStars: 900,
+  discordMembers:
+    typeof __COMMUNITY_STATS__ !== 'undefined'
+      ? __COMMUNITY_STATS__.discordMembers
+      : 1650,
+  githubStars:
+    typeof __COMMUNITY_STATS__ !== 'undefined'
+      ? __COMMUNITY_STATS__.githubStars
+      : 1050,
 };
 
 export const editLink = (project: string): DefaultTheme.EditLink => {

--- a/.web/package.json
+++ b/.web/package.json
@@ -5,8 +5,9 @@
   "author": "Minekube",
   "scripts": {
     "dev": "pnpm exec vitepress dev docs",
-    "build": "pnpm exec vitepress build docs",
-    "serve": "pnpm exec vitepress serve docs"
+    "build": "node scripts/build-with-community-stats.mjs",
+    "serve": "pnpm exec vitepress serve docs",
+    "test": "node --test scripts/*.test.mjs"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20251117.0",

--- a/.web/scripts/build-with-community-stats.mjs
+++ b/.web/scripts/build-with-community-stats.mjs
@@ -1,0 +1,27 @@
+import { spawn } from 'node:child_process';
+
+import { buildStatsEnv, fetchCommunityStats } from './community-stats.mjs';
+
+const stats = await fetchCommunityStats();
+const statsEnv = buildStatsEnv(stats);
+
+console.log(
+  `[community-stats] Discord members: ${statsEnv.GATE_DOCS_DISCORD_MEMBERS}; GitHub stars: ${statsEnv.GATE_DOCS_GITHUB_STARS}`
+);
+
+const command = process.platform === 'win32' ? 'pnpm.cmd' : 'pnpm';
+const child = spawn(command, ['exec', 'vitepress', 'build', 'docs'], {
+  env: {
+    ...process.env,
+    ...statsEnv,
+  },
+  stdio: 'inherit',
+});
+
+child.on('exit', (code, signal) => {
+  if (signal) {
+    process.kill(process.pid, signal);
+    return;
+  }
+  process.exit(code ?? 1);
+});

--- a/.web/scripts/community-stats.mjs
+++ b/.web/scripts/community-stats.mjs
@@ -1,0 +1,105 @@
+export const DEFAULT_COMMUNITY_STATS = {
+  discordMembers: 1650,
+  githubStars: 1050,
+};
+
+export const DEFAULT_DISCORD_INVITE_CODE = 'HvQugYx';
+export const DEFAULT_GITHUB_REPO = 'minekube/gate';
+
+const isValidCount = (value) => Number.isInteger(value) && value >= 0;
+
+export function parseGitHubRepoStats(payload) {
+  const count = payload?.stargazers_count;
+  if (!isValidCount(count)) {
+    throw new Error('GitHub API response did not include stargazers_count');
+  }
+  return count;
+}
+
+export function parseDiscordInviteStats(payload) {
+  const count = payload?.approximate_member_count;
+  if (!isValidCount(count)) {
+    throw new Error(
+      'Discord invite API response did not include approximate_member_count'
+    );
+  }
+  return count;
+}
+
+async function fetchJson(url, { fetchImpl = fetch, headers = {} } = {}) {
+  const response = await fetchImpl(url, {
+    headers: {
+      Accept: 'application/json',
+      ...headers,
+    },
+    signal: AbortSignal.timeout(10_000),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Request failed with ${response.status} for ${url}`);
+  }
+
+  return response.json();
+}
+
+export async function fetchGitHubStars({
+  fetchImpl,
+  repo = process.env.GATE_GITHUB_REPO || DEFAULT_GITHUB_REPO,
+} = {}) {
+  const payload = await fetchJson(`https://api.github.com/repos/${repo}`, {
+    fetchImpl,
+    headers: {
+      'X-GitHub-Api-Version': '2022-11-28',
+      'User-Agent': 'gate-docs-build',
+    },
+  });
+  return parseGitHubRepoStats(payload);
+}
+
+export async function fetchDiscordMembers({
+  fetchImpl,
+  inviteCode = process.env.GATE_DISCORD_INVITE_CODE ||
+    DEFAULT_DISCORD_INVITE_CODE,
+} = {}) {
+  const payload = await fetchJson(
+    `https://discord.com/api/v10/invites/${inviteCode}?with_counts=true`,
+    { fetchImpl }
+  );
+  return parseDiscordInviteStats(payload);
+}
+
+export async function fetchCommunityStats({ fetchImpl, logger = console } = {}) {
+  const stats = {};
+
+  try {
+    stats.discordMembers = await fetchDiscordMembers({ fetchImpl });
+  } catch (error) {
+    logger.warn(
+      `[community-stats] Discord member count unavailable, using fallback: ${error.message}`
+    );
+  }
+
+  try {
+    stats.githubStars = await fetchGitHubStars({ fetchImpl });
+  } catch (error) {
+    logger.warn(
+      `[community-stats] GitHub star count unavailable, using fallback: ${error.message}`
+    );
+  }
+
+  return stats;
+}
+
+export function buildStatsEnv(stats = {}) {
+  const discordMembers = isValidCount(stats.discordMembers)
+    ? stats.discordMembers
+    : DEFAULT_COMMUNITY_STATS.discordMembers;
+  const githubStars = isValidCount(stats.githubStars)
+    ? stats.githubStars
+    : DEFAULT_COMMUNITY_STATS.githubStars;
+
+  return {
+    GATE_DOCS_DISCORD_MEMBERS: String(discordMembers),
+    GATE_DOCS_GITHUB_STARS: String(githubStars),
+  };
+}

--- a/.web/scripts/community-stats.test.mjs
+++ b/.web/scripts/community-stats.test.mjs
@@ -1,0 +1,32 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  DEFAULT_COMMUNITY_STATS,
+  buildStatsEnv,
+  parseDiscordInviteStats,
+  parseGitHubRepoStats,
+} from './community-stats.mjs';
+
+test('parseGitHubRepoStats reads stargazers_count', () => {
+  assert.equal(parseGitHubRepoStats({ stargazers_count: 1050 }), 1050);
+});
+
+test('parseDiscordInviteStats reads approximate_member_count', () => {
+  assert.equal(parseDiscordInviteStats({ approximate_member_count: 1652 }), 1652);
+});
+
+test('stats parsers reject missing or invalid values', () => {
+  assert.throws(() => parseGitHubRepoStats({ stargazers_count: -1 }));
+  assert.throws(() => parseDiscordInviteStats({ approximate_member_count: '1652' }));
+});
+
+test('buildStatsEnv preserves fetched counts and falls back per field', () => {
+  assert.deepEqual(
+    buildStatsEnv({ discordMembers: 1652, githubStars: undefined }),
+    {
+      GATE_DOCS_DISCORD_MEMBERS: '1652',
+      GATE_DOCS_GITHUB_STARS: String(DEFAULT_COMMUNITY_STATS.githubStars),
+    }
+  );
+});


### PR DESCRIPTION
## Summary
- Fetch Discord member count and GitHub star count during the docs build.
- Inject the fetched values through Vite `define` as `__COMMUNITY_STATS__`, with checked-in fallbacks.
- Add focused Node tests for API response parsing and fallback behavior.

## Test Plan
- `pnpm test`
- `pnpm build`

## Notes
- Discord uses the public invite endpoint with `with_counts=true`.
- GitHub uses the repository `stargazers_count` field.