### PR TITLE
fix(java): reduce status response log churn

### DIFF
--- a/pkg/edition/java/proxy/session_status.go
+++ b/pkg/edition/java/proxy/session_status.go
@@ -2,7 +2,11 @@ package proxy
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
+	"net"
+	"syscall"
 
 	"github.com/go-logr/logr"
 	"go.minekube.com/gate/pkg/edition/java/forge/modinfo"
@@ -147,7 +151,7 @@ func (h *statusSessionHandler) handleStatusRequest(pc *proto.PacketContext) {
 		return
 	}
 	if !h.inbound.Active() {
-		log.Info("status response not sent because inbound is inactive")
+		log.V(1).Info("status response not sent because inbound is inactive")
 		return
 	}
 
@@ -164,10 +168,19 @@ func (h *statusSessionHandler) handleStatusRequest(pc *proto.PacketContext) {
 
 func (h *statusSessionHandler) writeStatusResponse(log logr.Logger, response *packet.StatusResponse) {
 	if err := h.conn.WritePacket(response); err != nil {
-		log.Info("error writing status response", "error", err)
+		statusResponseWriteErrorLog(log, err).Info("error writing status response", "error", err)
 		return
 	}
 	log.V(1).Info("sent status response")
+}
+
+func statusResponseWriteErrorLog(log logr.Logger, err error) logr.Logger {
+	var netErr net.Error
+	if errors.Is(err, netmc.ErrClosedConn) || errors.Is(err, io.ErrClosedPipe) ||
+		errs.IsConnClosedErr(err) || errors.Is(err, syscall.EPIPE) || errors.As(err, &netErr) {
+		return log.V(1)
+	}
+	return log
 }
 
 func (h *statusSessionHandler) handleStatusPing(p *proto.PacketContext) {

--- a/pkg/edition/java/proxy/session_status_test.go
+++ b/pkg/edition/java/proxy/session_status_test.go
@@ -1,0 +1,208 @@
+package proxy
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"strings"
+	"sync"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/go-logr/logr/funcr"
+	"github.com/robinbraemer/event"
+	"go.minekube.com/gate/pkg/edition/java/netmc"
+	"go.minekube.com/gate/pkg/edition/java/proto/packet"
+	"go.minekube.com/gate/pkg/edition/java/proto/state"
+	"go.minekube.com/gate/pkg/gate/proto"
+)
+
+const statusLogStressIterations = 10_000
+
+type statusLogSink struct {
+	mu    sync.Mutex
+	lines []string
+}
+
+func (s *statusLogSink) logger(verbosity int) logr.Logger {
+	return funcr.New(func(prefix, args string) {
+		s.mu.Lock()
+		defer s.mu.Unlock()
+		s.lines = append(s.lines, prefix+" "+args)
+	}, funcr.Options{Verbosity: verbosity})
+}
+
+func (s *statusLogSink) count(message string) int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	count := 0
+	for _, line := range s.lines {
+		if strings.Contains(line, `"msg"="`+message+`"`) {
+			count++
+		}
+	}
+	return count
+}
+
+type statusLogTestConn struct {
+	netmc.MinecraftConn
+	writeErr error
+	writes   int
+	closes   int
+}
+
+func (c *statusLogTestConn) WritePacket(proto.Packet) error {
+	c.writes++
+	return c.writeErr
+}
+
+func (c *statusLogTestConn) Close() error {
+	c.closes++
+	return nil
+}
+
+type inactiveStatusLogInbound struct{ Inbound }
+
+func (*inactiveStatusLogInbound) Active() bool { return false }
+
+func TestStatusResponseExpectedWriteFailuresAreDebug(t *testing.T) {
+	tests := map[string]error{
+		"closed connection": netmc.ErrClosedConn,
+		"closed pipe":       io.ErrClosedPipe,
+		"closed network":    net.ErrClosed,
+		"connection reset": &net.OpError{
+			Op:  "write",
+			Err: fmt.Errorf("wrapped reset: %w", syscall.ECONNRESET),
+		},
+		"broken pipe": &net.OpError{
+			Op:  "write",
+			Err: fmt.Errorf("wrapped broken pipe: %w", syscall.EPIPE),
+		},
+		"network timeout": fmt.Errorf("wrapped timeout: %w", &net.DNSError{
+			Err:       "status response timed out",
+			IsTimeout: true,
+		}),
+	}
+
+	for name, writeErr := range tests {
+		t.Run(name, func(t *testing.T) {
+			infoSink := new(statusLogSink)
+			debugSink := new(statusLogSink)
+			h := &statusSessionHandler{conn: &statusLogTestConn{writeErr: writeErr}}
+
+			for range statusLogStressIterations {
+				h.writeStatusResponse(infoSink.logger(0), &packet.StatusResponse{Status: "{}"})
+				h.writeStatusResponse(debugSink.logger(1), &packet.StatusResponse{Status: "{}"})
+			}
+
+			if got := infoSink.count("error writing status response"); got != 0 {
+				t.Fatalf("default-level records = %d, want 0", got)
+			}
+			if got := debugSink.count("error writing status response"); got != statusLogStressIterations {
+				t.Fatalf("debug records = %d, want %d", got, statusLogStressIterations)
+			}
+		})
+	}
+}
+
+func TestInactiveStatusResponsesAreDebug(t *testing.T) {
+	infoSink := new(statusLogSink)
+	debugSink := new(statusLogSink)
+
+	for range statusLogStressIterations {
+		newInactiveStatusHandler(t, infoSink.logger(0)).handleStatusRequest(&proto.PacketContext{
+			Packet: &packet.StatusRequest{},
+		})
+		newInactiveStatusHandler(t, debugSink.logger(1)).handleStatusRequest(&proto.PacketContext{
+			Packet: &packet.StatusRequest{},
+		})
+	}
+
+	if got := infoSink.count("status response not sent because inbound is inactive"); got != 0 {
+		t.Fatalf("default-level records = %d, want 0", got)
+	}
+	if got := debugSink.count("status response not sent because inbound is inactive"); got != statusLogStressIterations {
+		t.Fatalf("debug records = %d, want %d", got, statusLogStressIterations)
+	}
+}
+
+func TestStatusResponseStructuralWriteFailureRemainsInfo(t *testing.T) {
+	sink := new(statusLogSink)
+	conn := &statusLogTestConn{writeErr: errors.New("packet encode failed")}
+	h := &statusSessionHandler{conn: conn}
+
+	h.writeStatusResponse(sink.logger(0), &packet.StatusResponse{Status: "{}"})
+
+	if got := sink.count("error writing status response"); got != 1 {
+		t.Fatalf("default-level records = %d, want 1", got)
+	}
+	if conn.writes != 1 {
+		t.Fatalf("writes = %d, want 1", conn.writes)
+	}
+}
+
+func TestStatusResponseClosedPeerIsDebug(t *testing.T) {
+	testLogCount := func(t *testing.T, verbosity int) int {
+		t.Helper()
+
+		server, client := net.Pipe()
+		ctx := logr.NewContext(context.Background(), logr.Discard())
+		conn, _ := netmc.NewMinecraftConn(ctx, server, proto.ServerBound, time.Second, time.Second, -1, nil)
+		conn.SetState(state.Status)
+		t.Cleanup(func() { _ = conn.Close() })
+		_ = client.Close()
+
+		sink := new(statusLogSink)
+		h := &statusSessionHandler{conn: conn}
+		h.writeStatusResponse(sink.logger(verbosity), &packet.StatusResponse{Status: "{}"})
+		return sink.count("error writing status response")
+	}
+
+	if got := testLogCount(t, 0); got != 0 {
+		t.Fatalf("default-level records = %d, want 0", got)
+	}
+	if got := testLogCount(t, 1); got != 1 {
+		t.Fatalf("debug records = %d, want 1", got)
+	}
+}
+
+func TestDuplicateStatusRequestsDoNotMultiplyDiagnostics(t *testing.T) {
+	sink := new(statusLogSink)
+	h := newInactiveStatusHandler(t, sink.logger(1))
+	conn := h.conn.(*statusLogTestConn)
+	request := &proto.PacketContext{Packet: &packet.StatusRequest{}}
+
+	h.handleStatusRequest(request)
+	h.handleStatusRequest(request)
+
+	if got := sink.count("status response not sent because inbound is inactive"); got != 1 {
+		t.Fatalf("inactive diagnostics = %d, want 1", got)
+	}
+	if conn.writes != 0 {
+		t.Fatalf("writes = %d, want 0", conn.writes)
+	}
+	if conn.closes != 1 {
+		t.Fatalf("closes after duplicate = %d, want 1", conn.closes)
+	}
+}
+
+func newInactiveStatusHandler(t *testing.T, log logr.Logger) *statusSessionHandler {
+	t.Helper()
+
+	eventMgr := event.New()
+	event.Subscribe(eventMgr, 0, func(*PingEvent) {})
+	return &statusSessionHandler{
+		sessionHandlerDeps: &sessionHandlerDeps{eventMgr: eventMgr},
+		conn:               &statusLogTestConn{},
+		inbound:            &inactiveStatusLogInbound{},
+		log:                log,
+		resolvePingResponse: func(log logr.Logger, _ *proto.PacketContext) (logr.Logger, *packet.StatusResponse, error) {
+			return log, &packet.StatusResponse{Status: "{}"}, nil
+		},
+	}
+}


