### PR TITLE
Fix Linux installer for musl systems

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -3,7 +3,8 @@ before:
   hooks:
     - go mod download
 builds:
-  - env: [ CGO_ENABLED=0 ]
+  - id: gate
+    env: [ CGO_ENABLED=0 ]
     ldflags:
       - "-s -w"
       - "-X 'go.minekube.com/gate/pkg/version.Version={{.Version}}'"
@@ -11,8 +12,31 @@ builds:
       - linux
       - windows
       - darwin
+  - id: gate-musl
+    env: [ CGO_ENABLED=0 ]
+    tags:
+      - musl
+    ldflags:
+      - "-s -w"
+      - "-X 'go.minekube.com/gate/pkg/version.Version={{.Version}}'"
+    goos:
+      - linux
+    goarch:
+      - amd64
+      - arm64
+      - '386'
 archives:
-  - format: binary
+  - id: gate
+    ids:
+      - gate
+    formats:
+      - binary
+  - id: gate-musl
+    ids:
+      - gate-musl
+    formats:
+      - binary
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ with .Arm }}v{{ . }}{{ end }}{{ with .Mips }}_{{ . }}{{ end }}{{ if not (eq .Amd64 \"v1\") }}{{ .Amd64 }}{{ end }}_musl"
 checksum:
   name_template: 'checksums.txt'
 changelog:

--- a/.web/docs/guide/install/binaries.md
+++ b/.web/docs/guide/install/binaries.md
@@ -94,7 +94,13 @@ If you encounter any issues:
    - Try running the installation again
    - If it persists, please report it on our GitHub issues
 
-3. **Permission Denied**:
+3. **Linux binary does not run**:
+
+   - The installer selects `gate_*_linux_*_musl` automatically on Alpine/musl systems
+   - The musl binary is statically linked, but excludes native GeyserLite managed mode and Honeycomb OpenTelemetry auto-configuration
+   - For managed Bedrock on musl, set `bedrock.managed.engine: java`; for native GeyserLite or full OTEL support, use a glibc-based distribution/image such as Debian, Ubuntu, or Fedora, or run the official Docker image
+
+4. **Permission Denied**:
    - Our scripts install to user space and shouldn't require elevated privileges
    - If you see permission errors, ensure you have write access to the installation directory
 

--- a/.web/docs/public/build_tags_test.sh
+++ b/.web/docs/public/build_tags_test.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+set -eu
+
+deps=$(go list -tags musl -deps ./cmd/gate)
+
+if printf '%s\n' "$deps" | grep -Eq '^(github.com/ebitengine/purego|go.minekube.com/geyserlite|github.com/honeycombio/otel-config-go/otelconfig)$'; then
+    echo "musl build still depends on geyserlite, purego, or Honeycomb OTEL auto-config" >&2
+    exit 1
+fi
+
+go test -tags musl ./cmd/gate ./pkg/internal/otelutil ./pkg/edition/bedrock/geyser

--- a/.web/docs/public/install
+++ b/.web/docs/public/install
@@ -1,18 +1,27 @@
-#!/bin/bash
-set -e
+#!/usr/bin/env bash
+set -euo pipefail
 
 # Colors for terminal output
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-NC='\033[0m' # No Color
+RED=''
+GREEN=''
+YELLOW=''
+NC=''
+
+if [ -t 1 ]; then
+    RED='\033[0;31m'
+    GREEN='\033[0;32m'
+    YELLOW='\033[1;33m'
+    NC='\033[0m'
+fi
 
 # Constants
 REPO_OWNER="minekube"
 REPO_NAME="gate"
 INSTALL_DIR="${GATE_INSTALL_DIR:-$HOME/.local/bin}"
-TEMP_DIR="/tmp/gate-installer"
+TEMP_DIR=""
+INSTALL_STAGING_PATH=""
 REQUIRED_SPACE_MB=50
+LINUX_LIBC=""
 
 # Functions
 
@@ -27,6 +36,20 @@ print_warning() {
 
 print_error() {
     echo -e "${RED}$1${NC}"
+}
+
+cleanup() {
+    if [ -n "${TEMP_DIR:-}" ] && [ -d "$TEMP_DIR" ]; then
+        rm -rf "$TEMP_DIR"
+    fi
+    if [ -n "${INSTALL_STAGING_PATH:-}" ] && [ -f "$INSTALL_STAGING_PATH" ]; then
+        rm -f "$INSTALL_STAGING_PATH"
+    fi
+}
+
+make_temp_dir() {
+    TEMP_DIR=$(mktemp -d "${TMPDIR:-/tmp}/gate-installer.XXXXXX")
+    trap cleanup EXIT
 }
 
 # Detect system architecture
@@ -58,6 +81,60 @@ detect_os() {
     esac
 }
 
+detect_linux_libc() {
+    [ "$OS" = "linux" ] || return 0
+
+    if [ "${GATE_INSTALLER_ASSUME_GLIBC:-}" = "1" ]; then
+        LINUX_LIBC="glibc"
+        return 0
+    fi
+
+    case "${GATE_INSTALLER_LINUX_LIBC:-}" in
+        glibc|musl)
+            LINUX_LIBC="$GATE_INSTALLER_LINUX_LIBC"
+            return 0
+            ;;
+        "")
+            ;;
+        *)
+            print_error "Unsupported GATE_INSTALLER_LINUX_LIBC=$GATE_INSTALLER_LINUX_LIBC (want glibc or musl)."
+            exit 1
+            ;;
+    esac
+
+    if [ -f /etc/alpine-release ]; then
+        LINUX_LIBC="musl"
+        return 0
+    fi
+
+    case "$ARCH" in
+        amd64)
+            if [ -e /lib64/ld-linux-x86-64.so.2 ] || [ -e /lib/x86_64-linux-gnu/ld-linux-x86-64.so.2 ]; then
+                LINUX_LIBC="glibc"
+                return 0
+            fi
+            ;;
+        arm64)
+            if [ -e /lib/ld-linux-aarch64.so.1 ] || [ -e /lib/aarch64-linux-gnu/ld-linux-aarch64.so.1 ]; then
+                LINUX_LIBC="glibc"
+                return 0
+            fi
+            ;;
+        386)
+            if [ -e /lib/ld-linux.so.2 ] || [ -e /lib/i386-linux-gnu/ld-linux.so.2 ]; then
+                LINUX_LIBC="glibc"
+                return 0
+            fi
+            ;;
+    esac
+
+    if command -v ldd >/dev/null && ldd --version 2>&1 | grep -qi 'glibc\|gnu libc'; then
+        LINUX_LIBC="glibc"
+    else
+        LINUX_LIBC="musl"
+    fi
+}
+
 # Check available disk space
 check_disk_space() {
     local install_dir="$1"
@@ -79,14 +156,101 @@ download() {
     mkdir -p "$TEMP_DIR"
 
     if command -v curl >/dev/null; then
-        curl -L "$url" --output "$output" && return 0
+        curl --fail --location --progress-bar --output "$output" "$url" && return 0
     elif command -v wget >/dev/null; then
         wget -q "$url" -O "$output" && return 0
     fi
 
     print_error "Failed to download from $url using curl or wget."
-    rm -rf "$TEMP_DIR"
     return 1
+}
+
+fetch_url() {
+    local url="$1"
+
+    if command -v curl >/dev/null; then
+        curl -fsSL "$url" && return 0
+    elif command -v wget >/dev/null; then
+        wget -qO- "$url" && return 0
+    fi
+
+    return 1
+}
+
+# Check whether a release asset exists before selecting it. GitHub releases can
+# briefly be published before GoReleaser has uploaded the binaries.
+url_exists() {
+    local url="$1"
+
+    if command -v curl >/dev/null; then
+        curl -fsSIL "$url" >/dev/null 2>&1
+        return $?
+    elif command -v wget >/dev/null; then
+        wget -q --spider "$url" >/dev/null 2>&1
+        return $?
+    fi
+
+    return 1
+}
+
+binary_name() {
+    local version="$1"
+    local os="$2"
+    local arch="$3"
+    local name
+
+    name="gate_${version}_${os}_${arch}"
+    if [ "$os" = "windows" ]; then
+        name="${name}.exe"
+    elif [ "$os" = "linux" ] && [ "$LINUX_LIBC" = "musl" ]; then
+        name="${name}_musl"
+    fi
+
+    echo "$name"
+}
+
+resolve_release_artifacts() {
+    local releases_json
+    local candidate_version
+    local candidate_binary
+    local candidate_download_url
+    local candidate_checksums_url
+
+    if ! releases_json=$(fetch_url "https://api.github.com/repos/$REPO_OWNER/$REPO_NAME/releases?per_page=10"); then
+        print_error "Failed to fetch Gate release information from GitHub."
+        exit 1
+    fi
+
+    for candidate_version in $(printf '%s\n' "$releases_json" | awk '
+        /"tag_name":/ {
+            tag = $0
+            sub(/.*"tag_name":[[:space:]]*"/, "", tag)
+            sub(/".*/, "", tag)
+        }
+        /"prerelease":/ {
+            if (tag != "" && $0 ~ /false/) {
+                sub(/^v/, "", tag)
+                print tag
+            }
+            tag = ""
+        }
+    '); do
+        candidate_binary=$(binary_name "$candidate_version" "$OS" "$ARCH")
+        candidate_download_url="https://github.com/$REPO_OWNER/$REPO_NAME/releases/download/v${candidate_version}/${candidate_binary}"
+        candidate_checksums_url="https://github.com/$REPO_OWNER/$REPO_NAME/releases/download/v${candidate_version}/checksums.txt"
+
+        if url_exists "$candidate_download_url" && url_exists "$candidate_checksums_url"; then
+            VERSION="$candidate_version"
+            BINARY_NAME="$candidate_binary"
+            DOWNLOAD_URL="$candidate_download_url"
+            CHECKSUMS_URL="$candidate_checksums_url"
+            return 0
+        fi
+    done
+
+    print_error "Failed to find a Gate release with binaries for ${OS}-${ARCH}."
+    print_error "If a release was just published, wait a minute for release assets to finish uploading and retry."
+    exit 1
 }
 
 # Verify the checksum of the downloaded file
@@ -98,15 +262,22 @@ verify_checksum() {
     local actual_checksum
 
     filename=$(basename "$file")
-    expected_checksum=$(grep "$filename" "$checksum_file" | awk '{print $1}')
+    if ! expected_checksum=$(awk -v filename="$filename" '$2 == filename { print $1; found = 1; exit } END { if (!found) exit 1 }' "$checksum_file"); then
+        print_error "Checksum for $filename was not found in checksums.txt."
+        rm -f "$file" "$checksum_file"
+        exit 1
+    fi
 
     if command -v sha256sum >/dev/null; then
         actual_checksum=$(sha256sum "$file" | awk '{print $1}')
     elif command -v shasum >/dev/null; then
         actual_checksum=$(shasum -a 256 "$file" | awk '{print $1}')
+    elif command -v openssl >/dev/null; then
+        actual_checksum=$(openssl dgst -sha256 "$file" | awk '{print $NF}')
     else
-        print_warning "No SHA256 checksum tool found. Skipping verification."
-        return 0
+        print_error "No SHA256 checksum tool found. Install sha256sum, shasum, or openssl and retry."
+        rm -f "$file" "$checksum_file"
+        exit 1
     fi
 
     if [ "$expected_checksum" != "$actual_checksum" ]; then
@@ -119,6 +290,37 @@ verify_checksum() {
 
     print_info "✅ Checksum verified for $filename"
     rm -f "$checksum_file"
+}
+
+verify_executable() {
+    local file="$1"
+    local verify_output
+
+    verify_output="$TEMP_DIR/gate-version.out"
+    if "$file" --version >"$verify_output" 2>&1; then
+        return 0
+    fi
+
+    print_error "Installed Gate binary failed to run."
+    if [ -s "$verify_output" ]; then
+        cat "$verify_output" >&2
+    fi
+    if [ "$OS" = "linux" ]; then
+        print_error "The selected Linux binary did not run on this system. If libc detection was wrong, set GATE_INSTALLER_LINUX_LIBC=glibc or GATE_INSTALLER_LINUX_LIBC=musl and retry."
+    fi
+    exit 1
+}
+
+install_verified_binary() {
+    local source="$1"
+    local install_path="$2"
+
+    INSTALL_STAGING_PATH=$(mktemp "${install_path}.tmp.XXXXXX")
+    cp "$source" "$INSTALL_STAGING_PATH"
+    chmod 755 "$INSTALL_STAGING_PATH"
+    verify_executable "$INSTALL_STAGING_PATH"
+    mv -f "$INSTALL_STAGING_PATH" "$install_path"
+    INSTALL_STAGING_PATH=""
 }
 
 # Get installation path
@@ -145,19 +347,14 @@ install_gate() {
     print_info "✨ Installing Gate..."
 
     mkdir -p "$INSTALL_DIR"
-    mkdir -p "$TEMP_DIR"
+    make_temp_dir
 
     check_disk_space "$INSTALL_DIR"
 
     OS=$(detect_os)
     ARCH=$(detect_arch)
-
-    # Fetch the latest version from GitHub API
-    VERSION=$(curl -fsSL "https://api.github.com/repos/$REPO_OWNER/$REPO_NAME/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/' | sed 's/^v//')
-    if [ -z "$VERSION" ]; then
-        print_error "Failed to detect the latest version."
-        exit 1
-    fi
+    detect_linux_libc
+    resolve_release_artifacts
 
     INSTALL_PATH=$(get_install_path)
 
@@ -171,30 +368,14 @@ install_gate() {
         fi
     fi
 
-    # Set download URLs
-    BINARY_NAME="gate_${VERSION}_${OS}_${ARCH}"
-    if [ "$OS" = "windows" ]; then
-        BINARY_NAME="${BINARY_NAME}.exe"
-    fi
-
-    DOWNLOAD_URL="https://github.com/$REPO_OWNER/$REPO_NAME/releases/download/v${VERSION}/${BINARY_NAME}"
-    CHECKSUMS_URL="https://github.com/$REPO_OWNER/$REPO_NAME/releases/download/v${VERSION}/checksums.txt"
-
     print_info "⚡ Downloading Gate ${VERSION} for ${OS}-${ARCH}..."
     echo "📥 From: $DOWNLOAD_URL"
     
-    # ✨ Change: Download binary with original name to TEMP_DIR
     download "$DOWNLOAD_URL" "$TEMP_DIR/$BINARY_NAME"
-    
-    # ✨ Change: Download checksums file
     download "$CHECKSUMS_URL" "$TEMP_DIR/checksums.txt"
-    
-    # ✨ Change: Verify checksum using the correctly named binary
     verify_checksum "$TEMP_DIR/$BINARY_NAME" "$TEMP_DIR/checksums.txt"
-    
-    # ✨ Change: Move the verified binary to the installation path as 'gate'
-    mv "$TEMP_DIR/$BINARY_NAME" "$INSTALL_PATH"
-    chmod +x "$INSTALL_PATH"
+
+    install_verified_binary "$TEMP_DIR/$BINARY_NAME" "$INSTALL_PATH"
 
     # Update PATH for the current session
     update_path_session
@@ -209,7 +390,7 @@ install_gate() {
     echo "  export PATH=\"$INSTALL_DIR:\$PATH\""
     echo
     print_warning "Or add it permanently by running:"
-    echo "  echo 'export PATH=\"$INSTALL_DIR:\$PATH\"' >> \"\$HOME/.$(basename $SHELL)rc\" && source \"\$HOME/.$(basename $SHELL)rc\""
+    echo "  echo 'export PATH=\"$INSTALL_DIR:\$PATH\"' >> \"\$HOME/.$(basename "${SHELL:-sh}")rc\" && source \"\$HOME/.$(basename "${SHELL:-sh}")rc\""
     echo
     print_info "🚀 Run gate to start the proxy"
 }

--- a/.web/docs/public/install_test.sh
+++ b/.web/docs/public/install_test.sh
@@ -1,0 +1,673 @@
+#!/bin/sh
+set -eu
+
+ROOT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")/../../.." && pwd)
+
+fail() {
+    echo "FAIL: $1" >&2
+    exit 1
+}
+
+run_test() {
+    (
+        "$@"
+    )
+}
+
+write_fake_uname() {
+    dir="$1"
+    cat >"$dir/uname" <<'EOF'
+#!/bin/sh
+case "$1" in
+    -s) echo Linux ;;
+    -m) echo x86_64 ;;
+    *) exit 1 ;;
+esac
+EOF
+    chmod +x "$dir/uname"
+}
+
+write_fake_sha256sum() {
+    dir="$1"
+    cat >"$dir/sha256sum" <<'EOF'
+#!/bin/sh
+printf 'test-sha  %s\n' "$1"
+EOF
+    chmod +x "$dir/sha256sum"
+}
+
+link_required_tools_without_curl() {
+    dir="$1"
+    for cmd in awk basename cat chmod cp df dirname grep mkdir mktemp mv rm sed; do
+        tool_path=$(command -v "$cmd") || fail "missing required test tool: $cmd"
+        ln -s "$tool_path" "$dir/$cmd"
+    done
+}
+
+test_skips_release_without_assets() {
+    tmp=$(mktemp -d)
+    trap 'rm -rf "$tmp"' EXIT
+
+    mkdir -p "$tmp/bin" "$tmp/install"
+    write_fake_uname "$tmp/bin"
+    write_fake_sha256sum "$tmp/bin"
+
+    cat >"$tmp/bin/curl" <<'EOF'
+#!/bin/sh
+log="${CURL_LOG:?}"
+echo "$*" >> "$log"
+
+output_arg() {
+    previous=
+    for arg in "$@"; do
+        if [ "$previous" = "--output" ] || [ "$previous" = "-o" ]; then
+            echo "$arg"
+            return 0
+        fi
+        previous="$arg"
+    done
+    return 1
+}
+
+case "$*" in
+    *"https://api.github.com/repos/minekube/gate/releases?per_page=10"*)
+        cat <<'JSON'
+[
+  {"tag_name": "v2.0.0", "prerelease": false},
+  {"tag_name": "v1.0.0", "prerelease": false}
+]
+JSON
+        exit 0
+        ;;
+    *"v2.0.0/gate_2.0.0_linux_amd64"*)
+        exit 22
+        ;;
+    *"v2.0.0/checksums.txt"*)
+        exit 22
+        ;;
+    *"v1.0.0/gate_1.0.0_linux_amd64"*)
+        if [ "$#" -gt 0 ] && [ "$1" = "-fsSIL" ]; then
+            exit 0
+        fi
+        out=$(output_arg "$@")
+        cat >"$out" <<'GATE'
+#!/bin/sh
+echo "gate version test"
+GATE
+        exit 0
+        ;;
+    *"v1.0.0/checksums.txt"*)
+        if [ "$#" -gt 0 ] && [ "$1" = "-fsSIL" ]; then
+            exit 0
+        fi
+        out=$(output_arg "$@")
+        printf 'test-sha  gate_1.0.0_linux_amd64\n' > "$out"
+        exit 0
+        ;;
+esac
+
+echo "unexpected curl: $*" >&2
+exit 2
+EOF
+    chmod +x "$tmp/bin/curl"
+
+    CURL_LOG="$tmp/curl.log" \
+    GATE_INSTALL_DIR="$tmp/install" \
+    GATE_INSTALLER_ASSUME_GLIBC=1 \
+    PATH="$tmp/bin:$PATH" \
+        bash "$ROOT_DIR/.web/docs/public/install" >"$tmp/install.out"
+
+    "$tmp/install/gate" --version | grep -q "gate version test" || fail "installed binary came from the wrong release"
+    grep -q "v2.0.0/gate_2.0.0_linux_amd64" "$tmp/curl.log" || fail "newest asset was not probed"
+    grep -q "v1.0.0/gate_1.0.0_linux_amd64" "$tmp/curl.log" || fail "fallback asset was not downloaded"
+}
+
+test_download_uses_fail_flag() {
+    tmp=$(mktemp -d)
+    trap 'rm -rf "$tmp"' EXIT
+
+    mkdir -p "$tmp/bin" "$tmp/install"
+    write_fake_uname "$tmp/bin"
+    write_fake_sha256sum "$tmp/bin"
+
+    cat >"$tmp/bin/curl" <<'EOF'
+#!/bin/sh
+case "$*" in
+    *"https://api.github.com/repos/minekube/gate/releases?per_page=10"*)
+        printf '[{"tag_name":"v1.0.0","prerelease":false}]\n'
+        exit 0
+        ;;
+    *"v1.0.0/gate_1.0.0_linux_amd64"*)
+        case "$*" in
+            *"-f"*|*"--fail"*) ;;
+            *) exit 22 ;;
+        esac
+        if [ "$#" -gt 0 ] && [ "$1" = "-fsSIL" ]; then
+            exit 0
+        fi
+        previous=
+        for arg in "$@"; do
+            if [ "$previous" = "--output" ] || [ "$previous" = "-o" ]; then
+                cat >"$arg" <<'GATE'
+#!/bin/sh
+echo "gate version test"
+GATE
+                exit 0
+            fi
+            previous="$arg"
+        done
+        exit 2
+        ;;
+    *"v1.0.0/checksums.txt"*)
+        if [ "$#" -gt 0 ] && [ "$1" = "-fsSIL" ]; then
+            exit 0
+        fi
+        previous=
+        for arg in "$@"; do
+            if [ "$previous" = "--output" ] || [ "$previous" = "-o" ]; then
+                printf 'test-sha  gate_1.0.0_linux_amd64\n' > "$arg"
+                exit 0
+            fi
+            previous="$arg"
+        done
+        exit 2
+        ;;
+esac
+exit 2
+EOF
+    chmod +x "$tmp/bin/curl"
+
+    GATE_INSTALL_DIR="$tmp/install" \
+    GATE_INSTALLER_ASSUME_GLIBC=1 \
+    PATH="$tmp/bin:$PATH" \
+        bash "$ROOT_DIR/.web/docs/public/install" >"$tmp/install.out"
+}
+
+test_verifies_installed_binary() {
+    tmp=$(mktemp -d)
+    trap 'rm -rf "$tmp"' EXIT
+
+    mkdir -p "$tmp/bin" "$tmp/install"
+    write_fake_uname "$tmp/bin"
+    write_fake_sha256sum "$tmp/bin"
+    cat >"$tmp/install/gate" <<'GATE'
+#!/bin/sh
+echo "old gate"
+GATE
+    chmod +x "$tmp/install/gate"
+
+    cat >"$tmp/bin/curl" <<'EOF'
+#!/bin/sh
+case "$*" in
+    *"https://api.github.com/repos/minekube/gate/releases?per_page=10"*)
+        printf '[{"tag_name":"v1.0.0","prerelease":false}]\n'
+        exit 0
+        ;;
+    *"v1.0.0/gate_1.0.0_linux_amd64"*)
+        if [ "$#" -gt 0 ] && [ "$1" = "-fsSIL" ]; then
+            exit 0
+        fi
+        previous=
+        for arg in "$@"; do
+            if [ "$previous" = "--output" ] || [ "$previous" = "-o" ]; then
+                cat >"$arg" <<'GATE'
+#!/bin/sh
+exit 42
+GATE
+                exit 0
+            fi
+            previous="$arg"
+        done
+        exit 2
+        ;;
+    *"v1.0.0/checksums.txt"*)
+        if [ "$#" -gt 0 ] && [ "$1" = "-fsSIL" ]; then
+            exit 0
+        fi
+        previous=
+        for arg in "$@"; do
+            if [ "$previous" = "--output" ] || [ "$previous" = "-o" ]; then
+                printf 'test-sha  gate_1.0.0_linux_amd64\n' > "$arg"
+                exit 0
+            fi
+            previous="$arg"
+        done
+        exit 2
+        ;;
+esac
+exit 2
+EOF
+    chmod +x "$tmp/bin/curl"
+
+    if GATE_INSTALL_DIR="$tmp/install" \
+        GATE_INSTALLER_ASSUME_GLIBC=1 \
+        PATH="$tmp/bin:$PATH" \
+        bash "$ROOT_DIR/.web/docs/public/install" >"$tmp/install.out" 2>&1; then
+        fail "installer succeeded even though the installed binary does not run"
+    fi
+
+    grep -q "Installed Gate binary failed to run" "$tmp/install.out" || fail "missing executable verification error"
+    "$tmp/install/gate" --version | grep -q "old gate" || fail "failed staged binary replaced existing install"
+}
+
+test_linux_musl_selects_musl_asset() {
+    tmp=$(mktemp -d)
+    trap 'rm -rf "$tmp"' EXIT
+
+    mkdir -p "$tmp/bin" "$tmp/install"
+    write_fake_uname "$tmp/bin"
+    write_fake_sha256sum "$tmp/bin"
+
+    cat >"$tmp/bin/curl" <<'EOF'
+#!/bin/sh
+log="${CURL_LOG:?}"
+echo "$*" >> "$log"
+
+case "$*" in
+    *"https://api.github.com/repos/minekube/gate/releases?per_page=10"*)
+        printf '[{"tag_name":"v1.0.0","prerelease":false}]\n'
+        exit 0
+        ;;
+    *"v1.0.0/gate_1.0.0_linux_amd64_musl"*)
+        if [ "$#" -gt 0 ] && [ "$1" = "-fsSIL" ]; then
+            exit 0
+        fi
+        previous=
+        for arg in "$@"; do
+            if [ "$previous" = "--output" ] || [ "$previous" = "-o" ]; then
+                cat >"$arg" <<'GATE'
+#!/bin/sh
+echo "gate version test"
+GATE
+                exit 0
+            fi
+            previous="$arg"
+        done
+        exit 2
+        ;;
+    *"v1.0.0/checksums.txt"*)
+        if [ "$#" -gt 0 ] && [ "$1" = "-fsSIL" ]; then
+            exit 0
+        fi
+        previous=
+        for arg in "$@"; do
+            if [ "$previous" = "--output" ] || [ "$previous" = "-o" ]; then
+                printf 'test-sha  gate_1.0.0_linux_amd64_musl\n' > "$arg"
+                exit 0
+            fi
+            previous="$arg"
+        done
+        exit 2
+        ;;
+esac
+exit 22
+EOF
+    chmod +x "$tmp/bin/curl"
+
+    CURL_LOG="$tmp/curl.log" \
+    GATE_INSTALL_DIR="$tmp/install" \
+    GATE_INSTALLER_LINUX_LIBC=musl \
+    PATH="$tmp/bin:$PATH" \
+        bash "$ROOT_DIR/.web/docs/public/install" >"$tmp/install.out"
+
+    grep -q "gate_1.0.0_linux_amd64_musl" "$tmp/curl.log" || fail "musl asset was not selected"
+    if grep -q "gate_1.0.0_linux_amd64 " "$tmp/curl.log"; then
+        fail "glibc asset was selected for musl Linux"
+    fi
+}
+
+test_checksum_matches_exact_filename() {
+    tmp=$(mktemp -d)
+    trap 'rm -rf "$tmp"' EXIT
+
+    mkdir -p "$tmp/bin" "$tmp/install"
+    write_fake_uname "$tmp/bin"
+    write_fake_sha256sum "$tmp/bin"
+
+    cat >"$tmp/bin/curl" <<'EOF'
+#!/bin/sh
+case "$*" in
+    *"https://api.github.com/repos/minekube/gate/releases?per_page=10"*)
+        printf '[{"tag_name":"v1.0.0","prerelease":false}]\n'
+        exit 0
+        ;;
+    *"v1.0.0/gate_1.0.0_linux_amd64"*)
+        if [ "$#" -gt 0 ] && [ "$1" = "-fsSIL" ]; then
+            exit 0
+        fi
+        previous=
+        for arg in "$@"; do
+            if [ "$previous" = "--output" ] || [ "$previous" = "-o" ]; then
+                cat >"$arg" <<'GATE'
+#!/bin/sh
+echo "gate version test"
+GATE
+                exit 0
+            fi
+            previous="$arg"
+        done
+        exit 2
+        ;;
+    *"v1.0.0/checksums.txt"*)
+        if [ "$#" -gt 0 ] && [ "$1" = "-fsSIL" ]; then
+            exit 0
+        fi
+        previous=
+        for arg in "$@"; do
+            if [ "$previous" = "--output" ] || [ "$previous" = "-o" ]; then
+                {
+                    printf 'wrong-sha  gate_1.0.0_linux_amd64_musl\n'
+                    printf 'test-sha  gate_1.0.0_linux_amd64\n'
+                } > "$arg"
+                exit 0
+            fi
+            previous="$arg"
+        done
+        exit 2
+        ;;
+esac
+exit 2
+EOF
+    chmod +x "$tmp/bin/curl"
+
+    GATE_INSTALL_DIR="$tmp/install" \
+    GATE_INSTALLER_ASSUME_GLIBC=1 \
+    PATH="$tmp/bin:$PATH" \
+        bash "$ROOT_DIR/.web/docs/public/install" >"$tmp/install.out"
+}
+
+test_wget_only_fetches_release_metadata() {
+    tmp=$(mktemp -d)
+    trap 'rm -rf "$tmp"' EXIT
+
+    mkdir -p "$tmp/bin" "$tmp/install"
+    link_required_tools_without_curl "$tmp/bin"
+    write_fake_uname "$tmp/bin"
+    write_fake_sha256sum "$tmp/bin"
+    bash_path=$(command -v bash) || fail "missing bash"
+
+    cat >"$tmp/bin/wget" <<'EOF'
+#!/bin/sh
+log="${WGET_LOG:?}"
+echo "$*" >> "$log"
+
+case "$*" in
+    *"https://api.github.com/repos/minekube/gate/releases?per_page=10"*)
+        printf '[{"tag_name":"v1.0.0","prerelease":false}]\n'
+        exit 0
+        ;;
+    *"--spider"*"v1.0.0/gate_1.0.0_linux_amd64"*)
+        exit 0
+        ;;
+    *"--spider"*"v1.0.0/checksums.txt"*)
+        exit 0
+        ;;
+    *"v1.0.0/gate_1.0.0_linux_amd64"*)
+        out=
+        previous=
+        for arg in "$@"; do
+            if [ "$previous" = "-O" ]; then
+                out="$arg"
+                break
+            fi
+            previous="$arg"
+        done
+        [ -n "$out" ] || exit 2
+        cat >"$out" <<'GATE'
+#!/bin/sh
+echo "gate version test"
+GATE
+        exit 0
+        ;;
+    *"v1.0.0/checksums.txt"*)
+        out=
+        previous=
+        for arg in "$@"; do
+            if [ "$previous" = "-O" ]; then
+                out="$arg"
+                break
+            fi
+            previous="$arg"
+        done
+        [ -n "$out" ] || exit 2
+        printf 'test-sha  gate_1.0.0_linux_amd64\n' > "$out"
+        exit 0
+        ;;
+esac
+exit 2
+EOF
+    chmod +x "$tmp/bin/wget"
+
+    WGET_LOG="$tmp/wget.log" \
+    GATE_INSTALL_DIR="$tmp/install" \
+    GATE_INSTALLER_ASSUME_GLIBC=1 \
+    PATH="$tmp/bin" \
+        "$bash_path" "$ROOT_DIR/.web/docs/public/install" >"$tmp/install.out"
+
+    grep -q "api.github.com/repos/minekube/gate/releases" "$tmp/wget.log" || fail "release metadata was not fetched with wget"
+    "$tmp/install/gate" --version | grep -q "gate version test" || fail "wget-only install did not produce a runnable binary"
+}
+
+test_prereleases_are_skipped() {
+    tmp=$(mktemp -d)
+    trap 'rm -rf "$tmp"' EXIT
+
+    mkdir -p "$tmp/bin" "$tmp/install"
+    write_fake_uname "$tmp/bin"
+    write_fake_sha256sum "$tmp/bin"
+
+    cat >"$tmp/bin/curl" <<'EOF'
+#!/bin/sh
+log="${CURL_LOG:?}"
+echo "$*" >> "$log"
+
+case "$*" in
+    *"https://api.github.com/repos/minekube/gate/releases?per_page=10"*)
+        cat <<'JSON'
+[
+  {"tag_name": "v2.0.0-rc.1", "prerelease": true},
+  {"tag_name": "v1.0.0", "prerelease": false}
+]
+JSON
+        exit 0
+        ;;
+    *"v2.0.0-rc.1"*)
+        exit 2
+        ;;
+    *"v1.0.0/gate_1.0.0_linux_amd64"*)
+        if [ "$#" -gt 0 ] && [ "$1" = "-fsSIL" ]; then
+            exit 0
+        fi
+        previous=
+        for arg in "$@"; do
+            if [ "$previous" = "--output" ] || [ "$previous" = "-o" ]; then
+                cat >"$arg" <<'GATE'
+#!/bin/sh
+echo "gate version test"
+GATE
+                exit 0
+            fi
+            previous="$arg"
+        done
+        exit 2
+        ;;
+    *"v1.0.0/checksums.txt"*)
+        if [ "$#" -gt 0 ] && [ "$1" = "-fsSIL" ]; then
+            exit 0
+        fi
+        previous=
+        for arg in "$@"; do
+            if [ "$previous" = "--output" ] || [ "$previous" = "-o" ]; then
+                printf 'test-sha  gate_1.0.0_linux_amd64\n' > "$arg"
+                exit 0
+            fi
+            previous="$arg"
+        done
+        exit 2
+        ;;
+esac
+exit 2
+EOF
+    chmod +x "$tmp/bin/curl"
+
+    CURL_LOG="$tmp/curl.log" \
+    GATE_INSTALL_DIR="$tmp/install" \
+    GATE_INSTALLER_ASSUME_GLIBC=1 \
+    PATH="$tmp/bin:$PATH" \
+        bash "$ROOT_DIR/.web/docs/public/install" >"$tmp/install.out"
+
+    if grep -q "v2.0.0-rc.1" "$tmp/curl.log"; then
+        fail "prerelease asset was probed"
+    fi
+    grep -q "v1.0.0/gate_1.0.0_linux_amd64" "$tmp/curl.log" || fail "stable release was not selected"
+}
+
+test_missing_checksum_tool_fails_closed() {
+    tmp=$(mktemp -d)
+    trap 'rm -rf "$tmp"' EXIT
+
+    mkdir -p "$tmp/bin" "$tmp/install"
+    link_required_tools_without_curl "$tmp/bin"
+    write_fake_uname "$tmp/bin"
+    bash_path=$(command -v bash) || fail "missing bash"
+
+    cat >"$tmp/bin/curl" <<'EOF'
+#!/bin/sh
+case "$*" in
+    *"https://api.github.com/repos/minekube/gate/releases?per_page=10"*)
+        printf '[{"tag_name":"v1.0.0","prerelease":false}]\n'
+        exit 0
+        ;;
+    *"v1.0.0/gate_1.0.0_linux_amd64"*)
+        if [ "$#" -gt 0 ] && [ "$1" = "-fsSIL" ]; then
+            exit 0
+        fi
+        previous=
+        for arg in "$@"; do
+            if [ "$previous" = "--output" ] || [ "$previous" = "-o" ]; then
+                cat >"$arg" <<'GATE'
+#!/bin/sh
+echo "gate version test"
+GATE
+                exit 0
+            fi
+            previous="$arg"
+        done
+        exit 2
+        ;;
+    *"v1.0.0/checksums.txt"*)
+        if [ "$#" -gt 0 ] && [ "$1" = "-fsSIL" ]; then
+            exit 0
+        fi
+        previous=
+        for arg in "$@"; do
+            if [ "$previous" = "--output" ] || [ "$previous" = "-o" ]; then
+                printf 'test-sha  gate_1.0.0_linux_amd64\n' > "$arg"
+                exit 0
+            fi
+            previous="$arg"
+        done
+        exit 2
+        ;;
+esac
+exit 2
+EOF
+    chmod +x "$tmp/bin/curl"
+
+    if GATE_INSTALL_DIR="$tmp/install" \
+        GATE_INSTALLER_ASSUME_GLIBC=1 \
+        PATH="$tmp/bin" \
+        "$bash_path" "$ROOT_DIR/.web/docs/public/install" >"$tmp/install.out" 2>&1; then
+        fail "installer succeeded without a checksum tool"
+    fi
+
+    grep -q "No SHA256 checksum tool found" "$tmp/install.out" || fail "missing checksum tool error"
+    [ ! -e "$tmp/install/gate" ] || fail "unverified binary was installed"
+}
+
+test_replacement_is_staged_in_install_dir() {
+    tmp=$(mktemp -d)
+    trap 'rm -rf "$tmp"' EXIT
+
+    mkdir -p "$tmp/bin" "$tmp/install"
+    write_fake_uname "$tmp/bin"
+    write_fake_sha256sum "$tmp/bin"
+    real_cp=$(command -v cp) || fail "missing cp"
+
+    cat >"$tmp/bin/cp" <<EOF
+#!/bin/sh
+echo "\$2" >> "\${CP_LOG:?}"
+exec "$real_cp" "\$@"
+EOF
+    chmod +x "$tmp/bin/cp"
+
+    cat >"$tmp/bin/curl" <<'EOF'
+#!/bin/sh
+case "$*" in
+    *"https://api.github.com/repos/minekube/gate/releases?per_page=10"*)
+        printf '[{"tag_name":"v1.0.0","prerelease":false}]\n'
+        exit 0
+        ;;
+    *"v1.0.0/gate_1.0.0_linux_amd64"*)
+        if [ "$#" -gt 0 ] && [ "$1" = "-fsSIL" ]; then
+            exit 0
+        fi
+        previous=
+        for arg in "$@"; do
+            if [ "$previous" = "--output" ] || [ "$previous" = "-o" ]; then
+                cat >"$arg" <<'GATE'
+#!/bin/sh
+echo "gate version test"
+GATE
+                exit 0
+            fi
+            previous="$arg"
+        done
+        exit 2
+        ;;
+    *"v1.0.0/checksums.txt"*)
+        if [ "$#" -gt 0 ] && [ "$1" = "-fsSIL" ]; then
+            exit 0
+        fi
+        previous=
+        for arg in "$@"; do
+            if [ "$previous" = "--output" ] || [ "$previous" = "-o" ]; then
+                printf 'test-sha  gate_1.0.0_linux_amd64\n' > "$arg"
+                exit 0
+            fi
+            previous="$arg"
+        done
+        exit 2
+        ;;
+esac
+exit 2
+EOF
+    chmod +x "$tmp/bin/curl"
+
+    (
+        umask 077
+        CP_LOG="$tmp/cp.log" \
+        GATE_INSTALL_DIR="$tmp/install" \
+        GATE_INSTALLER_ASSUME_GLIBC=1 \
+        PATH="$tmp/bin:$PATH" \
+            bash "$ROOT_DIR/.web/docs/public/install" >"$tmp/install.out"
+    )
+
+    grep -q "^$tmp/install/gate.tmp\\." "$tmp/cp.log" || fail "binary was not staged inside install dir"
+    "$tmp/install/gate" --version | grep -q "gate version test" || fail "staged install did not produce a runnable binary"
+    mode=$(ls -l "$tmp/install/gate" | awk '{print $1}')
+    case "$mode" in
+        -rwxr-xr-x*) ;;
+        *) fail "installed binary mode was $mode, want -rwxr-xr-x" ;;
+    esac
+}
+
+run_test test_skips_release_without_assets
+run_test test_download_uses_fail_flag
+run_test test_verifies_installed_binary
+run_test test_linux_musl_selects_musl_asset
+run_test test_checksum_matches_exact_filename
+run_test test_wget_only_fetches_release_metadata
+run_test test_prereleases_are_skipped
+run_test test_missing_checksum_tool_fails_closed
+run_test test_replacement_is_staged_in_install_dir

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,11 @@ build: sync-configs
 
 # Run tests
 test: fmt vet
