### PR TITLE
docs: clean up protocol navigation

### DIFF
--- a/.web/AGENTS.md
+++ b/.web/AGENTS.md
@@ -1,0 +1,29 @@
+# Gate Web Docs Agent Notes
+
+These instructions apply to the VitePress documentation under `.web/docs`.
+
+## Navigation
+
+- Keep the top navigation limited to broad entry points. `Bedrock` and `Lite Mode` are acceptable header entries because they are primary user-facing Gate modes.
+- Do not add lower-level runtime pages such as `GeyserLite` and `ViaLite` to the header. Put them in the Guide sidebar near the related user-facing feature.
+- Do not use emoji in sidebar labels, top navigation labels, headings, or other structural navigation text. The docs should read like professional technical documentation.
+- Keep sidebar labels short and scannable. Prefer direct nouns such as `Bedrock Support`, `ViaLite`, and `Configuration`.
+
+## Content Shape
+
+- Avoid duplicating setup guidance across Bedrock, GeyserLite, ViaLite, compatibility, and multi-version pages.
+- Use `guide/bedrock.md` for operator-facing Bedrock setup.
+- Use `/geyserlite/` to explain the managed Bedrock runtime, release policy, and relation to GeyserMC.
+- Use `guide/compatibility.md` for server implementation compatibility. Its path and title should stay aligned around compatibility.
+- Use `guide/multi-version.md` for user-facing Via-powered multi-version setup.
+- Use `/vialite/` for the lower-level ViaLite runtime, topology, and release policy.
+
+## Verification
+
+- Run the VitePress build from `.web` before opening a docs PR:
+
+  ```sh
+  pnpm build
+  ```
+
+- When changing navigation, check the rendered desktop and mobile docs navigation before merging.

--- a/.web/docs/.vitepress/config.ts
+++ b/.web/docs/.vitepress/config.ts
@@ -21,6 +21,177 @@ const communityStats = {
   githubStars: numberFromEnv(process.env.GATE_DOCS_GITHUB_STARS, 1050),
 };
 