### PR DESCRIPTION
## Intent

Validate the minimal post-PR-886 Gate follow-up so the Java status-response path cannot spam default production logs during ordinary unreliable ping/connect churn. Inactive response skips and expected closed-peer/network write failures—including ErrClosedConn, closed pipe/network, reset, broken pipe, and wrapped net.Error timeouts—must remain diagnostically visible at V(1), while non-network structural packet registry/encoding/state failures remain info/default-visible. Preserve the existing log messages and error key, one-write semantics, and all protocol/session behavior; do not add sampling, configuration, schema changes, or unrelated refactoring. Validate the permanent deterministic 10,000-iteration log-level coverage, real closed-peer integration behavior, and duplicate-request bound.

## What Changed

- Move inactive status-response skips and expected closed-connection or network write failures to V(1) logging while keeping structural write failures visible at the default level.
- Add deterministic log-level stress coverage, real closed-peer coverage, and duplicate-request checks that preserve single-write and close behavior.

## Risk Assessment

✅ Low: The change is narrowly scoped to log verbosity, preserves write and session behavior, and retains default visibility for structural failures.

## Testing

Focused 10,000-iteration checks, direct emitted-log evidence, 100 repeated real closed-peer and duplicate-request checks, the complete proxy suite, and all Java-edition packages passed; cleanup verification confirmed a clean worktree.

