### PR TITLE
Fix config plugin message queuing during backend login

### DIFF
--- a/pkg/edition/java/proxy/session_backend_login.go
+++ b/pkg/edition/java/proxy/session_backend_login.go
@@ -309,6 +309,12 @@ func (b *backendLoginSessionHandler) handleServerLoginSuccess() {
 		}
 
 		ash := player.ActiveSessionHandler()
+		if csh, ok := ash.(*clientConfigSessionHandler); ok {
+			if err = csh.flushQueuedPluginMessagesTo(b.serverConn); err != nil {
+				fail(err)
+				return
+			}
+		}
 		csh, ok := ash.(*clientPlaySessionHandler)
 		if ok {
 			serverMc.SetAutoReading(false)

--- a/pkg/edition/java/proxy/session_backend_play_test.go
+++ b/pkg/edition/java/proxy/session_backend_play_test.go
@@ -55,6 +55,8 @@ func TestBackendPlayRegisterForwardsToPlayer(t *testing.T) {
 type testMinecraftConn struct {
 	writtenPackets []proto.Packet
 	connType       phase.ConnectionType
+	activeHandler  netmc.SessionHandler
+	writer         netmc.Writer
 }
 
 func (t *testMinecraftConn) Context() context.Context { return context.Background() }
@@ -70,16 +72,19 @@ func (t *testMinecraftConn) Type() phase.ConnectionType {
 	return phase.Vanilla
 }
 func (t *testMinecraftConn) SetType(ct phase.ConnectionType)            { t.connType = ct }
-func (t *testMinecraftConn) ActiveSessionHandler() netmc.SessionHandler { return nil }
-func (t *testMinecraftConn) SetActiveSessionHandler(*state.Registry, netmc.SessionHandler) {
+func (t *testMinecraftConn) ActiveSessionHandler() netmc.SessionHandler { return t.activeHandler }
+func (t *testMinecraftConn) SetActiveSessionHandler(_ *state.Registry, handler netmc.SessionHandler) {
+	t.activeHandler = handler
 }
 func (t *testMinecraftConn) SwitchSessionHandler(*state.Registry) bool { return true }
 func (t *testMinecraftConn) AddSessionHandler(*state.Registry, netmc.SessionHandler) {
 }
-func (t *testMinecraftConn) SetAutoReading(bool)               {}
-func (t *testMinecraftConn) SetProtocol(proto.Protocol)        {}
-func (t *testMinecraftConn) SetState(*state.Registry)          {}
-func (t *testMinecraftConn) SetOutboundState(*state.Registry)  {}
+func (t *testMinecraftConn) SetAutoReading(bool)        {}
+func (t *testMinecraftConn) SetProtocol(proto.Protocol) {}
+func (t *testMinecraftConn) SetState(*state.Registry)   {}
+func (t *testMinecraftConn) SetOutboundState(s *state.Registry) {
+	t.Writer().SetState(s)
+}
 func (t *testMinecraftConn) SetCompressionThreshold(int) error { return nil }
 func (t *testMinecraftConn) EnableEncryption([]byte) error     { return nil }
 func (t *testMinecraftConn) WritePacket(packet proto.Packet) error {
@@ -94,7 +99,25 @@ func (t *testMinecraftConn) BufferPacket(packet proto.Packet) error {
 func (t *testMinecraftConn) BufferPayload([]byte) error { return nil }
 func (t *testMinecraftConn) Flush() error               { return nil }
 func (t *testMinecraftConn) Reader() netmc.Reader       { return nil }
-func (t *testMinecraftConn) Writer() netmc.Writer       { return nil }
-func (t *testMinecraftConn) EnablePlayPacketQueue()     {}
+func (t *testMinecraftConn) Writer() netmc.Writer {
+	if t.writer == nil {
+		t.writer = &testWriter{}
+	}
+	return t.writer
+}
+func (t *testMinecraftConn) EnablePlayPacketQueue() {}
 
 var _ netmc.MinecraftConn = (*testMinecraftConn)(nil)
+
+type testWriter struct {
+	state *state.Registry
+}
+
+func (t *testWriter) WritePacket(proto.Packet) (int, error) { return 0, nil }
+func (t *testWriter) Write([]byte) (int, error)             { return 0, nil }
+func (t *testWriter) Flush() error                          { return nil }
+func (t *testWriter) SetProtocol(proto.Protocol)            {}
+func (t *testWriter) SetState(s *state.Registry)            { t.state = s }
+func (t *testWriter) SetCompressionThreshold(int) error     { return nil }
+func (t *testWriter) EnableEncryption([]byte) error         { return nil }
+func (t *testWriter) Direction() proto.Direction            { return proto.ClientBound }

--- a/pkg/edition/java/proxy/session_client_config.go
+++ b/pkg/edition/java/proxy/session_client_config.go
@@ -2,9 +2,13 @@ package proxy
 
 import (
 	"bytes"
+	"fmt"
+	"sync"
 
+	"github.com/gammazero/deque"
 	"github.com/go-logr/logr"
 	"github.com/robinbraemer/event"
+	"go.minekube.com/common/minecraft/component"
 	"go.minekube.com/gate/pkg/edition/java/netmc"
 	"go.minekube.com/gate/pkg/edition/java/proto/packet"
 	"go.minekube.com/gate/pkg/edition/java/proto/packet/config"
@@ -22,9 +26,17 @@ type clientConfigSessionHandler struct {
 	player *connectedPlayer
 	log    logr.Logger
 
-	brandChannel string
-
 	configSwitchDone future.Future[any]
+
+	mu struct {
+		sync.Mutex
+		pluginMessages           deque.Deque[*plugin.Message]
+		pluginMessagesBytes      int
+		pluginMessagesOverflowed bool
+		brandChannel             string
+		brandForwardedServer     *serverConnection
+		readyServer              *serverConnection
+	}
 
 	nopSessionHandler
 }
@@ -80,20 +92,13 @@ func (h *clientConfigSessionHandler) HandlePacket(pc *proto.PacketContext) {
 
 // handleBackendFinishUpdate handles the backend finishing the config stage.
 func (h *clientConfigSessionHandler) handleBackendFinishUpdate(serverConn *serverConnection, p *config.FinishedUpdate) *future.Future[any] {
-	smc, ok := serverConn.ensureConnected()
+	_, ok := serverConn.ensureConnected()
 	if !ok {
 		return nil
 	}
 	brand := serverConn.player.ClientBrand()
-	if brand == "" && h.brandChannel != "" {
-		buf := new(bytes.Buffer)
-		_ = util.WriteString(buf, brand)
-
-		brandPacket := &plugin.Message{
-			Channel: h.brandChannel,
-			Data:    buf.Bytes(),
-		}
-		_ = smc.WritePacket(brandPacket)
+	if brand != "" {
+		h.writeBrandPacketTo(serverConn, brand)
 	}
 
 	if err := h.player.WritePacket(p); err != nil {
@@ -115,23 +120,29 @@ func handleResourcePackResponse(p *packet.ResourcePackResponse, handler resource
 }
 
 func (h *clientConfigSessionHandler) handlePluginMessage(p *plugin.Message) {
-	serverConn := h.player.connectionInFlight()
-	if serverConn == nil {
-		return
-	}
-
 	if plugin.McBrand(p) {
 		brand := plugin.ReadBrandMessage(p.Data)
-		h.brandChannel = p.Channel
+		h.player.setClientBrand(brand)
+		readyServer := h.setBrandChannel(p.Channel)
 		h.event().FireParallel(&PlayerClientBrandEvent{
 			player: h.player,
 			brand:  brand,
 		})
 		// Client sends `minecraft:brand` packet immediately after Login,
 		// but at this time the backend server may not be ready
+		if readyServer != nil {
+			h.writeBrandPacketTo(readyServer, brand)
+		}
+		return
 	} else if bungeecord.IsBungeeCordMessage(p) {
 		return
+	} else if h.enqueuePluginMessage(h.player.connectionInFlightOrConnectedServer(), p) {
+		return
 	} else {
+		serverConn := h.player.connectionInFlightOrConnectedServer()
+		if serverConn == nil {
+			return
+		}
 		id, ok := h.player.proxy.ChannelRegistrar().FromID(p.Channel)
 		if !ok {
 			smc, ok := serverConn.ensureConnected()
@@ -164,8 +175,127 @@ func (h *clientConfigSessionHandler) handlePluginMessage(p *plugin.Message) {
 	}
 }
 
+func (h *clientConfigSessionHandler) setBrandChannel(channel string) *serverConnection {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.mu.brandChannel = channel
+	return h.mu.readyServer
+}
+
+func (h *clientConfigSessionHandler) brandPacket(brand string) *plugin.Message {
+	h.mu.Lock()
+	channel := h.mu.brandChannel
+	h.mu.Unlock()
+	if channel == "" {
+		return nil
+	}
+	buf := new(bytes.Buffer)
+	_ = util.WriteString(buf, brand)
+	return &plugin.Message{
+		Channel: channel,
+		Data:    buf.Bytes(),
+	}
+}
+
+func (h *clientConfigSessionHandler) writeBrandPacketTo(serverConn *serverConnection, brand string) {
+	h.mu.Lock()
+	if h.mu.brandForwardedServer == serverConn {
+		h.mu.Unlock()
+		return
+	}
+	h.mu.Unlock()
+
+	brandPacket := h.brandPacket(brand)
+	if brandPacket == nil {
+		return
+	}
+	smc, ok := serverConn.ensureConnected()
+	if !ok {
+		return
+	}
+	if err := smc.WritePacket(brandPacket); err != nil {
+		return
+	}
+
+	h.mu.Lock()
+	h.mu.brandForwardedServer = serverConn
+	h.mu.Unlock()
+}
+
+// enqueuePluginMessage returns true when the message was handled by the queue
+// path, including overflow rejection. It returns false only once the backend is
+// ready for direct config plugin messages.
+func (h *clientConfigSessionHandler) enqueuePluginMessage(target *serverConnection, msg *plugin.Message) bool {
+	h.mu.Lock()
+	if target != nil && h.mu.readyServer == target {
+		h.mu.Unlock()
+		return false
+	}
+	if h.mu.pluginMessagesOverflowed {
+		h.mu.Unlock()
+		return true
+	}
+	newBytes := h.mu.pluginMessagesBytes + len(msg.Data)
+	newCount := h.mu.pluginMessages.Len() + 1
+	if newBytes > maxQueuedLoginPluginMessageBytes || newCount > maxQueuedLoginPluginMessages {
+		h.mu.pluginMessagesOverflowed = true
+		h.mu.pluginMessages.Clear()
+		h.mu.pluginMessagesBytes = 0
+		h.mu.Unlock()
+		h.log.Info("disconnecting player: pre-backend config plugin message queue exceeded its limits",
+			"messages", newCount, "bytes", newBytes)
+		h.player.Disconnect(&component.Text{
+			Content: "Too many plugin messages were sent before joining a server",
+		})
+		return true
+	}
+	h.mu.pluginMessages.PushBack(&plugin.Message{
+		Channel: msg.Channel,
+		Data:    append([]byte(nil), msg.Data...),
+	})
+	h.mu.pluginMessagesBytes = newBytes
+	h.mu.Unlock()
+	return true
+}
+
+func (h *clientConfigSessionHandler) flushQueuedPluginMessagesTo(serverConn *serverConnection) error {
+	smc, ok := serverConn.ensureConnected()
+	if !ok {
+		return netmc.ErrClosedConn
+	}
+
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if h.mu.readyServer == serverConn {
+		return nil
+	}
+
+	h.mu.pluginMessagesBytes = 0
+	n := h.mu.pluginMessages.Len()
+	msgs := make([]*plugin.Message, 0, n)
+	for h.mu.pluginMessages.Len() != 0 {
+		msgs = append(msgs, h.mu.pluginMessages.PopFront())
+	}
+	for _, pm := range msgs {
+		if err := smc.BufferPacket(pm); err != nil {
+			return fmt.Errorf("error buffering queued config plugin message %q: %w", pm.Channel, err)
+		}
+	}
+	if n != 0 {
+		if err := smc.Flush(); err != nil {
+			return err
+		}
+	}
+	h.mu.readyServer = serverConn
+	return nil
+}
+
 func (h *clientConfigSessionHandler) handleKnownPacks(p *config.KnownPacks, pc *proto.PacketContext) {
-	smc, ok := h.player.connectionInFlightOrConnectedServer().ensureConnected()
+	serverConn := h.player.connectionInFlightOrConnectedServer()
+	if serverConn == nil {
+		return
+	}
+	smc, ok := serverConn.ensureConnected()
 	if ok {
 		_ = smc.WritePacket(p)
 	}

--- a/pkg/edition/java/proxy/session_client_config_test.go
+++ b/pkg/edition/java/proxy/session_client_config_test.go
@@ -1,0 +1,120 @@
+package proxy
+
+import (
+	"net"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/robinbraemer/event"
+	"go.minekube.com/gate/pkg/edition/java/proto/packet/config"
+	"go.minekube.com/gate/pkg/edition/java/proto/packet/plugin"
+	"go.minekube.com/gate/pkg/edition/java/proto/state"
+	"go.minekube.com/gate/pkg/edition/java/proxy/message"
+)
+
+func newTestConfigHandler(t *testing.T) (*clientConfigSessionHandler, *connectedPlayer, *serverConnection, *testMinecraftConn) {
+	t.Helper()
+
+	clientConn := &testMinecraftConn{}
+	backendConn := &testMinecraftConn{}
+	player := &connectedPlayer{
+		MinecraftConn: clientConn,
+		log:           logr.Discard(),
+	}
+	proxy := &Proxy{
+		event:            event.Nop,
+		channelRegistrar: message.NewChannelRegistrar(),
+	}
+	server := newRegisteredServer(NewServerInfo("purpur", &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 25565}))
+	serverConn := newServerConnection(server, nil, player)
+	serverConn.connection = backendConn
+	player.sessionHandlerDeps = &sessionHandlerDeps{proxy: proxy}
+
+	return newClientConfigSessionHandler(player), player, serverConn, backendConn
+}
+
+func TestClientConfigQueuesPluginMessagesUntilBackendReady(t *testing.T) {
+	handler, player, serverConn, backendConn := newTestConfigHandler(t)
+
+	player.mu.Lock()
+	player.connInFlight = serverConn
+	player.mu.Unlock()
+
+	handler.handlePluginMessage(&plugin.Message{
+		Channel: "minecraft:register",
+		Data:    []byte("purpur:config"),
+	})
+
+	if got := len(backendConn.writtenPackets); got != 0 {
+		t.Fatalf("plugin message was written before backend config was ready: got %d packets", got)
+	}
+
+	if err := handler.flushQueuedPluginMessagesTo(serverConn); err != nil {
+		t.Fatalf("flush queued config plugin messages: %v", err)
+	}
+
+	if got := len(backendConn.writtenPackets); got != 1 {
+		t.Fatalf("queued plugin messages written to backend = %d, want 1", got)
+	}
+	got, ok := backendConn.writtenPackets[0].(*plugin.Message)
+	if !ok {
+		t.Fatalf("queued packet type = %T, want *plugin.Message", backendConn.writtenPackets[0])
+	}
+	if got.Channel != "minecraft:register" || string(got.Data) != "purpur:config" {
+		t.Fatalf("queued packet = %q %q, want minecraft:register purpur:config", got.Channel, string(got.Data))
+	}
+}
+
+func TestClientConfigForwardsPluginMessagesAfterBackendReady(t *testing.T) {
+	handler, player, serverConn, backendConn := newTestConfigHandler(t)
+
+	player.mu.Lock()
+	player.connInFlight = serverConn
+	player.mu.Unlock()
+
+	if err := handler.flushQueuedPluginMessagesTo(serverConn); err != nil {
+		t.Fatalf("mark backend ready: %v", err)
+	}
+
+	handler.handlePluginMessage(&plugin.Message{
+		Channel: "minecraft:register",
+		Data:    []byte("purpur:ready"),
+	})
+
+	if got := len(backendConn.writtenPackets); got != 1 {
+		t.Fatalf("direct plugin messages written to backend = %d, want 1", got)
+	}
+	got := backendConn.writtenPackets[0].(*plugin.Message)
+	if got.Channel != "minecraft:register" || string(got.Data) != "purpur:ready" {
+		t.Fatalf("direct packet = %q %q, want minecraft:register purpur:ready", got.Channel, string(got.Data))
+	}
+}
+
+func TestClientConfigBackendFinishReplaysClientBrandAndSwitchesOnlyOutboundState(t *testing.T) {
+	handler, player, serverConn, backendConn := newTestConfigHandler(t)
+	player.setClientBrand("vanilla")
+	handler.handlePluginMessage(&plugin.Message{
+		Channel: plugin.BrandChannel,
+		Data:    []byte{0x07, 'v', 'a', 'n', 'i', 'l', 'l', 'a'},
+	})
+
+	done := handler.handleBackendFinishUpdate(serverConn, &config.FinishedUpdate{})
+	if done == nil {
+		t.Fatal("handleBackendFinishUpdate returned nil future")
+	}
+
+	if got := len(backendConn.writtenPackets); got != 1 {
+		t.Fatalf("backend packets = %d, want replayed brand only", got)
+	}
+	brand, ok := backendConn.writtenPackets[0].(*plugin.Message)
+	if !ok {
+		t.Fatalf("backend packet type = %T, want *plugin.Message", backendConn.writtenPackets[0])
+	}
+	if brand.Channel != plugin.BrandChannel || string(plugin.ReadBrandMessage(brand.Data)) != "vanilla" {
+		t.Fatalf("brand replay = %q %q, want minecraft:brand vanilla", brand.Channel, plugin.ReadBrandMessage(brand.Data))
+	}
+	writer := player.Writer().(*testWriter)
+	if writer.state != state.Play {
+		t.Fatalf("client outbound state = %v, want Play", writer.state)
+	}
+}


### PR DESCRIPTION
## Summary
- Queue client config-state plugin messages until the backend has completed login and entered config, then flush them before backend config processing continues.
- Preserve and replay client brand correctly for config transitions, including the previously inverted empty-brand check.
- Add focused regression coverage for pre-backend config plugin message queuing, direct forwarding after readiness, and brand replay/outbound state switching.

Fixes minekube/moxy#356

## Test Plan
- go test ./pkg/edition/java/proxy -run 'TestClientConfig(QueuesPluginMessagesUntilBackendReady|ForwardsPluginMessagesAfterBackendReady|BackendFinishReplaysClientBrandAndSwitchesOnlyOutboundState)' -count=1
- go test ./pkg/edition/java/proxy -count=1
- go test ./pkg/edition/java/proto/... ./pkg/edition/java/config ./pkg/edition/java/netmc -count=1
- go test ./pkg/edition/java/... -count=1
- go test ./... -count=1
- git diff --check

## Notes
- GitHub issue minekube/moxy#356 has no comments; the linked Discord thread was not available from the local CLI context, so the regression is the smallest local unit/state-machine reproduction of the described reconfiguration hang.
