### PR TITLE
fix(java): ignore untracked modern resource pack responses

### DIFF
--- a/pkg/edition/java/proxy/internal/resourcepack/handler_modern.go
+++ b/pkg/edition/java/proxy/internal/resourcepack/handler_modern.go
@@ -149,16 +149,18 @@ func (m *modernHandler) OnResourcePackResponse(bundle *ResponseBundle) (bool, er
 		}
 	}
 
-	e := newPlayerResourcePackStatusEvent(m.player, bundle.Status, queued.ID, *queued)
-	event.FireParallel(m.eventMgr, e, func(e *PlayerResourcePackStatusEvent) {
-		if e.Status() == packet.DeclinedResourcePackResponseStatus &&
-			e.PackInfo().ShouldForce &&
-			!e.OverwriteKick() {
-			m.player.Disconnect(&component.Translation{
-				Key: "multiplayer.requiredTexturePrompt.disconnect",
-			})
-		}
-	})
+	if queued != nil {
+		e := newPlayerResourcePackStatusEvent(m.player, bundle.Status, id, *queued)
+		event.FireParallel(m.eventMgr, e, func(e *PlayerResourcePackStatusEvent) {
+			if e.Status() == packet.DeclinedResourcePackResponseStatus &&
+				e.PackInfo().ShouldForce &&
+				!e.OverwriteKick() {
+				m.player.Disconnect(&component.Translation{
+					Key: "multiplayer.requiredTexturePrompt.disconnect",
+				})
+			}
+		})
+	}
 
 	switch bundle.Status {
 	// The player has accepted the resource pack and will proceed to download it.

--- a/pkg/edition/java/proxy/internal/resourcepack/handler_modern_test.go
+++ b/pkg/edition/java/proxy/internal/resourcepack/handler_modern_test.go
@@ -1,0 +1,38 @@
+package resourcepack
+
+import (
+	"testing"
+
+	"github.com/robinbraemer/event"
+	"go.minekube.com/common/minecraft/component"
+	"go.minekube.com/gate/pkg/edition/java/proto/packet"
+	"go.minekube.com/gate/pkg/edition/java/proto/state"
+	"go.minekube.com/gate/pkg/edition/java/proto/version"
+	"go.minekube.com/gate/pkg/gate/proto"
+	"go.minekube.com/gate/pkg/util/uuid"
+)
+
+type testPlayer struct{}
+
+func (testPlayer) ID() uuid.UUID                          { return uuid.New() }
+func (testPlayer) WritePacket(proto.Packet) error         { return nil }
+func (testPlayer) BundleHandler() *BundleDelimiterHandler { return nil }
+func (testPlayer) State() *state.Registry                 { return state.Play }
+func (testPlayer) Protocol() proto.Protocol               { return version.Minecraft_1_20_3.Protocol }
+func (testPlayer) BackendInFlight() proto.PacketWriter    { return nil }
+func (testPlayer) Disconnect(component.Component)         {}
+
+func TestModernHandlerIgnoresUntrackedResourcePackResponse(t *testing.T) {
+	h := newModernHandler(testPlayer{}, event.Nop)
+
+	handled, err := h.OnResourcePackResponse(&ResponseBundle{
+		ID:     uuid.New(),
+		Status: packet.SuccessfulResourcePackResponseStatus,
+	})
+	if err != nil {
+		t.Fatalf("OnResourcePackResponse returned error: %v", err)
+	}
+	if handled {
+		t.Fatal("OnResourcePackResponse handled untracked response")
+	}
+}


### PR DESCRIPTION
## Summary
- avoid dereferencing a missing queued resource pack in the modern resource-pack response handler
- keep forwarding/handling behavior unchanged for untracked responses
- add regression coverage for an untracked successful response

## Production evidence
Connect prod logs showed players joining endpoints successfully, then Gate recovered a panic in the client packet read loop:

`resourcepack/handler_modern.go:152 runtime error: invalid memory address or nil pointer dereference`

That path can happen when the client sends a modern resource-pack response for an ID Gate no longer has in `outstandingPacks`.

## Tests
- `go test -timeout 30s ./pkg/edition/java/proxy/internal/resourcepack`
- `go test -timeout 60s ./pkg/edition/java/proxy -run 'Test.*ResourcePack|TestDecoder_StatusResponse|Test.*Status|Test.*Forge|Test.*Vialite'`