<details>
<summary>Evidence: Exact status-log behavior transcript</summary>

<code>Closed peer: default records=0; V(1) records=1 with unchanged message and `error` key. Structural failure: default record=1, writes=1. Two inactive requests: default records=0; V(1) records=1, writes=0, closes=1.</code>

```text
=== RUN   TestStatusLogReviewerEvidence
=== RUN   TestStatusLogReviewerEvidence/real_closed_peer
    status_log_evidence_test.go:39: closed peer default log records: 0 ([])
    status_log_evidence_test.go:40: closed peer V(1) log records: 1 ([ "level"=1 "msg"="error writing status response" "error"="io: read/write on closed pipe"])
=== RUN   TestStatusLogReviewerEvidence/structural_encoder_failure
    status_log_evidence_test.go:50: structural failure default log: [ "level"=0 "msg"="error writing status response" "error"="packet encode failed"]; writes=1
=== RUN   TestStatusLogReviewerEvidence/inactive_and_duplicate_requests
    status_log_evidence_test.go:66: inactive default log records: 0
    status_log_evidence_test.go:67: inactive V(1) log after two requests: [ "level"=1 "msg"="status response not sent because inbound is inactive"]; writes=0 closes=1
--- PASS: TestStatusLogReviewerEvidence (0.00s)
    --- PASS: TestStatusLogReviewerEvidence/real_closed_peer (0.00s)
    --- PASS: TestStatusLogReviewerEvidence/structural_encoder_failure (0.00s)
    --- PASS: TestStatusLogReviewerEvidence/inactive_and_duplicate_requests (0.00s)
PASS
ok  	go.minekube.com/gate/pkg/edition/java/proxy	0.310s
```
</details>
<details>
<summary>Evidence: Focused 10,000-iteration regression transcript</summary>