+	sh .web/docs/public/build_tags_test.sh
+	@case "$$(uname -s)" in \
+		MINGW*|MSYS*|CYGWIN*) echo "Skipping installer shell tests on Windows";; \
+		*) bash .web/docs/public/install_test.sh;; \
+	esac
 	go test ./...
 
 # Run go fmt against code

--- a/pkg/edition/bedrock/geyser/managed_lite.go
+++ b/pkg/edition/bedrock/geyser/managed_lite.go
@@ -1,3 +1,5 @@
+//go:build !musl
+
 package geyser
 
 import (

--- a/pkg/edition/bedrock/geyser/managed_lite_disabled.go
+++ b/pkg/edition/bedrock/geyser/managed_lite_disabled.go
@@ -1,0 +1,26 @@
+//go:build musl
+
+package geyser
+
+import (
+	"context"
+	"fmt"
+
+	"go.minekube.com/gate/pkg/edition/bedrock/config"
+)
+
+type liteManagedRunner struct{}
+
+func newLiteManagedRunner(*config.Config) *liteManagedRunner {
+	return &liteManagedRunner{}
+}
+
+func (r *liteManagedRunner) EnsureKey(context.Context) error {
+	return fmt.Errorf("managed geyserlite engine is not available in this Gate build; set bedrock.managed.engine to %q or use the standard glibc Linux build", config.ManagedEngineJava)
+}
+
+func (r *liteManagedRunner) Start(context.Context) error {
+	return fmt.Errorf("managed geyserlite engine is not available in this Gate build; set bedrock.managed.engine to %q or use the standard glibc Linux build", config.ManagedEngineJava)
+}
+
+func (r *liteManagedRunner) Stop() {}

--- a/pkg/edition/bedrock/geyser/managed_runner_musl_test.go
+++ b/pkg/edition/bedrock/geyser/managed_runner_musl_test.go
@@ -1,0 +1,48 @@
+//go:build musl
+
+package geyser
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"go.minekube.com/gate/pkg/edition/bedrock/config"
+)
+
+func TestNoGeyserliteBuildRejectsGeyserliteEngine(t *testing.T) {
+	runner, err := newManagedRunner(&config.Config{
+		FloodgateKeyPath: "floodgate.pem",
+		Managed: &config.ManagedGeyser{
+			Enabled: true,
+			Engine:  config.ManagedEngineGeyserlite,
+		},
+	})
+	if err != nil {
+		t.Fatalf("newManagedRunner() error = %v", err)
+	}
+
+	err = runner.EnsureKey(context.Background())
+	if err == nil {
+		t.Fatal("EnsureKey() error = nil, want unavailable geyserlite error")
+	}
+	if !strings.Contains(err.Error(), "managed geyserlite engine is not available") {
+		t.Fatalf("EnsureKey() error = %q, want unavailable geyserlite error", err)
+	}
+}
+
+func TestNoGeyserliteBuildKeepsJavaEngine(t *testing.T) {
+	runner, err := newManagedRunner(&config.Config{
+		FloodgateKeyPath: "floodgate.pem",
+		Managed: &config.ManagedGeyser{
+			Enabled: true,
+			Engine:  config.ManagedEngineJava,
+		},
+	})
+	if err != nil {
+		t.Fatalf("newManagedRunner() error = %v", err)
+	}
+	if _, ok := runner.(*javaManagedRunner); !ok {
+		t.Fatalf("newManagedRunner() = %T, want *javaManagedRunner", runner)
+	}
+}

