### PR TITLE
fix: forward early config plugin messages

### DIFF
--- a/pkg/edition/java/proxy/session_backend_login.go
+++ b/pkg/edition/java/proxy/session_backend_login.go
@@ -309,6 +309,12 @@ func (b *backendLoginSessionHandler) handleServerLoginSuccess() {
 		}
 
 		ash := player.ActiveSessionHandler()
+		if csh, ok := ash.(*clientConfigSessionHandler); ok {
+			if err = csh.flushQueuedPluginMessagesTo(b.serverConn); err != nil {
+				fail(err)
+				return
+			}
+		}
 		csh, ok := ash.(*clientPlaySessionHandler)
 		if ok {
 			serverMc.SetAutoReading(false)

--- a/pkg/edition/java/proxy/session_backend_play_test.go
+++ b/pkg/edition/java/proxy/session_backend_play_test.go
@@ -55,6 +55,8 @@ func TestBackendPlayRegisterForwardsToPlayer(t *testing.T) {
 type testMinecraftConn struct {
 	writtenPackets []proto.Packet
 	connType       phase.ConnectionType
+	activeHandler  netmc.SessionHandler
+	writer         netmc.Writer
 }
 
 func (t *testMinecraftConn) Context() context.Context { return context.Background() }
@@ -70,8 +72,9 @@ func (t *testMinecraftConn) Type() phase.ConnectionType {
 	return phase.Vanilla
 }
 func (t *testMinecraftConn) SetType(ct phase.ConnectionType)            { t.connType = ct }
-func (t *testMinecraftConn) ActiveSessionHandler() netmc.SessionHandler { return nil }
-func (t *testMinecraftConn) SetActiveSessionHandler(*state.Registry, netmc.SessionHandler) {
+func (t *testMinecraftConn) ActiveSessionHandler() netmc.SessionHandler { return t.activeHandler }
+func (t *testMinecraftConn) SetActiveSessionHandler(_ *state.Registry, handler netmc.SessionHandler) {
+	t.activeHandler = handler
 }
 func (t *testMinecraftConn) SwitchSessionHandler(*state.Registry) bool { return true }
 func (t *testMinecraftConn) AddSessionHandler(*state.Registry, netmc.SessionHandler) {
@@ -93,7 +96,23 @@ func (t *testMinecraftConn) BufferPacket(packet proto.Packet) error {
 func (t *testMinecraftConn) BufferPayload([]byte) error { return nil }
 func (t *testMinecraftConn) Flush() error               { return nil }
 func (t *testMinecraftConn) Reader() netmc.Reader       { return nil }
-func (t *testMinecraftConn) Writer() netmc.Writer       { return nil }
-func (t *testMinecraftConn) EnablePlayPacketQueue()     {}
+func (t *testMinecraftConn) Writer() netmc.Writer {
+	if t.writer == nil {
+		t.writer = &testWriter{}
+	}
+	return t.writer
+}
+func (t *testMinecraftConn) EnablePlayPacketQueue() {}
 
 var _ netmc.MinecraftConn = (*testMinecraftConn)(nil)
+
+type testWriter struct{}
+
+func (t *testWriter) WritePacket(proto.Packet) (int, error) { return 0, nil }
+func (t *testWriter) Write([]byte) (int, error)             { return 0, nil }
+func (t *testWriter) Flush() error                          { return nil }
+func (t *testWriter) SetProtocol(proto.Protocol)            {}
+func (t *testWriter) SetState(*state.Registry)              {}
+func (t *testWriter) SetCompressionThreshold(int) error     { return nil }
+func (t *testWriter) EnableEncryption([]byte) error         { return nil }
+func (t *testWriter) Direction() proto.Direction            { return proto.ClientBound }

--- a/pkg/edition/java/proxy/session_client_config.go
+++ b/pkg/edition/java/proxy/session_client_config.go
@@ -2,9 +2,13 @@ package proxy
 
 import (
 	"bytes"
+	"fmt"
+	"sync"
 
+	"github.com/gammazero/deque"
 	"github.com/go-logr/logr"
 	"github.com/robinbraemer/event"
+	"go.minekube.com/common/minecraft/component"
 	"go.minekube.com/gate/pkg/edition/java/netmc"
 	"go.minekube.com/gate/pkg/edition/java/proto/packet"
 	"go.minekube.com/gate/pkg/edition/java/proto/packet/config"
@@ -22,9 +26,16 @@ type clientConfigSessionHandler struct {
 	player *connectedPlayer
 	log    logr.Logger
 
-	brandChannel string
-
 	configSwitchDone future.Future[any]
+
+	mu struct {
+		sync.Mutex
+		pluginMessages           deque.Deque[*plugin.Message]
+		pluginMessagesBytes      int
+		pluginMessagesOverflowed bool
+		brandChannel             string
+		readyServer              *serverConnection
+	}
 
 	nopSessionHandler
 }
@@ -85,15 +96,10 @@ func (h *clientConfigSessionHandler) handleBackendFinishUpdate(serverConn *serve
 		return nil
 	}
 	brand := serverConn.player.ClientBrand()
-	if brand == "" && h.brandChannel != "" {
-		buf := new(bytes.Buffer)
-		_ = util.WriteString(buf, brand)
-
-		brandPacket := &plugin.Message{
-			Channel: h.brandChannel,
-			Data:    buf.Bytes(),
+	if brand != "" {
+		if brandPacket := h.brandPacket(brand); brandPacket != nil {
+			_ = smc.WritePacket(brandPacket)
 		}
-		_ = smc.WritePacket(brandPacket)
 	}
 
 	if err := h.player.WritePacket(p); err != nil {
@@ -115,23 +121,33 @@ func handleResourcePackResponse(p *packet.ResourcePackResponse, handler resource
 }
 
 func (h *clientConfigSessionHandler) handlePluginMessage(p *plugin.Message) {
-	serverConn := h.player.connectionInFlight()
-	if serverConn == nil {
-		return
-	}
-
 	if plugin.McBrand(p) {
 		brand := plugin.ReadBrandMessage(p.Data)
-		h.brandChannel = p.Channel
+		h.player.setClientBrand(brand)
+		readyServer := h.setBrandChannel(p.Channel)
 		h.event().FireParallel(&PlayerClientBrandEvent{
 			player: h.player,
 			brand:  brand,
 		})
 		// Client sends `minecraft:brand` packet immediately after Login,
 		// but at this time the backend server may not be ready
+		if readyServer != nil {
+			if brandPacket := h.brandPacket(brand); brandPacket != nil {
+				if smc, ok := readyServer.ensureConnected(); ok {
+					_ = smc.WritePacket(brandPacket)
+				}
+			}
+		}
+		return
 	} else if bungeecord.IsBungeeCordMessage(p) {
 		return
+	} else if h.enqueuePluginMessage(h.player.connectionInFlightOrConnectedServer(), p) {
+		return
 	} else {
+		serverConn := h.player.connectionInFlightOrConnectedServer()
+		if serverConn == nil {
+			return
+		}
 		id, ok := h.player.proxy.ChannelRegistrar().FromID(p.Channel)
 		if !ok {
 			smc, ok := serverConn.ensureConnected()
@@ -164,8 +180,102 @@ func (h *clientConfigSessionHandler) handlePluginMessage(p *plugin.Message) {
 	}
 }
 
+func (h *clientConfigSessionHandler) setBrandChannel(channel string) *serverConnection {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.mu.brandChannel = channel
+	return h.mu.readyServer
+}
+
+func (h *clientConfigSessionHandler) brandPacket(brand string) *plugin.Message {
+	h.mu.Lock()
+	channel := h.mu.brandChannel
+	h.mu.Unlock()
+	if channel == "" {
+		return nil
+	}
+	buf := new(bytes.Buffer)
+	_ = util.WriteString(buf, brand)
+	return &plugin.Message{
+		Channel: channel,
+		Data:    buf.Bytes(),
+	}
+}
+
+// enqueuePluginMessage returns true when the message was handled by the queue
+// path, including overflow rejection. It returns false only once the backend is
+// ready for direct config plugin messages.
+func (h *clientConfigSessionHandler) enqueuePluginMessage(target *serverConnection, msg *plugin.Message) bool {
+	h.mu.Lock()
+	if target != nil && h.mu.readyServer == target {
+		h.mu.Unlock()
+		return false
+	}
+	if h.mu.pluginMessagesOverflowed {
+		h.mu.Unlock()
+		return true
+	}
+	newBytes := h.mu.pluginMessagesBytes + len(msg.Data)
+	newCount := h.mu.pluginMessages.Len() + 1
+	if newBytes > maxQueuedLoginPluginMessageBytes || newCount > maxQueuedLoginPluginMessages {
+		h.mu.pluginMessagesOverflowed = true
+		h.mu.pluginMessages.Clear()
+		h.mu.pluginMessagesBytes = 0
+		h.mu.Unlock()
+		h.log.Info("disconnecting player: pre-backend config plugin message queue exceeded its limits",
+			"messages", newCount, "bytes", newBytes)
+		h.player.Disconnect(&component.Text{
+			Content: "Too many plugin messages were sent before joining a server",
+		})
+		return true
+	}
+	h.mu.pluginMessages.PushBack(&plugin.Message{
+		Channel: msg.Channel,
+		Data:    append([]byte(nil), msg.Data...),
+	})
+	h.mu.pluginMessagesBytes = newBytes
+	h.mu.Unlock()
+	return true
+}
+
+func (h *clientConfigSessionHandler) flushQueuedPluginMessagesTo(serverConn *serverConnection) error {
+	smc, ok := serverConn.ensureConnected()
+	if !ok {
+		return netmc.ErrClosedConn
+	}
+
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if h.mu.readyServer == serverConn {
+		return nil
+	}
+
+	h.mu.pluginMessagesBytes = 0
+	n := h.mu.pluginMessages.Len()
+	msgs := make([]*plugin.Message, 0, n)
+	for h.mu.pluginMessages.Len() != 0 {
+		msgs = append(msgs, h.mu.pluginMessages.PopFront())
+	}
+	for _, pm := range msgs {
+		if err := smc.BufferPacket(pm); err != nil {
+			return fmt.Errorf("error buffering queued config plugin message %q: %w", pm.Channel, err)
+		}
+	}
+	if n != 0 {
+		if err := smc.Flush(); err != nil {
+			return err
+		}
+	}
+	h.mu.readyServer = serverConn
+	return nil
+}
+
 func (h *clientConfigSessionHandler) handleKnownPacks(p *config.KnownPacks, pc *proto.PacketContext) {
-	smc, ok := h.player.connectionInFlightOrConnectedServer().ensureConnected()
+	serverConn := h.player.connectionInFlightOrConnectedServer()
+	if serverConn == nil {
+		return
+	}
+	smc, ok := serverConn.ensureConnected()
 	if ok {
 		_ = smc.WritePacket(p)
 	}

--- a/pkg/edition/java/proxy/session_client_config_test.go
+++ b/pkg/edition/java/proxy/session_client_config_test.go
@@ -1,0 +1,378 @@
+package proxy
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/robinbraemer/event"
+	javaconfig "go.minekube.com/gate/pkg/edition/java/config"
+	cfgpacket "go.minekube.com/gate/pkg/edition/java/proto/packet/config"
+	"go.minekube.com/gate/pkg/edition/java/proto/packet/plugin"
+	"go.minekube.com/gate/pkg/edition/java/proto/state"
+	"go.minekube.com/gate/pkg/edition/java/proto/util"
+	"go.minekube.com/gate/pkg/edition/java/proxy/message"
+	"go.minekube.com/gate/pkg/gate/proto"
+)
+
+func TestBackendLoginSuccessFlushesQueuedConfigPluginMessages(t *testing.T) {
+	clientConn := &testMinecraftConn{}
+	backendConn := &testMinecraftConn{}
+	player := &connectedPlayer{
+		MinecraftConn:      clientConn,
+		log:                logr.Discard(),
+		sessionHandlerDeps: &sessionHandlerDeps{proxy: newConfigTestProxy()},
+	}
+	configHandler := newClientConfigSessionHandler(player)
+	clientConn.SetActiveSessionHandler(state.Config, configHandler)
+
+	msg := &plugin.Message{
+		Channel: "vv:mod_details",
+		Data:    []byte(`{"platform":"ViaFabric"}`),
+	}
+	configHandler.handlePluginMessage(msg)
+	if len(backendConn.writtenPackets) != 0 {
+		t.Fatalf("backend packets before connection = %d, want 0", len(backendConn.writtenPackets))
+	}
+
+	serverConn := &serverConnection{
+		player: player,
+		log:    logr.Discard(),
+	}
+	serverConn.mu.Lock()
+	serverConn.connection = backendConn
+	serverConn.mu.Unlock()
+	player.mu.Lock()
+	player.connInFlight = serverConn
+	player.mu.Unlock()
+
+	handler := &backendLoginSessionHandler{
+		serverConn: serverConn,
+		requestCtx: &connRequestCxt{
+			Context:  context.Background(),
+			response: make(chan *connResponse, 1),
+		},
+		log: logr.Discard(),
+		sessionHandlerDeps: &sessionHandlerDeps{
+			eventMgr:       event.New(),
+			configProvider: &testConfigProvider{cfg: &javaconfig.Config{}},
+		},
+	}
+
+	handler.handleServerLoginSuccess()
+
+	for _, pkt := range backendConn.writtenPackets {
+		got, ok := pkt.(*plugin.Message)
+		if !ok {
+			continue
+		}
+		if got.Channel != msg.Channel {
+			t.Fatalf("queued plugin channel = %q, want %q", got.Channel, msg.Channel)
+		}
+		if string(got.Data) != string(msg.Data) {
+			t.Fatalf("queued plugin data = %q, want %q", string(got.Data), string(msg.Data))
+		}
+		return
+	}
+	t.Fatalf("queued config plugin message was not flushed to backend; packets: %#v", backendConn.writtenPackets)
+}
+
+func TestConfigPluginMessageQueuesWhileBackendConnectionInFlightWithoutSocket(t *testing.T) {
+	clientConn := &testMinecraftConn{}
+	backendConn := &testMinecraftConn{}
+	player := &connectedPlayer{
+		MinecraftConn:      clientConn,
+		log:                logr.Discard(),
+		sessionHandlerDeps: &sessionHandlerDeps{proxy: newConfigTestProxy()},
+	}
+	configHandler := newClientConfigSessionHandler(player)
+	clientConn.SetActiveSessionHandler(state.Config, configHandler)
+
+	serverConn := &serverConnection{
+		player: player,
+		log:    logr.Discard(),
+	}
+	player.mu.Lock()
+	player.connInFlight = serverConn
+	player.mu.Unlock()
+
+	msg := &plugin.Message{Channel: "vv:mod_details", Data: []byte(`{"phase":"in-flight"}`)}
+	configHandler.handlePluginMessage(msg)
+	if len(backendConn.writtenPackets) != 0 {
+		t.Fatalf("backend packets before socket = %d, want 0", len(backendConn.writtenPackets))
+	}
+
+	serverConn.mu.Lock()
+	serverConn.connection = backendConn
+	serverConn.mu.Unlock()
+	handleBackendLoginSuccessForConfigTest(t, serverConn)
+
+	requirePluginMessagesInOrder(t, backendConn.writtenPackets, msg)
+}
+
+func TestConfigPluginMessageQueuesUntilBackendConfigReadyAndPreservesOrder(t *testing.T) {
+	clientConn := &testMinecraftConn{}
+	backendConn := &testMinecraftConn{}
+	player := &connectedPlayer{
+		MinecraftConn:      clientConn,
+		log:                logr.Discard(),
+		sessionHandlerDeps: &sessionHandlerDeps{proxy: newConfigTestProxy()},
+	}
+	configHandler := newClientConfigSessionHandler(player)
+	clientConn.SetActiveSessionHandler(state.Config, configHandler)
+
+	serverConn := &serverConnection{
+		player: player,
+		log:    logr.Discard(),
+	}
+	serverConn.mu.Lock()
+	serverConn.connection = backendConn
+	serverConn.mu.Unlock()
+	player.mu.Lock()
+	player.connInFlight = serverConn
+	player.mu.Unlock()
+
+	first := &plugin.Message{Channel: "vv:mod_details", Data: []byte(`{"order":1}`)}
+	second := &plugin.Message{Channel: "fabric:registry", Data: []byte(`{"order":2}`)}
+	configHandler.handlePluginMessage(first)
+	configHandler.handlePluginMessage(second)
+	if len(backendConn.writtenPackets) != 0 {
+		t.Fatalf("backend packets before login success = %d, want 0", len(backendConn.writtenPackets))
+	}
+
+	handleBackendLoginSuccessForConfigTest(t, serverConn)
+
+	requirePluginMessagesInOrder(t, backendConn.writtenPackets, first, second)
+}
+
+func TestConfigPluginMessageForwardsAfterBackendConfigReady(t *testing.T) {
+	clientConn := &testMinecraftConn{}
+	backendConn := &testMinecraftConn{}
+	player := &connectedPlayer{
+		MinecraftConn:      clientConn,
+		log:                logr.Discard(),
+		sessionHandlerDeps: &sessionHandlerDeps{proxy: newConfigTestProxy()},
+	}
+	configHandler := newClientConfigSessionHandler(player)
+	clientConn.SetActiveSessionHandler(state.Config, configHandler)
+
+	serverConn := &serverConnection{
+		player: player,
+		log:    logr.Discard(),
+	}
+	serverConn.mu.Lock()
+	serverConn.connection = backendConn
+	serverConn.mu.Unlock()
+	player.mu.Lock()
+	player.connInFlight = serverConn
+	player.mu.Unlock()
+
+	handleBackendLoginSuccessForConfigTest(t, serverConn)
+
+	msg := &plugin.Message{Channel: "vv:mod_details", Data: []byte(`{"ready":true}`)}
+	configHandler.handlePluginMessage(msg)
+
+	requirePluginMessagesInOrder(t, backendConn.writtenPackets, msg)
+}
+
+func TestConfigPluginMessageQueuesForNewBackendAttemptAfterPreviousReady(t *testing.T) {
+	clientConn := &testMinecraftConn{}
+	firstBackendConn := &testMinecraftConn{}
+	secondBackendConn := &testMinecraftConn{}
+	player := &connectedPlayer{
+		MinecraftConn:      clientConn,
+		log:                logr.Discard(),
+		sessionHandlerDeps: &sessionHandlerDeps{proxy: newConfigTestProxy()},
+	}
+	configHandler := newClientConfigSessionHandler(player)
+	clientConn.SetActiveSessionHandler(state.Config, configHandler)
+
+	firstServerConn := &serverConnection{player: player, log: logr.Discard()}
+	firstServerConn.mu.Lock()
+	firstServerConn.connection = firstBackendConn
+	firstServerConn.mu.Unlock()
+	player.mu.Lock()
+	player.connInFlight = firstServerConn
+	player.mu.Unlock()
+	handleBackendLoginSuccessForConfigTest(t, firstServerConn)
+
+	secondServerConn := &serverConnection{player: player, log: logr.Discard()}
+	secondServerConn.mu.Lock()
+	secondServerConn.connection = secondBackendConn
+	secondServerConn.mu.Unlock()
+	player.mu.Lock()
+	player.connInFlight = secondServerConn
+	player.mu.Unlock()
+
+	msg := &plugin.Message{Channel: "vv:mod_details", Data: []byte(`{"retry":true}`)}
+	configHandler.handlePluginMessage(msg)
+	if len(secondBackendConn.writtenPackets) != 0 {
+		t.Fatalf("second backend packets before config ready = %d, want 0", len(secondBackendConn.writtenPackets))
+	}
+
+	handleBackendLoginSuccessForConfigTest(t, secondServerConn)
+
+	requirePluginMessagesInOrder(t, secondBackendConn.writtenPackets, msg)
+}
+
+func TestClientConfigForwardsLateBrandAfterBackendConfigReady(t *testing.T) {
+	clientConn := &testMinecraftConn{}
+	backendConn := &testMinecraftConn{}
+	player := &connectedPlayer{
+		MinecraftConn:      clientConn,
+		log:                logr.Discard(),
+		sessionHandlerDeps: &sessionHandlerDeps{proxy: newConfigTestProxy()},
+	}
+	configHandler := newClientConfigSessionHandler(player)
+	clientConn.SetActiveSessionHandler(state.Config, configHandler)
+
+	serverConn := &serverConnection{player: player, log: logr.Discard()}
+	serverConn.mu.Lock()
+	serverConn.connection = backendConn
+	serverConn.mu.Unlock()
+	player.mu.Lock()
+	player.connInFlight = serverConn
+	player.mu.Unlock()
+	handleBackendLoginSuccessForConfigTest(t, serverConn)
+
+	var data strings.Builder
+	if err := util.WriteString(&data, "ViaFabric"); err != nil {
+		t.Fatalf("write brand: %v", err)
+	}
+	configHandler.handlePluginMessage(&plugin.Message{
+		Channel: plugin.BrandChannel,
+		Data:    []byte(data.String()),
+	})
+
+	requirePluginMessagesInOrder(t, backendConn.writtenPackets, &plugin.Message{
+		Channel: plugin.BrandChannel,
+		Data:    []byte(data.String()),
+	})
+}
+
+func TestClientConfigStoresBrandPluginMessage(t *testing.T) {
+	player := &connectedPlayer{
+		MinecraftConn:      &testMinecraftConn{},
+		log:                logr.Discard(),
+		sessionHandlerDeps: &sessionHandlerDeps{proxy: newConfigTestProxy()},
+	}
+	handler := newClientConfigSessionHandler(player)
+
+	var data strings.Builder
+	if err := util.WriteString(&data, "ViaFabric"); err != nil {
+		t.Fatalf("write brand: %v", err)
+	}
+	handler.handlePluginMessage(&plugin.Message{
+		Channel: plugin.BrandChannel,
+		Data:    []byte(data.String()),
+	})
+
+	if got := player.ClientBrand(); got != "ViaFabric" {
+		t.Fatalf("client brand = %q, want ViaFabric", got)
+	}
+}
+
+func TestClientConfigDropsKnownPacksWhenNoTargetServer(t *testing.T) {
+	player := &connectedPlayer{
+		MinecraftConn:      &testMinecraftConn{},
+		log:                logr.Discard(),
+		sessionHandlerDeps: &sessionHandlerDeps{proxy: newConfigTestProxy()},
+	}
+	handler := newClientConfigSessionHandler(player)
+
+	handler.handleKnownPacks(&cfgpacket.KnownPacks{}, nil)
+}
+
+func handleBackendLoginSuccessForConfigTest(t *testing.T, serverConn *serverConnection) {
+	t.Helper()
+	handler := &backendLoginSessionHandler{
+		serverConn: serverConn,
+		requestCtx: &connRequestCxt{
+			Context:  context.Background(),
+			response: make(chan *connResponse, 1),
+		},
+		log: logr.Discard(),
+		sessionHandlerDeps: &sessionHandlerDeps{
+			eventMgr:       event.New(),
+			configProvider: &testConfigProvider{cfg: &javaconfig.Config{}},
+		},
+	}
+	handler.handleServerLoginSuccess()
+}
+
+func requirePluginMessagesInOrder(t *testing.T, packets []proto.Packet, want ...*plugin.Message) {
+	t.Helper()
+	got := make([]*plugin.Message, 0, len(want))
+	for _, pkt := range packets {
+		msg, ok := pkt.(*plugin.Message)
+		if ok {
+			got = append(got, msg)
+		}
+	}
+	if len(got) < len(want) {
+		t.Fatalf("plugin messages = %d, want at least %d; packets: %#v", len(got), len(want), packets)
+	}
+	got = got[len(got)-len(want):]
+	for i, msg := range want {
+		if got[i].Channel != msg.Channel {
+			t.Fatalf("plugin[%d] channel = %q, want %q", i, got[i].Channel, msg.Channel)
+		}
+		if string(got[i].Data) != string(msg.Data) {
+			t.Fatalf("plugin[%d] data = %q, want %q", i, string(got[i].Data), string(msg.Data))
+		}
+	}
+}
+
+func newConfigTestProxy() *Proxy {
+	return &Proxy{
+		event:            event.Nop,
+		channelRegistrar: message.NewChannelRegistrar(),
+	}
+}
+
+func TestClientConfigForwardsStoredBrandOnBackendFinishUpdate(t *testing.T) {
+	backendConn := &testMinecraftConn{}
+	player := &connectedPlayer{
+		MinecraftConn:      &testMinecraftConn{},
+		log:                logr.Discard(),
+		sessionHandlerDeps: &sessionHandlerDeps{proxy: newConfigTestProxy()},
+	}
+	handler := newClientConfigSessionHandler(player)
+
+	var data strings.Builder
+	if err := util.WriteString(&data, "ViaFabric"); err != nil {
+		t.Fatalf("write brand: %v", err)
+	}
+	handler.handlePluginMessage(&plugin.Message{
+		Channel: plugin.BrandChannel,
+		Data:    []byte(data.String()),
+	})
+
+	serverConn := &serverConnection{
+		player: player,
+		log:    logr.Discard(),
+	}
+	serverConn.mu.Lock()
+	serverConn.connection = backendConn
+	serverConn.mu.Unlock()
+
+	if fut := handler.handleBackendFinishUpdate(serverConn, &cfgpacket.FinishedUpdate{}); fut == nil {
+		t.Fatal("handleBackendFinishUpdate returned nil future")
+	}
+
+	for _, pkt := range backendConn.writtenPackets {
+		got, ok := pkt.(*plugin.Message)
+		if !ok {
+			continue
+		}
+		if got.Channel != plugin.BrandChannel {
+			t.Fatalf("brand channel = %q, want %q", got.Channel, plugin.BrandChannel)
+		}
+		if brand := plugin.ReadBrandMessage(got.Data); brand != "ViaFabric" {
+			t.Fatalf("forwarded brand = %q, want ViaFabric", brand)
+		}
+		return
+	}
+	t.Fatalf("stored brand was not forwarded to backend; packets: %#v", backendConn.writtenPackets)
+}


### PR DESCRIPTION
## Summary
- queue client configuration plugin messages until the target backend connection is actually ready for config-stage plugin messages
- scope config readiness to the concrete `serverConnection`, preserving behavior across backend retries/fallbacks while the client remains in configuration
- preserve FIFO ordering for early ViaFabric/ViaVersion config plugin messages such as `vv:mod_details`
- store and forward config-stage `minecraft:brand`, including late brand packets after backend config readiness
- drop `KnownPacks` safely when no backend target exists, matching Velocity's later null-target guard instead of risking a config-state nil dereference

Closes #686.

## Velocity comparison
I cloned PaperMC/Velocity and compared the relevant paths and blame/history:
- `ClientConfigSessionHandler.handle(PluginMessagePacket)` came from PaperMC/Velocity#1096, whose body says Fabric API sends `PluginMessage` during configuration and uses `PingIdentify` to confirm readiness. The linked issue PaperMC/Velocity#1095 was a Fabric backend where direct join worked but Velocity join failed with “Incomplete set of tags”.
- Velocity#1096 forwards config-stage plugin messages only when `getConnectionInFlight()` is already non-null; if the client sends before that, the message is still dropped. Later Velocity changes added brand handling (#1223) and plugin-message events in configuration (#1398-era commit `9d1332d3a`), but still did not add a config-stage queue.
- Velocity's bounded pre-join/login/FML plugin-message queue started in commit `9776675b` with the explicit rationale that mods can send plugin messages too early and Velocity aggravates the timing; #632 extended events for queued messages, and #1800 capped the queue to avoid OOM.
- Velocity also later guarded targetless `KnownPacks` forwarding in commit `8c8162dbf`, discarding it when there is no target server.

So Gate originally matched Velocity's current config-stage behavior closely, including the apparent drop window. This PR intentionally extends the same bounded-queue pattern Gate/Velocity already use for pre-join plugin messages to the 1.20.2+ configuration state, because ViaFabric/ViaVersion compatibility messages can arrive before the backend config handler is ready.

## Reproduction / Tests
Added regression tests for:
- config plugin message before any backend connection exists
- `connInFlight` set but backend socket not attached yet
- backend socket attached but backend still not config-ready
- FIFO ordering across queued config messages
- direct forwarding after backend config readiness
- backend retry after a previous backend became config-ready
- config-stage brand storage, finish-update forwarding, and late-brand forwarding
- targetless `KnownPacks` handling in client configuration

Automated red/green check:
- red: in a temporary worktree, I restored only `session_backend_login.go` and `session_client_config.go` to `origin/master` while keeping the new regression tests. The focused test run failed because queued config plugin messages were not flushed, messages were forwarded before backend config readiness, late/stored brand was not forwarded, and config brand was not stored.
- green: the same focused regression test run passes on this branch.

Live Craftless validation:
- built the local `minekube/craftless` CLI with `mise exec -- gradle :cli:installDist`
- started a Fabric 1.21.11 backend via Docker image `itzg/minecraft-server:java25` with `fabric-api`, `viafabric`, `viabackwards`, `viarewind`, `lithium`, `ferrite-core`, and `styled-chat`
- built `origin/master` Gate and this branch, then ran Craftless' real Fabric client harness through each Gate binary
- result: the local Craftless harness did **not** reproduce the reporter's timeout on old Gate; old Gate and fixed Gate both joined and sent chat successfully

Craftless old-Gate evidence:
- Gate log: `Player433` connected and joined `viafabric`
- Backend log: `Player433 joined the game` and `<Player433> old gate 686 craftless`
- Craftless artifacts: `/tmp/gate-686-live/artifacts-old/client-events.jsonl` and `/tmp/gate-686-live/artifacts-old/gameplay-results.jsonl`, with `player.chat` status `ACCEPTED`

Craftless fixed-Gate evidence:
- Gate log: `Player171` connected and joined `viafabric`
- Backend log: `Player171 joined the game` and `<Player171> fixed gate 686 craftless`
- Craftless artifacts: `/tmp/gate-686-live/artifacts-fixed/client-events.jsonl` and `/tmp/gate-686-live/artifacts-fixed/gameplay-results.jsonl`, with `player.chat` status `ACCEPTED`

Note: the currently local Craftless Fabric harness is pinned to a Minecraft 1.21.6 Fabric client and does not include the reporter's exact 26.1.2 client setup. Because old Gate also passes with this harness, Craftless does not provide a live red/green reproduction for #686 as-is. The red/green confirmation for this PR is the focused regression suite above.

## Verification
- `go test ./pkg/edition/java/proxy -run 'TestBackendLoginSuccessFlushesQueuedConfigPluginMessages|TestConfigPluginMessageQueuesWhileBackendConnectionInFlightWithoutSocket|TestConfigPluginMessageQueuesUntilBackendConfigReadyAndPreservesOrder|TestConfigPluginMessageForwardsAfterBackendConfigReady|TestConfigPluginMessageQueuesForNewBackendAttemptAfterPreviousReady|TestClientConfigForwardsLateBrandAfterBackendConfigReady|TestClientConfigStoresBrandPluginMessage|TestClientConfigDropsKnownPacksWhenNoTargetServer|TestClientConfigForwardsStoredBrandOnBackendFinishUpdate' -count=1`
- same focused test run against old product code: failed as expected
- `go test -race ./pkg/edition/java/proxy -count=1`
- `git diff --check`
- `go test ./...`