```text
=== RUN   TestStatusResponseExpectedWriteFailuresAreDebug
=== RUN   TestStatusResponseExpectedWriteFailuresAreDebug/closed_pipe
=== RUN   TestStatusResponseExpectedWriteFailuresAreDebug/closed_network
=== RUN   TestStatusResponseExpectedWriteFailuresAreDebug/connection_reset
=== RUN   TestStatusResponseExpectedWriteFailuresAreDebug/broken_pipe
=== RUN   TestStatusResponseExpectedWriteFailuresAreDebug/network_timeout
=== RUN   TestStatusResponseExpectedWriteFailuresAreDebug/closed_connection
--- PASS: TestStatusResponseExpectedWriteFailuresAreDebug (0.07s)
    --- PASS: TestStatusResponseExpectedWriteFailuresAreDebug/closed_pipe (0.01s)
    --- PASS: TestStatusResponseExpectedWriteFailuresAreDebug/closed_network (0.01s)
    --- PASS: TestStatusResponseExpectedWriteFailuresAreDebug/connection_reset (0.01s)
    --- PASS: TestStatusResponseExpectedWriteFailuresAreDebug/broken_pipe (0.01s)
    --- PASS: TestStatusResponseExpectedWriteFailuresAreDebug/network_timeout (0.01s)
    --- PASS: TestStatusResponseExpectedWriteFailuresAreDebug/closed_connection (0.01s)
=== RUN   TestInactiveStatusResponsesAreDebug
--- PASS: TestInactiveStatusResponsesAreDebug (0.02s)
=== RUN   TestStatusResponseStructuralWriteFailureRemainsInfo
--- PASS: TestStatusResponseStructuralWriteFailureRemainsInfo (0.00s)
=== RUN   TestStatusResponseClosedPeerIsDebug
--- PASS: TestStatusResponseClosedPeerIsDebug (0.00s)
=== RUN   TestDuplicateStatusRequestsDoNotMultiplyDiagnostics
--- PASS: TestDuplicateStatusRequestsDoNotMultiplyDiagnostics (0.00s)
PASS
ok  	go.minekube.com/gate/pkg/edition/java/proxy	0.442s
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `go test ./pkg/edition/java/proxy -run 'Test(StatusResponseExpectedWriteFailuresAreDebug|InactiveStatusResponsesAreDebug|StatusResponseStructuralWriteFailureRemainsInfo|StatusResponseClosedPeerIsDebug|DuplicateStatusRequestsDoNotMultiplyDiagnostics)$' -count=1 -v`
- <code>Temporary evidence harness: `go test ./pkg/edition/java/proxy -run &#39;^TestStatusLogReviewerEvidence$&#39; -count=1 -v` (harness removed afterward)</code>
- `go test ./pkg/edition/java/proxy -run 'Test(StatusResponseClosedPeerIsDebug|DuplicateStatusRequestsDoNotMultiplyDiagnostics)$' -count=100`
- `go test ./pkg/edition/java/proxy -count=1`
- `go test ./pkg/edition/java/... -count=1`
- `git status --short`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
