### PR TITLE
Use vialite v0.1.0 release

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -35,7 +35,7 @@ require (
 	go.minekube.com/common v0.3.0
 	go.minekube.com/connect v0.6.2
 	go.minekube.com/geyserlite v0.3.13
-	go.minekube.com/vialite v0.0.0-20260621104032-00edaf7f9039
+	go.minekube.com/vialite v0.1.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.64.0
 	go.opentelemetry.io/otel v1.41.0
 	go.opentelemetry.io/otel/metric v1.41.0
@@ -108,5 +108,3 @@ require (
 	google.golang.org/genproto/googleapis/api v0.0.0-20251202230838-ff82c1b0f217 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20251202230838-ff82c1b0f217 // indirect
 )
-
-replace go.minekube.com/vialite => github.com/minekube/vialite/go v0.0.0-20260621104032-00edaf7f9039

--- a/go.sum
+++ b/go.sum
@@ -114,8 +114,6 @@ github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.3/go.mod h1:zQrxl1YP88HQlA6i9c63
 github.com/honeycombio/otel-config-go v1.17.0 h1:3/zig0L3IGnfgiCrEfAwBsM0rF57+TKTyJ/a8yqW2eM=
 github.com/honeycombio/otel-config-go v1.17.0/go.mod h1:g2mMdfih4sYKfXBtz2mNGvo3HiQYqX4Up4pdA8JOF2s=
 github.com/jellevandenhooff/dkim v0.0.0-20150330215556-f50fe3d243e1/go.mod h1:E0B/fFc00Y+Rasa88328GlI/XbtyysCtTHZS8h7IrBU=
-github.com/jellydator/ttlcache/v3 v3.4.0 h1:YS4P125qQS0tNhtL6aeYkheEaB/m8HCqdMMP4mnWdTY=
-github.com/jellydator/ttlcache/v3 v3.4.0/go.mod h1:Hw9EgjymziQD3yGsQdf1FqFdpp7YjFMd4Srg5EJlgD4=
 github.com/jellydator/ttlcache/v3 v3.4.1 h1:bOdXmXiycyK6E6Qjyuj5vl+/vU3SCOoDs8a86NbHjAQ=
 github.com/jellydator/ttlcache/v3 v3.4.1/go.mod h1:j7LO12PNghFg5+0v9budMAT4rDK4JY969jb9vOdOBBk=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
@@ -142,8 +140,6 @@ github.com/lunixbochs/vtclean v1.0.0/go.mod h1:pHhQNgMf3btfWnGBVipUOjRYhoOsdGqdm
 github.com/mailru/easyjson v0.0.0-20190312143242-1de009706dbe/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/microcosm-cc/bluemonday v1.0.1/go.mod h1:hsXNsILzKxV+sX77C5b8FSuKF00vh2OMYv+xgHpAMF4=
-github.com/minekube/vialite/go v0.0.0-20260621104032-00edaf7f9039 h1:r2UnyqFwQkSSj2YanXgSVbK2B7vQoHosvPRAlL1gKrw=
-github.com/minekube/vialite/go v0.0.0-20260621104032-00edaf7f9039/go.mod h1:W9L1l8/b/GsLmkw1BW4wijaaPj/zV3OdrtYJgWdkhxE=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/neelance/astrewrite v0.0.0-20160511093645-99348263ae86/go.mod h1:kHJEU3ofeGjhHklVoIGuVj85JJwZ6kWPaJwCIxgnFmo=
@@ -258,6 +254,8 @@ go.minekube.com/connect v0.6.2 h1:RajPc7YgqygcOviV2g4xetL3J0Wzi8b/lsYXUzIltxE=
 go.minekube.com/connect v0.6.2/go.mod h1:28k11I4RyzUfAL3AkOXt3atzjeOFAC8eqbCMwsYKAb0=
 go.minekube.com/geyserlite v0.3.13 h1:Pe6I20z1EvXgWHJ/OUrXag+vQ2m0GcnUFhY140E4UbI=
 go.minekube.com/geyserlite v0.3.13/go.mod h1:yy0/M0zSD6X3FoQMwtmf5Jn+7YFM7AZWamKw0E8fnOE=
+go.minekube.com/vialite v0.1.0 h1:RMnNeDcDKchIs+N5KqxOzCK9tgkrVPjgUgjU5ARdn5o=
+go.minekube.com/vialite v0.1.0/go.mod h1:W9L1l8/b/GsLmkw1BW4wijaaPj/zV3OdrtYJgWdkhxE=
 go.opencensus.io v0.18.0/go.mod h1:vKdFvxhtzZ9onBp9VKHK8z/sRpBMnKAsufL7wlDrCOA=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=
 go.opentelemetry.io/auto/sdk v1.2.1/go.mod h1:KRTj+aOaElaLi+wW1kO/DZRXwkF4C5xPbEe3ZiIhN7Y=


### PR DESCRIPTION
## Summary

- Updates Gate to consume the released `go.minekube.com/vialite v0.1.0` module.
- Removes the temporary replace to the old GitHub pseudo-version.
- Refreshes `go.sum` for the released module.

## Verification

- `go list -m all | rg 'go\\.minekube\\.com/vialite|github\\.com/minekube/vialite'` shows `go.minekube.com/vialite v0.1.0` with no replace.
- `go mod verify`
- `go test ./pkg/edition/java/proxy ./pkg/edition/java/config`
- `go test ./...`
- `git diff --check`

## Release verification

`vialite v0.1.0` release was created and verified before this update:

- Release workflow succeeded: https://github.com/minekube/vialite/actions/runs/27975217211
- Release URL: https://github.com/minekube/vialite/releases/tag/v0.1.0
- Downloaded release assets and verified `sha256sum -c checksums.txt` for:
  - `libvialite-linux-amd64.so`
  - `libvialite-linux-arm64.so`
  - `libvialite.h`
  - `vialite-linux-amd64`
  - `vialite-linux-arm64`
  - `vialite-windows-amd64.exe`

## Runtime note

This PR updates Gate to the released artifact-bearing vialite module. Full Via protocol compatibility testing is still blocked by the current vialite native bridge implementation: `v0.1.0` is the ABI/artifact scaffold and does not yet wire the Via runtime packet proxy.
