### PR TITLE
fix(java): log status response write failures

### DIFF
--- a/pkg/edition/java/proxy/internal/resourcepack/handler_modern.go
+++ b/pkg/edition/java/proxy/internal/resourcepack/handler_modern.go
@@ -149,16 +149,18 @@ func (m *modernHandler) OnResourcePackResponse(bundle *ResponseBundle) (bool, er
 		}
 	}
 
-	e := newPlayerResourcePackStatusEvent(m.player, bundle.Status, queued.ID, *queued)
-	event.FireParallel(m.eventMgr, e, func(e *PlayerResourcePackStatusEvent) {
-		if e.Status() == packet.DeclinedResourcePackResponseStatus &&
-			e.PackInfo().ShouldForce &&
-			!e.OverwriteKick() {
-			m.player.Disconnect(&component.Translation{
-				Key: "multiplayer.requiredTexturePrompt.disconnect",
-			})
-		}
-	})
+	if queued != nil {
+		e := newPlayerResourcePackStatusEvent(m.player, bundle.Status, id, *queued)
+		event.FireParallel(m.eventMgr, e, func(e *PlayerResourcePackStatusEvent) {
+			if e.Status() == packet.DeclinedResourcePackResponseStatus &&
+				e.PackInfo().ShouldForce &&
+				!e.OverwriteKick() {
+				m.player.Disconnect(&component.Translation{
+					Key: "multiplayer.requiredTexturePrompt.disconnect",
+				})
+			}
+		})
+	}
 
 	switch bundle.Status {
 	// The player has accepted the resource pack and will proceed to download it.

--- a/pkg/edition/java/proxy/internal/resourcepack/handler_modern_test.go
+++ b/pkg/edition/java/proxy/internal/resourcepack/handler_modern_test.go
@@ -1,0 +1,38 @@
+package resourcepack
+
+import (
+	"testing"
+
+	"github.com/robinbraemer/event"
+	"go.minekube.com/common/minecraft/component"
+	"go.minekube.com/gate/pkg/edition/java/proto/packet"
+	"go.minekube.com/gate/pkg/edition/java/proto/state"
+	"go.minekube.com/gate/pkg/edition/java/proto/version"
+	"go.minekube.com/gate/pkg/gate/proto"
+	"go.minekube.com/gate/pkg/util/uuid"
+)
+
+type testPlayer struct{}
+
+func (testPlayer) ID() uuid.UUID                          { return uuid.New() }
+func (testPlayer) WritePacket(proto.Packet) error         { return nil }
+func (testPlayer) BundleHandler() *BundleDelimiterHandler { return nil }
+func (testPlayer) State() *state.Registry                 { return state.Play }
+func (testPlayer) Protocol() proto.Protocol               { return version.Minecraft_1_20_3.Protocol }
+func (testPlayer) BackendInFlight() proto.PacketWriter    { return nil }
+func (testPlayer) Disconnect(component.Component)         {}
+
+func TestModernHandlerIgnoresUntrackedResourcePackResponse(t *testing.T) {
+	h := newModernHandler(testPlayer{}, event.Nop)
+
+	handled, err := h.OnResourcePackResponse(&ResponseBundle{
+		ID:     uuid.New(),
+		Status: packet.SuccessfulResourcePackResponseStatus,
+	})
+	if err != nil {
+		t.Fatalf("OnResourcePackResponse returned error: %v", err)
+	}
+	if handled {
+		t.Fatal("OnResourcePackResponse handled untracked response")
+	}
+}

--- a/pkg/edition/java/proxy/session_status.go
+++ b/pkg/edition/java/proxy/session_status.go
@@ -127,7 +127,7 @@ func (h *statusSessionHandler) handleStatusRequest(pc *proto.PacketContext) {
 		}
 		if !h.eventMgr.HasSubscriber(e) {
 			// Fast path: No event handler, just send response
-			_ = h.conn.WritePacket(res)
+			h.writeStatusResponse(log, res)
 			return
 		}
 		// Need to unmarshal status response to ping struct for event handlers
@@ -147,6 +147,7 @@ func (h *statusSessionHandler) handleStatusRequest(pc *proto.PacketContext) {
 		return
 	}
 	if !h.inbound.Active() {
+		log.Info("status response not sent because inbound is inactive")
 		return
 	}
 
@@ -156,9 +157,17 @@ func (h *statusSessionHandler) handleStatusRequest(pc *proto.PacketContext) {
 		log.Error(err, "error marshaling ping response to json")
 		return
 	}
-	_ = h.conn.WritePacket(&packet.StatusResponse{
+	h.writeStatusResponse(log, &packet.StatusResponse{
 		Status: string(response),
 	})
+}
+
+func (h *statusSessionHandler) writeStatusResponse(log logr.Logger, response *packet.StatusResponse) {
+	if err := h.conn.WritePacket(response); err != nil {
+		log.Info("error writing status response", "error", err)
+		return
+	}
+	log.V(1).Info("sent status response")
 }
 
 func (h *statusSessionHandler) handleStatusPing(p *proto.PacketContext) {


### PR DESCRIPTION
## Summary
- log errors when Java status responses fail to write
- log when status responses are skipped because the inbound connection is inactive
- keep this on the v0.68.14 hotfix line used by Connect production

## Tests
- go test ./pkg/edition/java/proxy