### PR TITLE
fix: retain queued backend keepalive replies

### DIFF
--- a/pkg/edition/java/proxy/server.go
+++ b/pkg/edition/java/proxy/server.go
@@ -232,12 +232,14 @@ type serverConnection struct {
 	connPhase  phase.BackendConnectionPhase
 }
 
+const pendingKeepAliveCapacity = 64
+
 func newServerConnection(server *registeredServer, previousServer *registeredServer, player *connectedPlayer) *serverConnection {
 	return &serverConnection{
 		server:         server,
 		player:         player,
 		previousServer: previousServer,
-		pendingPings:   lru.NewSync[int64, time.Time](lru.WithCapacity(5)),
+		pendingPings:   lru.NewSync[int64, time.Time](lru.WithCapacity(pendingKeepAliveCapacity)),
 		log: player.log.WithName("serverConn").WithValues(
 			"serverName", server.info.Name(),
 			"serverAddr", server.info.Addr()),

--- a/pkg/edition/java/proxy/session_client_play.go
+++ b/pkg/edition/java/proxy/session_client_play.go
@@ -293,15 +293,10 @@ func sendKeepAliveToBackend(serverConn *serverConnection, player *connectedPlaye
 	if serverConn == nil {
 		return false
 	}
-	sentTime, ok := serverConn.pendingPings.Get(p.RandomID)
+	sentTime, ok := consumePendingKeepAlive(serverConn, p.RandomID)
 	if !ok {
 		return false
 	}
-	// We removed this pending ping, so it is ours: consume it regardless of
-	// whether it can be forwarded, so it is not re-dispatched to another
-	// connection.
-	serverConn.pendingPings.Delete(p.RandomID)
-
 	// A matching pending ID proves this reply belongs to this backend. Encode it
 	// with the backend connection state; during 1.20.2+ switches the client and
 	// backend can briefly be in different CONFIG/PLAY states.
@@ -316,8 +311,25 @@ func sendKeepAliveToBackend(serverConn *serverConnection, player *connectedPlaye
 	return true
 }
 
+func consumePendingKeepAlive(serverConn *serverConnection, randomID int64) (time.Time, bool) {
+	serverConn.mu.Lock()
+	defer serverConn.mu.Unlock()
+
+	sentTime, ok := serverConn.pendingPings.Get(randomID)
+	if !ok {
+		return time.Time{}, false
+	}
+	// We removed this pending ping, so it is ours: consume it regardless of
+	// whether it can be forwarded, so it is not re-dispatched to another
+	// connection or forwarded twice by concurrent handlers.
+	serverConn.pendingPings.Delete(randomID)
+	return sentTime, true
+}
+
 func recordBackendKeepAlive(serverConn *serverConnection, p *packet.KeepAlive) {
-	serverConn.pendingPings.Flush()
+	serverConn.mu.Lock()
+	defer serverConn.mu.Unlock()
+
 	serverConn.pendingPings.Set(p.RandomID, time.Now())
 }
 

--- a/pkg/edition/java/proxy/session_client_play_keepalive_test.go
+++ b/pkg/edition/java/proxy/session_client_play_keepalive_test.go
@@ -35,7 +35,7 @@ func newKeepAliveFixture(clientState, backendState *state.Registry) (*connectedP
 	sc := &serverConnection{
 		player:       player,
 		log:          logr.Discard(),
-		pendingPings: lru.NewSync[int64, time.Time](lru.WithCapacity(5)),
+		pendingPings: lru.NewSync[int64, time.Time](lru.WithCapacity(pendingKeepAliveCapacity)),
 	}
 	sc.connection = backend
 	return player, sc, backend
@@ -96,28 +96,37 @@ func TestSendKeepAliveIgnoresUnknownPing(t *testing.T) {
 	}
 }
 
-// Backends such as Minestom only accept a response to the latest keep-alive
-// they sent. Keep older IDs out of the pending set so late Bedrock/Geyser
-// replies are dropped instead of being forwarded to the backend and causing
-// "Bad Keep Alive packet" kicks after rapid server switches.
-func TestRecordBackendKeepAliveInvalidatesOlderPendingPings(t *testing.T) {
+func TestConsumePendingKeepAliveConsumesOnce(t *testing.T) {
+	_, sc, _ := newKeepAliveFixture(state.Play, state.Play)
+	const id = int64(1001)
+	sc.pendingPings.Set(id, time.Now())
+
+	if _, ok := consumePendingKeepAlive(sc, id); !ok {
+		t.Fatal("expected first consume to find pending keep-alive")
+	}
+	if _, ok := consumePendingKeepAlive(sc, id); ok {
+		t.Fatal("expected second consume to miss already-consumed keep-alive")
+	}
+}
+
+// Paper can send several keep-alives while the client stalls. When the client
+// replies in order, forwarding only the newest reply makes Paper see a skipped
+// earlier challenge and kick the player as out-of-order.
+func TestRecordBackendKeepAliveRetainsQueuedPendingPings(t *testing.T) {
 	player, sc, backend := newKeepAliveFixture(state.Play, state.Play)
 
-	recordBackendKeepAlive(sc, &packet.KeepAlive{RandomID: 1})
-	recordBackendKeepAlive(sc, &packet.KeepAlive{RandomID: 2})
-
-	if sendKeepAliveToBackend(sc, player, &packet.KeepAlive{RandomID: 1}) {
-		t.Fatal("expected stale keep-alive response to be ignored")
-	}
-	if len(backend.written) != 0 {
-		t.Fatalf("expected stale keep-alive not to be forwarded, got %d writes", len(backend.written))
+	ids := []int64{1, 2, 3, 4, 5, 6, 7}
+	for _, id := range ids {
+		recordBackendKeepAlive(sc, &packet.KeepAlive{RandomID: id})
 	}
 
-	if !sendKeepAliveToBackend(sc, player, &packet.KeepAlive{RandomID: 2}) {
-		t.Fatal("expected latest keep-alive response to be consumed")
+	for _, id := range ids {
+		if !sendKeepAliveToBackend(sc, player, &packet.KeepAlive{RandomID: id}) {
+			t.Fatalf("expected queued keep-alive %d to be consumed", id)
+		}
 	}
-	if len(backend.written) != 1 {
-		t.Fatalf("expected latest keep-alive forwarded once, got %d writes", len(backend.written))
+	if len(backend.written) != len(ids) {
+		t.Fatalf("expected all queued keep-alives forwarded once, got %d writes", len(backend.written))
 	}
 }
 


### PR DESCRIPTION
## Summary
- stop flushing older pending backend keepalive IDs when a new backend keepalive arrives
- retain a bounded queue of pending backend keepalives and consume exact matching replies atomically
- replace the stale-latest-only regression test with Paper burst/queued keepalive coverage

## Root cause
Gate commit `ebf7b8a3` added `pendingPings.Flush()` in `recordBackendKeepAlive` to drop stale replies for backends such as Minestom. In the Paper/Geyser staging path this is wrong: Paper can have multiple outstanding keepalives while the client stalls, then receive replies in order as a burst. Flushing older IDs makes Gate drop the older client replies and forward only the newest reply, so Paper sees skipped challenges and kicks the player as out-of-order.

Velocity reference behavior keeps all pending backend keepalive IDs in a map and removes only the exact matching ID when the client replies. This PR restores that behavior in Gate while keeping the cache bounded.

## Staging evidence
Observed failing session on `connect-proxy-staging.minekube.net`:
- Paper kicked `RoboFlax2` at `2026-06-22 18:59:42 Europe/Berlin`
- reason: `Disconnecting RoboFlax2 for sending keepalive response (56874923) out-of-order!`
- Fly trace showed older queued replies were dropped as non-pending after `recordBackendKeepAlive` flushed the pending set; only latest reply `56874923` was forwarded.

After this fix was deployed through Moxy staging with a local Gate replace:
- session `d8sn4d2cinjc20e4jqh0`
- joined `2026-06-22T17:34:45.498Z`
- `selectedTransport=direct`, `warmPath=warm`
- keepalives continued forwarding through at least `2026-06-22T17:37:27Z`
- no Paper `out-of-order`, no `Timed out`, no `Internal server connection error`

## Verification
- `GOROOT=/opt/homebrew/Cellar/go/1.26.2/libexec go test ./pkg/edition/java/proxy -run KeepAlive -count=1`
- `GOROOT=/opt/homebrew/Cellar/go/1.26.2/libexec go test ./pkg/edition/java/proxy -count=1`
- `GOROOT=/opt/homebrew/Cellar/go/1.26.2/libexec go test ./...`