--- a/pkg/edition/bedrock/geyser/managed_runner_test.go
+++ b/pkg/edition/bedrock/geyser/managed_runner_test.go
@@ -1,3 +1,5 @@
+//go:build !musl
+
 package geyser
 
 import (

--- a/pkg/internal/otelutil/otel.go
+++ b/pkg/internal/otelutil/otel.go
@@ -1,3 +1,5 @@
+//go:build !musl
+
 package otelutil
 
 import (

--- a/pkg/internal/otelutil/otel_musl.go
+++ b/pkg/internal/otelutil/otel_musl.go
@@ -1,0 +1,18 @@
+//go:build musl
+
+package otelutil
+
+import (
+	"context"
+	"fmt"
+	"os"
+)
+
+// Init is intentionally minimal for musl builds so the portable Linux binary
+// does not depend on host instrumentation packages that pull in libdl.
+func Init(context.Context) (func(), error) {
+	if os.Getenv("OTEL_METRICS_ENABLED") == "true" || os.Getenv("OTEL_TRACES_ENABLED") == "true" {
+		return nil, fmt.Errorf("OpenTelemetry is not available in the musl Linux build; use the standard glibc Linux build for OTEL support")
+	}
+	return func() {}, nil
+}


### PR DESCRIPTION
## Summary
- add musl-tagged Linux release artifacts (`gate_<version>_linux_<arch>_musl`) via GoReleaser
- make the Unix installer skip asset-less releases, use fail-fast downloads, verify staged binaries, and select `_musl` assets on Alpine/musl
- add musl build fallbacks that omit native GeyserLite and Honeycomb otel-config dependencies so the musl binary is statically linked
- document the musl binary tradeoffs and add installer/build-tag regression tests

## Musl build caveat
The musl binary intentionally excludes native GeyserLite managed mode and Honeycomb OpenTelemetry auto-configuration because those paths currently pull in `purego`/`libdl`. Managed Bedrock on musl should use `bedrock.managed.engine: java`; users needing native GeyserLite or full OTEL support should use the standard glibc build or Docker image.

## Verification
- `make test`
- `go run github.com/goreleaser/goreleaser/v2@latest check`
- `go run github.com/goreleaser/goreleaser/v2@latest release --snapshot --clean --skip=publish`
- `GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -tags musl -ldflags="-s -w" -o /tmp/gate_linux_amd64_musl_check gate.go` produced a statically linked ELF