+const guideSidebar = [
+  {
+    text: 'Getting Started',
+    items: [
+      { text: 'Introduction', link: '/guide/' },
+      { text: 'Quick Start', link: '/guide/quick-start' },
+      { text: 'Why', link: '/guide/why' },
+      { text: 'Feedback', link: '/guide/feedback' },
+    ],
+  },
+  {
+    text: 'Installation',
+    items: [
+      {
+        text: 'Prebuilt Binaries',
+        link: '/guide/install/binaries',
+      },
+      {
+        text: 'Go Install',
+        link: '/guide/install/go',
+      },
+      {
+        text: 'Docker',
+        link: '/guide/install/docker',
+      },
+      {
+        text: 'Kubernetes',
+        link: '/guide/install/kubernetes',
+      },
+    ],
+  },
+  {
+    text: 'Core Features',
+    items: [
+      {
+        text: 'Bedrock Support',
+        link: '/guide/bedrock',
+      },
+      {
+        text: 'GeyserLite',
+        link: '/geyserlite/',
+      },
+      {
+        text: 'Compatibility',
+        link: '/guide/compatibility',
+      },
+      {
+        text: 'Multi-Version Support',
+        link: '/guide/multi-version',
+      },
+      {
+        text: 'ViaLite',
+        link: '/vialite/',
+      },
+      {
+        text: 'Lite Mode',
+        link: '/guide/lite',
+      },
+      {
+        text: 'Modded Servers',
+        link: '/guide/modded-servers',
+      },
+    ],
+  },
+  {
+    text: 'Developers & API',
+    items: [
+      {
+        text: 'Developers Guide',
+        link: '/developers/',
+      },
+      {
+        text: 'API & SDKs',
+        link: '/developers/api/',
+      },
+      {
+        text: 'Events',
+        link: '/developers/events',
+      },
+      {
+        text: 'Commands',
+        link: '/developers/commands',
+      },
+      {
+        text: 'Examples',
+        link: '/developers/examples/simple-proxy',
+      },
+    ],
+  },
+  {
+    text: 'Configuration',
+    items: [
+      {
+        text: 'Configuration & Templates',
+        link: '/guide/config/',
+      },
+      {
+        text: 'Auto Reload',
+        link: '/guide/config/reload',
+      },
+      {
+        text: 'Builtin Commands',
+        link: '/guide/builtin-commands',
+      },
+      {
+        text: 'Rate Limiting',
+        link: '/guide/rate-limiting',
+      },
+      {
+        text: 'Enabling Connect',
+        link: '/guide/connect',
+      },
+      {
+        text: 'ForcedHosts Routing',
+        link: '/guide/forced-hosts',
+      },
+    ],
+  },
+  {
+    text: 'OpenTelemetry',
+    items: [
+      {
+        text: 'Overview',
+        link: '/guide/otel/',
+      },
+      {
+        text: 'Grafana',
+        items: [
+          {
+            text: 'Grafana Cloud',
+            link: '/guide/otel/grafana-cloud/',
+          },
+          {
+            text: 'Self-hosted Grafana Stack',
+            link: '/guide/otel/self-hosted/grafana-stack.md',
+          },
+          {
+            text: 'Grafana Dashboards',
+            link: '/guide/otel/self-hosted/dashboard',
+          },
+        ],
+      },
+      {
+        text: 'Honeycomb',
+        link: '/guide/otel/honeycomb/',
+      },
+      {
+        text: 'Self-hosted Jaeger',
+        link: '/guide/otel/self-hosted/jaeger',
+      },
+      {
+        text: 'FAQ',
+        link: '/guide/otel/faq/',
+      },
+    ],
+  },
+  {
+    text: 'Security',
+    items: [
+      {
+        text: 'Cybersecurity',
+        link: '/guide/security/',
+      },
+      {
+        text: 'DDoS Protection',
+        link: '/guide/security/ddos',
+      },
+    ],
+  },
+];
+
 export default defineConfig({
   title: `Gate Proxy${additionalTitle}`,
   description: ogDescription,
@@ -116,8 +287,6 @@ export default defineConfig({
     nav: [
       { text: 'Guide', link: '/guide/' },
       { text: 'Bedrock', link: '/guide/bedrock' },
-      { text: 'GeyserLite', link: '/geyserlite/' },
-      { text: 'ViaLite', link: '/vialite/' },
       { text: 'Lite Mode', link: '/guide/lite' },
       { text: 'API & SDKs', link: '/developers/api/' },
       { text: 'Config', link: '/guide/config/' },
@@ -134,164 +303,7 @@ export default defineConfig({
     ],
 
     sidebar: {
-      '/guide/': [
-        {
-          text: 'Getting Started',
-          items: [
-            { text: 'Introduction', link: '/guide/' },
-            { text: 'Quick Start', link: '/guide/quick-start' },
-            { text: 'Why', link: '/guide/why' },
-            { text: 'Feedback', link: '/guide/feedback' },
-          ],
-        },
-        {
-          text: '📦 Installation',
-          items: [
-            {
-              text: 'Prebuilt Binaries',
-              link: '/guide/install/binaries',
-            },
-            {
-              text: 'Go Install',
-              link: '/guide/install/go',
-            },
-            {
-              text: 'Docker',
-              link: '/guide/install/docker',
-            },
-            {
-              text: 'Kubernetes',
-              link: '/guide/install/kubernetes',
-            },
-          ],
-        },
-        {
-          text: 'Core Features',
-          items: [
-            {
-              text: '🎮 Bedrock Support',
-              link: '/guide/bedrock',
-            },
-            {
-              text: '⚡ Lite Mode',
-              link: '/guide/lite',
-            },
-            {
-              text: '🔧 Modded Servers',
-              link: '/guide/modded-servers',
-            },
-            {
-              text: '🔗 Compatibility',
-              link: '/guide/compatibility',
-            },
-          ],
-        },
-        {
-          text: 'Developers & API',
-          items: [
-            {
-              text: '👨‍💻 Developers Guide',
-              link: '/developers/',
-            },
-            {
-              text: '🚀 API & SDKs',
-              link: '/developers/api/',
-            },
-            {
-              text: '📚 Events',
-              link: '/developers/events',
-            },
-            {
-              text: '⚡ Commands',
-              link: '/developers/commands',
-            },
-            {
-              text: '💡 Examples',
-              link: '/developers/examples/simple-proxy',
-            },
-          ],
-        },
-        {
-          text: 'Configuration',
-          items: [
-            {
-              text: '📋 Configuration & Templates',
-              link: '/guide/config/',
-            },
-            {
-              text: '🔄 Auto Reload',
-              link: '/guide/config/reload',
-            },
-            {
-              text: '⚙️ Builtin Commands',
-              link: '/guide/builtin-commands',
-            },
-            {
-              text: '🛡️ Rate Limiting',
-              link: '/guide/rate-limiting',
-            },
-            {
-              text: '🌐 Enabling Connect',
-              link: '/guide/connect',
-            },
-            {
-              text: '🌐 ForcedHosts Routing',
-              link: '/guide/forced-hosts',
-            },
-          ],
-        },
-        {
-          text: 'OpenTelemetry',
-          items: [
-            {
-              text: 'Overview',
-              link: '/guide/otel/',
-            },
-            {
-              text: 'Grafana',
-              items: [
-                {
-                  text: 'Grafana Cloud',
-                  link: '/guide/otel/grafana-cloud/',
-                },
-                {
-                  text: 'Self-hosted Grafana Stack',
-                  link: '/guide/otel/self-hosted/grafana-stack.md',
-                },
-                {
-                  text: 'Grafana Dashboards',
-                  link: '/guide/otel/self-hosted/dashboard',
-                },
-              ],
-            },
-            {
-              text: 'Honeycomb',
-              link: '/guide/otel/honeycomb/',
-            },
-            {
-              text: 'Self-hosted Jaeger',
-              link: '/guide/otel/self-hosted/jaeger',
-            },
-            {
-              text: 'FAQ',
-              link: '/guide/otel/faq/',
-            },
-          ],
-        },
-        {
-          text: 'Security',
-          items: [
-            {
-              text: 'Cybersecurity',
-              link: '/guide/security/',
-            },
-            {
-              text: 'DDoS Protection',
-              link: '/guide/security/ddos',
-            },
-          ],
-        },
-      ],
+      '/guide/': guideSidebar,
       '/developers/': [
         {
           text: 'Developers Guide',
@@ -384,48 +396,12 @@ export default defineConfig({
           ],
         },
         {
-          text: '← Back to Guides',
+          text: 'Back to Guides',
           link: '/guide/',
         },
       ],
-      '/geyserlite/': [
-        {
-          text: 'GeyserLite',
-          items: [
-            {
-              text: 'Overview',
-              link: '/geyserlite/',
-            },
-            {
-              text: 'Gate Bedrock Guide',
-              link: '/guide/bedrock',
-            },
-            {
-              text: 'ViaLite',
-              link: '/vialite/',
-            },
-          ],
-        },
-      ],
-      '/vialite/': [
-        {
-          text: 'ViaLite',
-          items: [
-            {
-              text: 'Overview',
-              link: '/vialite/',
-            },
-            {
-              text: 'Compatibility Guide',
-              link: '/guide/compatibility',
-            },
-            {
-              text: 'GeyserLite',
-              link: '/geyserlite/',
-            },
-          ],
-        },
-      ],
+      '/geyserlite/': guideSidebar,
+      '/vialite/': guideSidebar,
       // '/config/': [
       //     {
       //         text: 'Configuration',

--- a/.web/docs/geyserlite/index.md
+++ b/.web/docs/geyserlite/index.md
@@ -1,23 +1,17 @@
 ---
 title: "GeyserLite - Managed Bedrock Runtime for Gate"
-description: "GeyserLite packages GeyserMC as native artifacts and embeddable libraries so Gate can manage Bedrock cross-play with low overhead."
+description: "GeyserLite is the managed runtime Gate uses to provide Bedrock cross-play through GeyserMC."
 ---
 
 # GeyserLite
 
-GeyserLite is Minekube's native runtime shape for
-[GeyserMC](https://geysermc.org/). Gate uses it to provide managed Bedrock
-cross-play without asking operators to run a separate JVM process.
+GeyserLite is Minekube's managed runtime packaging for
+[GeyserMC](https://geysermc.org/). Gate uses it for Bedrock cross-play without
+requiring operators to run and wire a separate Geyser process for the common
+case.
 
-For most Gate users, this is the only config needed:
-
-```yaml
-config:
-  bedrock: true
-```
-
-Gate starts the managed Bedrock runtime, generates the Floodgate key material,
-and connects GeyserLite to Gate's Java listener.
+For operator setup and configuration examples, use the
+[Bedrock support guide](/guide/bedrock).
 
 ## Topology
 
@@ -31,69 +25,45 @@ Bedrock player
 
 GeyserLite is the Bedrock ingress layer. It translates Bedrock protocol into
 Java protocol before the connection reaches Gate. Gate then owns routing,
-events, forwarding, and backend login.
+events, forwarding, Connect integration, and backend login.
 
-If ViaLite is also enabled, it sits behind Gate. That means Bedrock traffic is
+If [ViaLite](/vialite/) is enabled, it sits behind Gate. Bedrock traffic is
 already translated to Java before ViaLite handles backend version translation.
 
-## Managed Config
+## Runtime Scope
 
-Use the shorthand for the default managed setup:
+GeyserLite is responsible for the managed Geyser runtime shape:
 
-```yaml
-config:
-  bedrock: true
-```
+- Native executable for managed subprocess mode.
+- Shared library for embedded integrations where supported.
+- Container image for standalone deployments.
+- Release artifacts and checksums that Gate can consume as a managed
+  dependency.
 
-Use object form when you need to customize the listener, username format, or
-Geyser config overrides:
-
-```yaml
-config:
-  bedrock:
-    enabled: true
-    usernameFormat: ".%s"
-    geyserListenAddr: "localhost:25567"
-    managed:
-      enabled: true
-      configOverrides:
-        bedrock:
-          port: 19132
-```
-
-Gate keeps the Java-side listener private by default. Expose
-`geyserListenAddr` only when GeyserLite runs outside the same network namespace.
+Gate decides which runtime mode to use for the current platform and
+configuration. The Bedrock guide covers the Gate config surface.
 
 ## Version Policy
 
 GeyserLite tracks upstream Geyser through a pinned source ref and a managed
-release chain. When a GeyserLite release is published, Gate can consume it as a
-managed dependency.
-
-Production guidance follows upstream Geyser support:
+release chain. Production guidance follows upstream Geyser support:
 
 - If Geyser officially supports the relevant Java and Bedrock versions, Gate's
   managed Bedrock mode is the stable path.
-- If a server updates to a brand-new Java version before Geyser supports it,
-  operators should usually wait before upgrading production backends.
-- ViaLite may help early adopters when only the Java backend protocol is newer,
-  but it cannot fix unsupported Bedrock client protocols or missing Geyser
-  Bedrock-to-Java translation.
+- If a backend updates to a brand-new Java version before Geyser supports it,
+  production networks should usually wait before upgrading Bedrock-critical
+  servers.
+- Preview pins are exceptional. They should require a concrete upstream Geyser
+  preview build or PR and a clear user-impact reason.
 
-## Runtime Modes
-
-GeyserLite ships as:
-
-- Native executable for managed subprocess mode.
-- Shared library for embedded Go and Rust integrations.
-- Container image for standalone deployments.
-
-Gate chooses the managed runtime shape supported by the current platform and
-configuration.
+ViaLite may help when only the Java backend protocol is newer, but it cannot
+fix unsupported Bedrock client protocols or missing Geyser Bedrock-to-Java
+translation.
 
 ## Links
 
-- [Gate Bedrock guide](/guide/bedrock)
+- [Bedrock support guide](/guide/bedrock)
+- [ViaLite](/vialite/)
 - [GeyserLite repository](https://github.com/minekube/geyserlite)
 - [GeyserLite releases](https://github.com/minekube/geyserlite/releases)
 - [GeyserMC supported versions](https://geysermc.org/wiki/geyser/supported-versions/)

--- a/.web/docs/guide/compatibility.md
+++ b/.web/docs/guide/compatibility.md
@@ -1,46 +1,21 @@
 ---
-title: "Gate Compatibility - Supported Minecraft Versions"
-description: "Gate supports Minecraft versions 1.8 to latest, including modded servers, plugins, and cross-platform compatibility."
+title: "Gate Compatibility"
+description: "Gate compatibility notes for Minecraft server implementations, modded servers, proxy setups, Bedrock players, and multi-version networks."
 ---
 
-# Server Compatibility
+# Compatibility
 
-Gate is compatible with many Minecraft server implementations.
-The expectation is that if the server acts like vanilla, Gate will work,
-and we make special provisions for modded setups where we can.
+Gate is compatible with many Minecraft server implementations. If the server
+acts like vanilla, Gate should work, and Gate includes specific support for
+common modded setups.
 
-Gate provides excellent support for **modded servers** including Fabric and NeoForge. See our [Modded Servers Guide](modded-servers) for detailed setup instructions.
+Gate itself supports Minecraft 1.8 through the latest version supported by the
+current Gate release. For client/backend protocol translation between different
+Java Minecraft versions, see [Multi-Version Support](multi-version).
 
-Gate is compatible with Minecraft 1.8 through the latest version
-and we maintainers update Gate as soon as a new Minecraft version is released.
+## Server Implementations
 
-## Java Version Translation
-
-Gate can run managed Via translation in classic proxy mode. When `config.via.enabled`
-is true, Gate starts [ViaLite](/vialite/), keeps it on the latest stable release by default,
-and routes backend connections through Via-compatible protocol translation.
-This applies to both configured servers and API-registered servers, so dynamic
-Connect/session backends can be joined by Java clients even when the backend
-Minecraft version differs from the client version.
-
-```yaml
-config:
-  via:
-    enabled: true
-```
-
-Lite mode does not run managed Via translation. Dynamic API-registered backend
-translation is supported by the managed runtime; subprocess mode is the portable
-default, and embedded mode is available where the native shared library is
-supported. For controlled deployments, Gate still supports exact vialite version
-pins, offline mode, and local artifact paths.
-
-For Bedrock players, [GeyserLite](/geyserlite/) translates the Bedrock session
-before Gate routes to a backend. ViaLite can still help behind Gate when the
-backend Java protocol is newer, but it does not add unsupported Geyser Bedrock
-protocol support.
-
-## Paper <VPBadge>Recommended</VPBadge>
+### Paper <VPBadge>Recommended</VPBadge>
 
 We highly recommend using [Paper](https://papermc.io/) for running a server in most cases.
 Gate is tested with older and most recent versions of it.
@@ -48,14 +23,14 @@ Gate is tested with older and most recent versions of it.
 You can use `modern` forwarding (like Velocity does) if you run Paper
 1.13.2 or higher. If you use Paper 1.12.2 or lower, you can use `legacy` BungeeCord-style forwarding or the more secure `bungeeguard` [Bungeeguard](https://www.spigotmc.org/resources/bungeeguard.79601/) forwarding.
 
-## Spigot
+### Spigot
 
 Spigot is not well-tested with Gate.
 However, it is based on vanilla and as it is the base for Paper, it is relatively well-supported.
 
 Spigot does not support Gate/Velocity modern forwarding, but does support legacy BungeeCord forwarding and the more secure Bungeeguard forwarding when using the [Bungeeguard](https://www.spigotmc.org/resources/bungeeguard.79601/) plugin.
 
-## Forks of Spigot/Paper
+### Forks of Spigot/Paper
 
 Forks of Spigot are not well-tested with Gate, though they may work perfectly fine.
 
@@ -90,12 +65,24 @@ Gate has excellent compatibility with modded Minecraft servers:
 - **Legacy forwarding only** - Use BungeeCord forwarding
 - **Older versions** - May have compatibility issues
 
-For detailed setup instructions, configuration examples, and troubleshooting, see our comprehensive [Modded Servers Guide](modded-servers).
+For setup instructions, configuration examples, and troubleshooting, see the
+[Modded Servers Guide](modded-servers).
 
-## Proxy-behind-proxy setups
+## Bedrock Players
 
-These setups are only supported with [Lite mode](lite#proxy-behind-proxy) or [Connect enabled](connect)!
+Bedrock support is handled by [GeyserLite](/geyserlite/) before the player
+reaches Gate. Start with the [Bedrock support guide](bedrock) for setup.
 
-You are best advised to avoid other kinds of setups, as they can cause lots of issues.
-Most proxy-behind-proxy setups are either illogical in the first place or can be handled more
-gracefully by purpose-built solutions like [Connect](https://connect.minekube.com/) or [Lite mode](lite).
+If Bedrock players need to join Java backend servers on a different Minecraft
+version, Gate may also use [Multi-Version Support](multi-version) behind Gate,
+after GeyserLite has translated the Bedrock session into Java protocol.
+
+## Proxy-Behind-Proxy Setups
+
+These setups are only supported with [Lite mode](lite#proxy-behind-proxy) or
+[Connect enabled](connect).
+
+Avoid other proxy-behind-proxy setups where possible. They often introduce
+ambiguous authentication and forwarding behavior that is better handled by
+purpose-built solutions like [Connect](https://connect.minekube.com/) or
+[Lite mode](lite).

--- a/.web/docs/guide/multi-version.md
+++ b/.web/docs/guide/multi-version.md
@@ -1,0 +1,62 @@
+---
+title: "Gate Multi-Version Support"
+description: "Use Gate's managed Via support to let Java clients join backend servers across different Minecraft protocol versions."
+---
+
+# Multi-Version Support
+
+Gate classic can route backend connections through managed Via-powered Java
+protocol translation. This lets clients join backend servers even when the
+client and backend Minecraft versions differ.
+
+Enable it with:
+
+```yaml
+config:
+  via:
+    enabled: true
+```
+
+Gate starts [ViaLite](/vialite/) and routes backend connections through it.
+This applies to configured servers and API-registered servers, so dynamic
+Connect/session backends can use the same version translation path.
+
+## Topology
+
+```text
+Java player
+  -> Gate classic
+  -> ViaLite
+  -> backend server
+
+Bedrock player
+  -> GeyserLite
+  -> Gate classic
+  -> ViaLite
+  -> backend server
+```
+
+ViaLite sits behind Gate. Gate accepts the player, handles routing and events,
+and then ViaLite translates the backend-facing Java protocol where needed.
+
+## Bedrock Players
+
+[GeyserLite](/geyserlite/) translates Bedrock sessions into Java protocol
+before the player reaches Gate. ViaLite can then help with Java backend version
+differences behind Gate.
+
+ViaLite does not replace Geyser protocol support. If Geyser does not support a
+new Bedrock or Java version yet, production networks should usually wait for
+official upstream Geyser support before upgrading Bedrock-critical backends.
+
+## Gate Lite
+
+Gate Lite raw-pipes backend traffic after the initial handshake so backend
+servers keep authentication ownership. Managed Via translation needs to decode
+and rewrite packets after login, so it belongs to Gate classic backend
+connections, not Gate Lite.
+
+## Runtime Details
+
+For runtime modes, platform support, pins, offline deployment, and release
+policy, see [ViaLite](/vialite/).

--- a/.web/docs/index.md
+++ b/.web/docs/index.md
@@ -56,6 +56,6 @@ features:
     details:
       Gate supports Minecraft server versions 1.8 to latest and is constantly updated to support
       new versions.
-    link: /guide/compatibility
-    linkText: Compatibility
+    link: /guide/multi-version
+    linkText: Multi-Version Support
 ---

--- a/.web/docs/vialite/index.md
+++ b/.web/docs/vialite/index.md
@@ -9,16 +9,8 @@ ViaLite is Minekube's managed Via runtime for Gate classic. It lets Gate route
 backend connections through Via-powered Java protocol translation while Gate
 keeps ownership of authentication, events, routing, Connect, and backend login.
 
-Enable it with:
-
-```yaml
-config:
-  via:
-    enabled: true
-```
-
-Gate starts ViaLite and automatically routes configured and API-registered
-classic backend servers through it.
+For user-facing setup, start with [Multi-Version Support](/guide/multi-version).
+This page covers the runtime shape behind that feature.
 
 ## Topology
 
@@ -45,33 +37,15 @@ then raw-pipes bytes so backend servers keep authentication ownership. ViaLite
 must decode and rewrite packets after login, so it belongs to Gate classic
 backend connections instead.
 
-## Config
+## Runtime Configuration
 
-The default path uses the latest stable ViaLite release:
-
-```yaml
-config:
-  via:
-    enabled: true
-```
-
-Operators can pin or override the runtime when they need controlled rollout or
-offline deployment:
-
-```yaml
-config:
-  via:
-    enabled: true
-    mode: subprocess
-    version: v0.3.0
-    # mirror: https://example.com/vialite/releases
-    # binaryPath: /opt/vialite/vialite
-    # libraryPath: /opt/vialite/libvialite.so
-    # offline: true
-```
+By default, Gate uses the latest stable ViaLite release for managed
+multi-version support. Operators can still pin or override the runtime when
+they need controlled rollout or offline deployment.
 
 Subprocess mode is the portable default. Embedded mode is available where the
-native shared library is supported.
+native shared library is supported. See
+[Multi-Version Support](/guide/multi-version) for the basic enablement config.
 
 ## Early Backend Upgrades
 
@@ -104,6 +78,7 @@ the stable ViaLite release channel.
 
 ## Links
 
+- [Multi-Version Support](/guide/multi-version)
 - [Gate compatibility guide](/guide/compatibility)
 - [GeyserLite docs](/geyserlite/)
 - [ViaLite repository](https://github.com/minekube/vialite)


### PR DESCRIPTION
## Summary
- remove emoji/sidebar-symbol labels from the docs sidebar and add .web/AGENTS.md guidance to keep navigation professional
- keep Bedrock and Lite Mode in the top nav while moving GeyserLite/ViaLite into the Guide/Core Features sidebar
- split Compatibility from a new Multi-Version Support page, with Via setup living on Multi-Version Support and runtime details on ViaLite
- tighten GeyserLite/ViaLite pages to avoid duplicate setup snippets

## Verification
- pnpm test
- pnpm build (exits 0; existing VitePress SSR warnings for document/Survey and /api/extensions still print)
- generated VitePress site data confirms top nav/sidebar labels and no emoji labels
- subagent review completed; initial duplicate-snippet and AGENTS wording findings fixed; final review reported no findings

Browser note: no in-app browser target was available in this session, so rendered nav was verified from generated VitePress site data instead of screenshot inspection.