### PR TITLE
Sync Java protocol 26.2 updates

### DIFF
--- a/pkg/edition/java/proto/packet/brigadier/minecraft_26_2_test.go
+++ b/pkg/edition/java/proto/packet/brigadier/minecraft_26_2_test.go
@@ -1,0 +1,28 @@
+package brigadier
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.minekube.com/gate/pkg/edition/java/proto/util"
+	"go.minekube.com/gate/pkg/edition/java/proto/version"
+)
+
+func TestMinecraft262RenamesColorArgumentToTeamColor(t *testing.T) {
+	var buf bytes.Buffer
+	require.NoError(t, util.WriteVarInt(&buf, 16))
+
+	arg, err := Decode(&buf, version.Minecraft_26_2.Protocol)
+	require.NoError(t, err)
+	require.Equal(t, "minecraft:team_color", arg.String())
+}
+
+func TestColorArgumentStillDecodesBeforeMinecraft262(t *testing.T) {
+	var buf bytes.Buffer
+	require.NoError(t, util.WriteVarInt(&buf, 16))
+
+	arg, err := Decode(&buf, version.Minecraft_1_21_11.Protocol)
+	require.NoError(t, err)
+	require.Equal(t, "minecraft:color", arg.String())
+}

--- a/pkg/edition/java/proto/packet/brigadier/registry.go
+++ b/pkg/edition/java/proto/packet/brigadier/registry.go
@@ -191,8 +191,8 @@ func init() {
 	empty(id("minecraft:block_predicate", mapSet(Minecraft_1_19, 13)))
 	empty(id("minecraft:item_stack", mapSet(Minecraft_1_19, 14)))
 	empty(id("minecraft:item_predicate", mapSet(Minecraft_1_19, 15)))
-	empty(id("minecraft:color", mapSet(Minecraft_1_19, 16)))
-	empty(id("minecraft:hex_color", mapSet(Minecraft_1_21_6, 17))) // added in 1.21.6
+	empty(id("minecraft:color", mapSet(Minecraft_26_2, -1), mapSet(Minecraft_1_19, 16))) // renamed to team_color in 26.2
+	empty(id("minecraft:hex_color", mapSet(Minecraft_1_21_6, 17)))                       // added in 1.21.6
 	empty(id("minecraft:component", mapSet(Minecraft_1_21_6, 18), mapSet(Minecraft_1_19, 17)))
 	empty(id("minecraft:style", mapSet(Minecraft_1_21_6, 19), mapSet(Minecraft_1_20_3, 18)))
 	empty(id("minecraft:message", mapSet(Minecraft_1_21_6, 20), mapSet(Minecraft_1_20_3, 19), mapSet(Minecraft_1_19, 18)))
@@ -236,7 +236,8 @@ func init() {
 	empty(id("minecraft:loot_predicate", mapSet(Minecraft_1_21_6, 53), mapSet(Minecraft_1_21_5, 52), mapSet(Minecraft_1_20_5, 51)))
 	empty(id("minecraft:loot_modifier", mapSet(Minecraft_1_21_6, 54), mapSet(Minecraft_1_21_5, 53), mapSet(Minecraft_1_20_5, 52)))
 
-	empty(id("minecraft:dialog", mapSet(Minecraft_1_21_6, 55))) // added in 1.21.6
+	empty(id("minecraft:dialog", mapSet(Minecraft_1_21_6, 55)))   // added in 1.21.6
+	empty(id("minecraft:team_color", mapSet(Minecraft_26_2, 16))) // renamed from color in 26.2
 
 	// Crossstitch support
 	register(id("crossstitch:mod_argument", mapSet(Minecraft_1_19, -256)), &ModArgumentProperty{}, ModArgumentPropertyCodec)

--- a/pkg/edition/java/proto/packet/joingame.go
+++ b/pkg/edition/java/proto/packet/joingame.go
@@ -32,6 +32,7 @@ type JoinGame struct {
 	LastDeathPosition    *DeathPosition         // 1.19+
 	PortalCooldown       int                    // 1.20+
 	SeaLevel             int                    // 1.21.2+
+	OnlineMode           bool                   // 26.2+
 	EnforcesSecureChat   bool                   // 1.20.5+
 }
 
@@ -212,10 +213,13 @@ func (j *JoinGame) encode1202Up(c *proto.PacketContext, wr io.Writer) error {
 	} else {
 		w.Bool(false)
 	}
+	w.VarInt(j.PortalCooldown)
 	if c.Protocol.GreaterEqual(version.Minecraft_1_21_2) {
 		w.VarInt(j.SeaLevel)
 	}
-	w.VarInt(j.PortalCooldown)
+	if c.Protocol.GreaterEqual(version.Minecraft_26_2) {
+		w.Bool(j.OnlineMode)
+	}
 	if c.Protocol.GreaterEqual(version.Minecraft_1_20_5) {
 		w.Bool(j.EnforcesSecureChat)
 	}
@@ -396,11 +400,14 @@ func (j *JoinGame) decode1202Up(c *proto.PacketContext, rd io.Reader) error {
 		}
 	}
 
+	r.VarInt(&j.PortalCooldown)
 	if c.Protocol.GreaterEqual(version.Minecraft_1_21_2) {
 		r.VarInt(&j.SeaLevel)
 	}
 
-	r.VarInt(&j.PortalCooldown)
+	if c.Protocol.GreaterEqual(version.Minecraft_26_2) {
+		r.Bool(&j.OnlineMode)
+	}
 	if c.Protocol.GreaterEqual(version.Minecraft_1_20_5) {
 		r.Bool(&j.EnforcesSecureChat)
 	}

--- a/pkg/edition/java/proto/packet/login.go
+++ b/pkg/edition/java/proto/packet/login.go
@@ -308,6 +308,7 @@ type ServerLoginSuccess struct {
 	UUID       uuid.UUID
 	Username   string
 	Properties []profile.Property // 1.19+
+	SessionID  uuid.UUID          // 26.2+
 }
 
 const serverLoginSuccessStrictErrorHandling = true
@@ -340,6 +341,12 @@ func (s *ServerLoginSuccess) Encode(c *proto.PacketContext, wr io.Writer) (err e
 	}
 	if c.Protocol == version.Minecraft_1_20_5.Protocol || c.Protocol == version.Minecraft_1_21.Protocol {
 		err = util.WriteBool(wr, serverLoginSuccessStrictErrorHandling)
+		if err != nil {
+			return err
+		}
+	}
+	if c.Protocol.GreaterEqual(version.Minecraft_26_2) {
+		err = util.WriteUUID(wr, s.SessionID)
 		if err != nil {
 			return err
 		}
@@ -382,6 +389,12 @@ func (s *ServerLoginSuccess) Decode(c *proto.PacketContext, rd io.Reader) (err e
 	}
 	if c.Protocol == version.Minecraft_1_20_5.Protocol || c.Protocol == version.Minecraft_1_21.Protocol {
 		_, err = util.ReadBool(rd)
+		if err != nil {
+			return
+		}
+	}
+	if c.Protocol.GreaterEqual(version.Minecraft_26_2) {
+		s.SessionID, err = util.ReadUUID(rd)
 		if err != nil {
 			return
 		}

--- a/pkg/edition/java/proto/packet/minecraft_26_2_test.go
+++ b/pkg/edition/java/proto/packet/minecraft_26_2_test.go
@@ -1,0 +1,72 @@
+package packet
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.minekube.com/gate/pkg/edition/java/proto/version"
+	"go.minekube.com/gate/pkg/gate/proto"
+	"go.minekube.com/gate/pkg/util/uuid"
+)
+
+func TestJoinGameMinecraft262OnlineModeRoundTrip(t *testing.T) {
+	levelName := "minecraft:overworld"
+	original := &JoinGame{
+		EntityID:           1,
+		Hardcore:           true,
+		LevelNames:         []string{"minecraft:overworld"},
+		MaxPlayers:         100,
+		ViewDistance:       12,
+		SimulationDistance: 10,
+		ReducedDebugInfo:   true,
+		ShowRespawnScreen:  true,
+		DoLimitedCrafting:  true,
+		Dimension:          0,
+		DimensionInfo: &DimensionInfo{
+			LevelName: &levelName,
+		},
+		PartialHashedSeed:  1234,
+		Gamemode:           1,
+		PreviousGamemode:   -1,
+		LastDeathPosition:  &DeathPosition{Key: "minecraft:overworld", Value: 42},
+		SeaLevel:           63,
+		PortalCooldown:     5,
+		OnlineMode:         true,
+		EnforcesSecureChat: true,
+	}
+	ctx := &proto.PacketContext{Direction: proto.ClientBound, Protocol: version.Minecraft_26_2.Protocol}
+
+	var buf bytes.Buffer
+	require.NoError(t, original.Encode(ctx, &buf))
+	require.True(t, bytes.HasSuffix(buf.Bytes(), []byte{
+		0x05, // portal cooldown
+		0x3f, // sea level
+		0x01, // online mode
+		0x01, // enforces secure chat
+	}))
+
+	var decoded JoinGame
+	require.NoError(t, decoded.Decode(ctx, &buf))
+	require.True(t, decoded.OnlineMode)
+	require.True(t, decoded.EnforcesSecureChat)
+	require.Equal(t, 0, buf.Len())
+}
+
+func TestServerLoginSuccessMinecraft262SessionIDRoundTrip(t *testing.T) {
+	sessionID := uuid.New()
+	original := &ServerLoginSuccess{
+		UUID:      testUUID,
+		Username:  "Robin",
+		SessionID: sessionID,
+	}
+	ctx := &proto.PacketContext{Direction: proto.ClientBound, Protocol: version.Minecraft_26_2.Protocol}
+
+	var buf bytes.Buffer
+	require.NoError(t, original.Encode(ctx, &buf))
+
+	var decoded ServerLoginSuccess
+	require.NoError(t, decoded.Decode(ctx, &buf))
+	require.Equal(t, sessionID, decoded.SessionID)
+	require.Equal(t, 0, buf.Len())
+}

--- a/pkg/edition/java/proto/version/version.go
+++ b/pkg/edition/java/proto/version/version.go
@@ -53,6 +53,7 @@ var (
 	Minecraft_1_21_9  = v(773, "1.21.9", "1.21.10")
 	Minecraft_1_21_11 = v(774, "1.21.11")
 	Minecraft_26_1    = v(775, "26.1", "26.1.1", "26.1.2")
+	Minecraft_26_2    = v(776, "26.2")
 
 	// Versions ordered from lowest to highest
 	Versions = []*proto.Version{
@@ -72,7 +73,8 @@ var (
 		Minecraft_1_18, Minecraft_1_18_2,
 		Minecraft_1_19, Minecraft_1_19_1, Minecraft_1_19_3, Minecraft_1_19_4,
 		Minecraft_1_20, Minecraft_1_20_2, Minecraft_1_20_3, Minecraft_1_20_5,
-		Minecraft_1_21, Minecraft_1_21_2, Minecraft_1_21_4, Minecraft_1_21_5, Minecraft_1_21_6, Minecraft_1_21_7, Minecraft_1_21_9, Minecraft_1_21_11, Minecraft_26_1,
+		Minecraft_1_21, Minecraft_1_21_2, Minecraft_1_21_4, Minecraft_1_21_5, Minecraft_1_21_6, Minecraft_1_21_7, Minecraft_1_21_9, Minecraft_1_21_11,
+		Minecraft_26_1, Minecraft_26_2,
 	}
 )
 

--- a/pkg/edition/java/proxy/proxy.go
+++ b/pkg/edition/java/proxy/proxy.go
@@ -64,6 +64,9 @@ type Proxy struct {
 	playerNames map[string]*connectedPlayer    // lower case usernames map
 	playerIDs   map[uuid.UUID]*connectedPlayer // uuids map
 
+	sessionIDMu      sync.Mutex
+	currentSessionID uuid.UUID
+
 	connectionsQuota *addrquota.Quota
 	loginsQuota      *addrquota.Quota
 
@@ -752,11 +755,43 @@ retry:
 // unregisters a connected player
 func (p *Proxy) unregisterConnection(player *connectedPlayer) (found bool) {
 	p.muP.Lock()
-	defer p.muP.Unlock()
 	_, found = p.playerIDs[player.ID()]
 	delete(p.playerNames, strings.ToLower(player.Username()))
 	delete(p.playerIDs, player.ID())
+	empty := len(p.playerIDs) == 0
+	p.muP.Unlock()
+	if empty {
+		p.resetSessionIDIfEmpty()
+	}
 	return found
+}
+
+func (p *Proxy) sessionID() uuid.UUID {
+	p.sessionIDMu.Lock()
+	defer p.sessionIDMu.Unlock()
+	if p.currentSessionID == uuid.Nil {
+		p.currentSessionID = uuid.New()
+	}
+	return p.currentSessionID
+}
+
+func (p *Proxy) resetSessionIDIfEmpty() {
+	p.muP.RLock()
+	empty := len(p.playerIDs) == 0
+	p.muP.RUnlock()
+	if !empty {
+		return
+	}
+
+	p.sessionIDMu.Lock()
+	defer p.sessionIDMu.Unlock()
+
+	p.muP.RLock()
+	empty = len(p.playerIDs) == 0
+	p.muP.RUnlock()
+	if empty {
+		p.currentSessionID = uuid.Nil
+	}
 }
 
 //

--- a/pkg/edition/java/proxy/session_backend_transition.go
+++ b/pkg/edition/java/proxy/session_backend_transition.go
@@ -196,6 +196,8 @@ func (b *backendTransitionSessionHandler) handleJoinGame(pc *proto.PacketContext
 		b.serverConn.player.mu.Unlock()
 	}
 
+	p.OnlineMode = b.serverConn.player.OnlineMode()
+
 	// The goods are in hand! We got JoinGame.
 	// Let's transition completely to the new state.
 	smc.SetAutoReading(false)

--- a/pkg/edition/java/proxy/session_client_auth.go
+++ b/pkg/edition/java/proxy/session_client_auth.go
@@ -193,6 +193,9 @@ func (a *authSessionHandler) completeLoginProtocolPhaseAndInitialize(player *con
 		Username:   player.Username(),
 		Properties: player.GameProfile().Properties,
 	}
+	if a.inbound.Protocol().GreaterEqual(version.Minecraft_26_2) {
+		loginSuccess.SessionID = a.proxy.sessionID()
+	}
 
 	// For Modern Forge clients on pre-1.20.2, delay sending LoginSuccess so the
 	// client remains in the LOGIN state during the backend FML handshake relay.

--- a/pkg/edition/java/proxy/session_id_test.go
+++ b/pkg/edition/java/proxy/session_id_test.go
@@ -1,0 +1,26 @@
+package proxy
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.minekube.com/gate/pkg/util/uuid"
+)
+
+func TestProxySessionIDSharedUntilProxyEmpties(t *testing.T) {
+	p := &Proxy{
+		playerIDs: map[uuid.UUID]*connectedPlayer{},
+	}
+
+	first := p.sessionID()
+	require.Equal(t, first, p.sessionID())
+
+	playerID := uuid.New()
+	p.playerIDs[playerID] = nil
+	p.resetSessionIDIfEmpty()
+	require.Equal(t, first, p.sessionID())
+
+	delete(p.playerIDs, playerID)
+	p.resetSessionIDIfEmpty()
+	require.NotEqual(t, first, p.sessionID())
+}


### PR DESCRIPTION
## Summary
- Port Velocity PR #14 protocol updates for Minecraft 26.1/26.2 into Gate.
- Add 26.2 JoinGame online-mode and login-success session ID handling, including shared per-proxy session IDs.
- Update brigadier color/team_color mapping and add regression coverage for the new wire behavior.
- Fix a quota validation format string uncovered by full `go test ./...` vet checks.

## Test Plan
- `go test ./...`
