### PR TITLE
docs: add ViaLite and GeyserLite pages

### DIFF
--- a/.web/docs/.vitepress/config.ts
+++ b/.web/docs/.vitepress/config.ts
@@ -116,6 +116,8 @@ export default defineConfig({
     nav: [
       { text: 'Guide', link: '/guide/' },
       { text: 'Bedrock', link: '/guide/bedrock' },
+      { text: 'GeyserLite', link: '/geyserlite/' },
+      { text: 'ViaLite', link: '/vialite/' },
       { text: 'Lite Mode', link: '/guide/lite' },
       { text: 'API & SDKs', link: '/developers/api/' },
       { text: 'Config', link: '/guide/config/' },
@@ -384,6 +386,44 @@ export default defineConfig({
         {
           text: '← Back to Guides',
           link: '/guide/',
+        },
+      ],
+      '/geyserlite/': [
+        {
+          text: 'GeyserLite',
+          items: [
+            {
+              text: 'Overview',
+              link: '/geyserlite/',
+            },
+            {
+              text: 'Gate Bedrock Guide',
+              link: '/guide/bedrock',
+            },
+            {
+              text: 'ViaLite',
+              link: '/vialite/',
+            },
+          ],
+        },
+      ],
+      '/vialite/': [
+        {
+          text: 'ViaLite',
+          items: [
+            {
+              text: 'Overview',
+              link: '/vialite/',
+            },
+            {
+              text: 'Compatibility Guide',
+              link: '/guide/compatibility',
+            },
+            {
+              text: 'GeyserLite',
+              link: '/geyserlite/',
+            },
+          ],
         },
       ],
       // '/config/': [

--- a/.web/docs/geyserlite/index.md
+++ b/.web/docs/geyserlite/index.md
@@ -1,0 +1,99 @@
+---
+title: "GeyserLite - Managed Bedrock Runtime for Gate"
+description: "GeyserLite packages GeyserMC as native artifacts and embeddable libraries so Gate can manage Bedrock cross-play with low overhead."
+---
+
+# GeyserLite
+
+GeyserLite is Minekube's native runtime shape for
+[GeyserMC](https://geysermc.org/). Gate uses it to provide managed Bedrock
+cross-play without asking operators to run a separate JVM process.
+
+For most Gate users, this is the only config needed:
+
+```yaml
+config:
+  bedrock: true
+```
+
+Gate starts the managed Bedrock runtime, generates the Floodgate key material,
+and connects GeyserLite to Gate's Java listener.
+
+## Topology
+
+```text
+Bedrock player
+  -> GeyserLite
+  -> Gate classic
+  -> optional ViaLite
+  -> backend server
+```
+
+GeyserLite is the Bedrock ingress layer. It translates Bedrock protocol into
+Java protocol before the connection reaches Gate. Gate then owns routing,
+events, forwarding, and backend login.
+
+If ViaLite is also enabled, it sits behind Gate. That means Bedrock traffic is
+already translated to Java before ViaLite handles backend version translation.
+
+## Managed Config
+
+Use the shorthand for the default managed setup:
+
+```yaml
+config:
+  bedrock: true
+```
+
+Use object form when you need to customize the listener, username format, or
+Geyser config overrides:
+
+```yaml
+config:
+  bedrock:
+    enabled: true
+    usernameFormat: ".%s"
+    geyserListenAddr: "localhost:25567"
+    managed:
+      enabled: true
+      configOverrides:
+        bedrock:
+          port: 19132
+```
+
+Gate keeps the Java-side listener private by default. Expose
+`geyserListenAddr` only when GeyserLite runs outside the same network namespace.
+
+## Version Policy
+
+GeyserLite tracks upstream Geyser through a pinned source ref and a managed
+release chain. When a GeyserLite release is published, Gate can consume it as a
+managed dependency.
+
+Production guidance follows upstream Geyser support:
+
+- If Geyser officially supports the relevant Java and Bedrock versions, Gate's
+  managed Bedrock mode is the stable path.
+- If a server updates to a brand-new Java version before Geyser supports it,
+  operators should usually wait before upgrading production backends.
+- ViaLite may help early adopters when only the Java backend protocol is newer,
+  but it cannot fix unsupported Bedrock client protocols or missing Geyser
+  Bedrock-to-Java translation.
+
+## Runtime Modes
+
+GeyserLite ships as:
+
+- Native executable for managed subprocess mode.
+- Shared library for embedded Go and Rust integrations.
+- Container image for standalone deployments.
+
+Gate chooses the managed runtime shape supported by the current platform and
+configuration.
+
+## Links
+
+- [Gate Bedrock guide](/guide/bedrock)
+- [GeyserLite repository](https://github.com/minekube/geyserlite)
+- [GeyserLite releases](https://github.com/minekube/geyserlite/releases)
+- [GeyserMC supported versions](https://geysermc.org/wiki/geyser/supported-versions/)

--- a/.web/docs/guide/bedrock.md
+++ b/.web/docs/guide/bedrock.md
@@ -42,7 +42,8 @@ gate --config config.yml
 Gate automatically generates encryption keys, downloads Geyser, creates optimized configs, and manages everything for you. The `bedrock: true` shorthand enables both Bedrock support and managed mode in one line.
 :::
 
-
+Managed Bedrock support is powered by [GeyserLite](/geyserlite/), Minekube's
+native runtime packaging of GeyserMC for Gate.
 
 ## How It Works
 
@@ -56,6 +57,11 @@ Gate's Bedrock support uses a **proxy-in-front-of-proxy** architecture with buil
 2. **Geyser** translates Bedrock protocol to Java Edition and forwards to Gate
 3. **Gate** receives translated connections, handles Floodgate authentication internally, and presents them as regular Java players to backend servers
 4. **Backend servers** see all players as normal Java Edition connections - no plugins required!
+
+If [ViaLite](/vialite/) is enabled, it runs behind Gate after GeyserLite has
+already translated Bedrock traffic to Java protocol. That can help with Java
+backend version differences, but it does not replace Geyser's Bedrock protocol
+support.
 
 ### Key Benefits
 

--- a/.web/docs/guide/compatibility.md
+++ b/.web/docs/guide/compatibility.md
@@ -17,7 +17,7 @@ and we maintainers update Gate as soon as a new Minecraft version is released.
 ## Java Version Translation
 
 Gate can run managed Via translation in classic proxy mode. When `config.via.enabled`
-is true, Gate starts vialite, keeps it on the latest stable release by default,
+is true, Gate starts [ViaLite](/vialite/), keeps it on the latest stable release by default,
 and routes backend connections through Via-compatible protocol translation.
 This applies to both configured servers and API-registered servers, so dynamic
 Connect/session backends can be joined by Java clients even when the backend
@@ -30,9 +30,15 @@ config:
 ```
 
 Lite mode does not run managed Via translation. Dynamic API-registered backend
-translation uses the default subprocess mode; embedded mode is limited to
-configured servers. For controlled deployments, Gate still supports exact
-vialite version pins, offline mode, and local artifact paths.
+translation is supported by the managed runtime; subprocess mode is the portable
+default, and embedded mode is available where the native shared library is
+supported. For controlled deployments, Gate still supports exact vialite version
+pins, offline mode, and local artifact paths.
+
+For Bedrock players, [GeyserLite](/geyserlite/) translates the Bedrock session
+before Gate routes to a backend. ViaLite can still help behind Gate when the
+backend Java protocol is newer, but it does not add unsupported Geyser Bedrock
+protocol support.
 
 ## Paper <VPBadge>Recommended</VPBadge>
 

--- a/.web/docs/vialite/index.md
+++ b/.web/docs/vialite/index.md
@@ -1,0 +1,111 @@
+---
+title: "ViaLite - Managed Java Version Compatibility for Gate"
+description: "ViaLite gives Gate managed Via-powered backend protocol translation for Java clients and Bedrock players already translated through GeyserLite."
+---
+
+# ViaLite
+
+ViaLite is Minekube's managed Via runtime for Gate classic. It lets Gate route
+backend connections through Via-powered Java protocol translation while Gate
+keeps ownership of authentication, events, routing, Connect, and backend login.
+
+Enable it with:
+
+```yaml
+config:
+  via:
+    enabled: true
+```
+
+Gate starts ViaLite and automatically routes configured and API-registered
+classic backend servers through it.
+
+## Topology
+
+```text
+Java player
+  -> Gate classic
+  -> ViaLite
+  -> backend server
+
+Bedrock player
+  -> GeyserLite
+  -> Gate classic
+  -> ViaLite
+  -> backend server
+```
+
+ViaLite sits behind Gate, not in front of it. Gate has already accepted the
+player and selected a backend before ViaLite translates backend packets.
+
+## Not Lite Mode
+
+Gate Lite intentionally reads the initial handshake, chooses a backend, and
+then raw-pipes bytes so backend servers keep authentication ownership. ViaLite
+must decode and rewrite packets after login, so it belongs to Gate classic
+backend connections instead.
+
+## Config
+
+The default path uses the latest stable ViaLite release:
+
+```yaml
+config:
+  via:
+    enabled: true
+```
+
+Operators can pin or override the runtime when they need controlled rollout or
+offline deployment:
+
+```yaml
+config:
+  via:
+    enabled: true
+    mode: subprocess
+    version: v0.3.0
+    # mirror: https://example.com/vialite/releases
+    # binaryPath: /opt/vialite/vialite
+    # libraryPath: /opt/vialite/libvialite.so
+    # offline: true
+```
+
+Subprocess mode is the portable default. Embedded mode is available where the
+native shared library is supported.
+
+## Early Backend Upgrades
+
+ViaLite can bridge some early-upgrade scenarios:
+
+- A Java backend moves to a newer Minecraft server version.
+- Gate can still accept the client session.
+- Via supports translation between Gate's backend-facing protocol and that
+  backend version.
+
+For Bedrock players, GeyserLite must still be able to translate the Bedrock
+session into Java and connect to Gate. ViaLite can help with the Java backend
+side after that point, but it cannot add missing Geyser Bedrock protocol
+support.
+
+## Update Chain
+
+ViaLite releases publish checksummed native artifacts. Gate consumes those
+releases as a managed dependency, so the normal chain is:
+
+```text
+ViaLite release
+  -> Gate managed dependency bump
+  -> Gate release
+  -> downstream deployments
+```
+
+Use pins only for controlled rollouts. Otherwise let Gate's managed runtime use
+the stable ViaLite release channel.
+
+## Links
+
+- [Gate compatibility guide](/guide/compatibility)
+- [GeyserLite docs](/geyserlite/)
+- [ViaLite repository](https://github.com/minekube/vialite)
+- [ViaLite releases](https://github.com/minekube/vialite/releases)
+- [ViaVersion](https://viaversion.com/)


### PR DESCRIPTION
## Summary
- add Gate website pages for `/vialite/` and `/geyserlite/`
- add nav/sidebar entries for both pages
- cross-link Bedrock and Compatibility guides to the new pages
- document topology and conservative early-upgrade guidance

## Verification
- `pnpm build` from `.web` exited 0
- existing SSR render warnings still print for `document` and `/api/extensions`; build completes successfully

## Review
- subagent reviewed and found one blocking Bedrock object-config snippet issue; fixed by adding `bedrock.enabled: true` before opening this PR