### PR TITLE
Stop Gate self-renovate release loop

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -33,6 +33,16 @@
       ],
       "matchCurrentVersion": "!/^0/",
       "automerge": true
+    },
+    {
+      "description": "Gate's example modules replace the root module locally, so version bumps of Gate itself only create release loops.",
+      "matchManagers": [
+        "gomod"
+      ],
+      "matchPackageNames": [
+        "go.minekube.com/gate"
+      ],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Disable Renovate updates for Gate own Go module, `go.minekube.com/gate`, in gomod-managed files.
- This prevents example modules with a local `replace go.minekube.com/gate => ../../../` from getting bumped after each Gate release and triggering another release-please cycle.

## Verification
- Confirmed with `jq` that `renovate.json` now has a disabled gomod package rule for `go.minekube.com/gate`.
- `npm exec --yes --package=renovate -- renovate-config-validator renovate.json`