### PR TITLE
fix(java): skip stale Via bridge requests on retry

### DIFF
--- a/pkg/edition/java/proxy/vialite.go
+++ b/pkg/edition/java/proxy/vialite.go
@@ -409,18 +409,53 @@ func (i *viaServerInfo) Dial(ctx context.Context, player Player) (net.Conn, erro
 		cancelBridge()
 		return nil, err
 	}
-	return conn, nil
+	return &viaBridgeDialConn{Conn: conn, cancelBridge: cancelBridge}, nil
+}
+
+// viaBridgeDialConn cancels an unclaimed bridge request when the corresponding
+// frontend connection closes. It intentionally does not watch the dial context:
+// connection-request contexts can end after a backend bridge is claimed.
+type viaBridgeDialConn struct {
+	net.Conn
+	cancelBridge context.CancelFunc
+}
+
+func (c *viaBridgeDialConn) Close() error {
+	c.cancelBridge()
+	return c.Conn.Close()
 }
 
 type viaBridgeRequest struct {
 	ctx    context.Context
 	player Player
+	cancel context.CancelFunc
+
+	mu      sync.Mutex
+	claimed bool
+}
+
+func (r *viaBridgeRequest) cancelIfUnclaimed() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if !r.claimed {
+		r.cancel()
+	}
+}
+
+func (r *viaBridgeRequest) claim() bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.ctx.Err() != nil {
+		return false
+	}
+	r.claimed = true
+	return true
 }
 
 type viaBackendBridge struct {
 	ln       net.Listener
 	dialer   ServerDialer
-	requests chan viaBridgeRequest
+	requests chan *viaBridgeRequest
 	done     chan struct{}
 	close    sync.Once
 }
@@ -433,7 +468,7 @@ func newViaBackendBridge(dialer ServerDialer) (*viaBackendBridge, error) {
 	b := &viaBackendBridge{
 		ln:       ln,
 		dialer:   dialer,
-		requests: make(chan viaBridgeRequest, 1024),
+		requests: make(chan *viaBridgeRequest, 1024),
 		done:     make(chan struct{}),
 	}
 	go b.accept()
@@ -446,10 +481,10 @@ func (b *viaBackendBridge) Addr() net.Addr {
 
 func (b *viaBackendBridge) Prepare(ctx context.Context, player Player) (func(), error) {
 	streamCtx, cancel := context.WithCancel(context.WithoutCancel(ctx))
-	req := viaBridgeRequest{ctx: streamCtx, player: player}
+	req := &viaBridgeRequest{ctx: streamCtx, player: player, cancel: cancel}
 	select {
 	case b.requests <- req:
-		return cancel, nil
+		return req.cancelIfUnclaimed, nil
 	case <-b.done:
 		cancel()
 		return nil, net.ErrClosed
@@ -480,14 +515,16 @@ func (b *viaBackendBridge) accept() {
 
 func (b *viaBackendBridge) handle(conn net.Conn) {
 	defer conn.Close()
-	var req viaBridgeRequest
-	select {
-	case req = <-b.requests:
-	case <-b.done:
-		return
-	}
-	if err := req.ctx.Err(); err != nil {
-		return
+	var req *viaBridgeRequest
+	for {
+		select {
+		case req = <-b.requests:
+		case <-b.done:
+			return
+		}
+		if req.claim() {
+			break
+		}
 	}
 	backend, err := b.dialer.Dial(req.ctx, req.player)
 	if err != nil {

--- a/pkg/edition/java/proxy/vialite_test.go
+++ b/pkg/edition/java/proxy/vialite_test.go
@@ -341,6 +341,134 @@ func TestProxyRegisterDynamicViaBackendPreservesServerDialer(t *testing.T) {
 	}
 }
 
+func TestViaServerInfoDialCloseSkipsUnclaimedRequestOnRetry(t *testing.T) {
+	viaLn, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer viaLn.Close()
+
+	original := &fakeDynamicDialer{
+		name:        "connect-session-1",
+		addr:        mustParseAddr("127.0.0.1:25566"),
+		connections: make(chan net.Conn, 2),
+		dialed:      make(chan Player, 2),
+	}
+	bridge, err := newViaBackendBridge(original)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer bridge.Close()
+
+	runner := &viaManagedRunner{
+		server: &fakeVialiteServer{backends: map[string]string{original.Name(): viaLn.Addr().String()}},
+		dynamicBackends: map[string]*viaDynamicBackend{
+			original.Name(): {bridge: bridge},
+		},
+	}
+	dialer := newViaServerInfo(original, runner).(ServerDialer)
+
+	accepted := make(chan net.Conn, 2)
+	go func() {
+		for range 2 {
+			conn, err := viaLn.Accept()
+			if err != nil {
+				return
+			}
+			accepted <- conn
+		}
+	}()
+
+	firstPlayer := &connectedPlayer{}
+	firstCtx, cancelFirst := context.WithCancel(context.Background())
+	firstFrontend, err := dialer.Dial(firstCtx, firstPlayer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	firstVia := <-accepted
+	cancelFirst()
+	_ = firstFrontend.Close()
+	_ = firstVia.Close()
+
+	secondPlayer := &connectedPlayer{}
+	secondFrontend, err := dialer.Dial(context.Background(), secondPlayer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer secondFrontend.Close()
+	secondVia := <-accepted
+	defer secondVia.Close()
+
+	bridgeFrontend, err := net.Dial("tcp", bridge.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer bridgeFrontend.Close()
+
+	select {
+	case got := <-original.dialed:
+		if got != secondPlayer {
+			t.Fatalf("retry bridge dial used player %p, want current retry player %p", got, secondPlayer)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("bridge did not invoke supplied ServerDialer")
+	}
+}
+
+func TestViaBackendBridgeClaimSurvivesRequestContextCancellation(t *testing.T) {
+	original := &fakeDynamicDialer{
+		name:        "connect-session-1",
+		addr:        mustParseAddr("127.0.0.1:25566"),
+		connections: make(chan net.Conn, 1),
+		dialed:      make(chan Player, 1),
+	}
+	bridge, err := newViaBackendBridge(original)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer bridge.Close()
+
+	requestCtx, cancelRequest := context.WithCancel(context.Background())
+	defer cancelRequest()
+	cancelBridge, err := bridge.Prepare(requestCtx, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cancelBridge()
+
+	bridgeFrontend, err := net.Dial("tcp", bridge.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer bridgeFrontend.Close()
+
+	var backendConn net.Conn
+	select {
+	case backendConn = <-original.connections:
+		defer backendConn.Close()
+	case <-time.After(time.Second):
+		t.Fatal("bridge did not claim the request")
+	}
+	cancelRequest()
+
+	if err := bridgeFrontend.SetDeadline(time.Now().Add(time.Second)); err != nil {
+		t.Fatal(err)
+	}
+	if err := backendConn.SetDeadline(time.Now().Add(time.Second)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := bridgeFrontend.Write([]byte("x")); err != nil {
+		t.Fatalf("write after request cancellation: %v", err)
+	}
+	buf := make([]byte, 1)
+	if _, err := backendConn.Read(buf); err != nil {
+		t.Fatalf("read after request cancellation: %v", err)
+	}
+	if string(buf) != "x" {
+		t.Fatalf("backend read %q, want x", string(buf))
+	}
+}
+
 func TestProxyRegisterSkipsDynamicViaBackendForMatchingClientProtocol(t *testing.T) {
 	cfg := &config.Config{
 		Via:  config.Via{Enabled: true},

--- a/pkg/edition/java/proxy/vialite_test.go
+++ b/pkg/edition/java/proxy/vialite_test.go
@@ -449,7 +449,7 @@ func TestViaBackendBridgeClaimSurvivesRequestContextCancellation(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatal("bridge did not claim the request")
 	}
-	cancelRequest()
+	cancelBridge()
 
 	if err := bridgeFrontend.SetDeadline(time.Now().Add(time.Second)); err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
## Intent

Validate and ship the committed Gate dynamic Via retry-safety fix at ac072963. Preserve the narrow behavior: a Via frontend connection closing before its bridge request is claimed must invalidate only that unclaimed request, and the arriving retry bridge must skip it and use the current retry/player. A claimed bridge must remain alive across the connection-request/login context ending. The change intentionally adds no per-attempt diagnostics because deterministic lifecycle tests provide the required privacy-safe evidence; do not broaden to production probing, configuration changes, restarts, deployments, unrelated refactors, or behavior changes.

## What Changed

- Cancel unclaimed dynamic Via bridge requests when their frontend connection closes, and skip stale requests so retries use the current player.
- Preserve claimed bridge streams during connection cleanup and add lifecycle regression coverage for retry and post-claim cancellation behavior.

## Risk Assessment

✅ Low: The change is narrowly scoped, the claim/cancel synchronization preserves the intended lifecycle, and the follow-up now directly verifies that cancellation after claim does not tear down bridge traffic.

## Testing

After baseline target/diff inspection, I exercised the retry and claimed-stream lifecycle over real loopback TCP, repeated the concurrency paths under the race detector, ran the affected package and repository-wide Go suites, captured two privacy-safe reviewer transcripts, and reverified the focused paths after restoring a clean worktree; all checks passed.

<details>
<summary>Evidence: Via retry and claimed-bridge lifecycle transcript</summary>

```text
Command:
go test -v ./pkg/edition/java/proxy -run '^(TestViaServerInfoDialCloseSkipsUnclaimedRequestOnRetry|TestViaBackendBridgeClaimSurvivesRequestContextCancellation)$' -count=1 -timeout=30s

Output:
=== RUN   TestViaServerInfoDialCloseSkipsUnclaimedRequestOnRetry
    vialite_test.go:413: OBSERVED: after attempt 1 closed before bridge claim, the arriving bridge selected attempt 2's current player
--- PASS: TestViaServerInfoDialCloseSkipsUnclaimedRequestOnRetry (0.00s)
=== RUN   TestViaBackendBridgeClaimSurvivesRequestContextCancellation
    vialite_test.go:471: OBSERVED: after the claimed request's cancel callback ran, the bridge still transferred payload "x"
--- PASS: TestViaBackendBridgeClaimSurvivesRequestContextCancellation (0.00s)
PASS
ok  	go.minekube.com/gate/pkg/edition/java/proxy	0.339s

End-user lifecycle represented by the real loopback TCP connections in these tests:
1. Attempt 1's frontend connection closes before Via claims its queued bridge request.
2. Attempt 2 is prepared with the current retry player.
3. The later Via bridge connection skips the invalid attempt-1 request and reaches the backend with attempt 2's player.
4. Separately, after a bridge request is claimed, invoking its cancellation callback does not end the established stream; payload "x" still reaches the backend.
```
</details>
<details>
<summary>Evidence: Connection-request context lifecycle transcript</summary>

```text
Command:
go test -v ./pkg/edition/java/proxy -run '^TestProxyRegisterDynamicViaBackendPreservesServerDialer$' -count=1 -timeout=30s

Output:
=== RUN   TestProxyRegisterDynamicViaBackendPreservesServerDialer
    vialite_test.go:342: OBSERVED: after the connection-request context ended, the claimed dynamic Via bridge still transferred payloads "x" and "y"
--- PASS: TestProxyRegisterDynamicViaBackendPreservesServerDialer (0.00s)
PASS
ok  	go.minekube.com/gate/pkg/edition/java/proxy	0.319s

End-user lifecycle represented by the test's dynamic Via path:
1. Gate registers a dynamic Via backend and opens the translated frontend connection.
2. The original connection-request context is canceled.
3. Gate's bridge still reaches the supplied backend dialer.
4. Payload "x" travels frontend-to-backend and payload "y" travels backend-to-frontend after that context has ended.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `pkg/edition/java/proxy/vialite_test.go:452` - This cancellation does not exercise the new claimed-request guard: `Prepare` uses `context.WithoutCancel`, and `cancelBridge` only runs after the final assertion. Call `cancelBridge()` immediately after the backend is claimed, then verify traffic still flows; otherwise a regression that cancels claimed bridges would pass this test.

🔧 Fix: Exercise claimed bridge cancellation in lifecycle regression
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`git status --short --branch`, `git rev-parse HEAD`, and `git diff aa50f2aced06b36a8faed479aa093c2b43960cfc..3bc8f9401f57c38a7286acd96562053e2b0beb6b`</code>
- `go test -race ./pkg/edition/java/proxy -run '^(TestViaServerInfoDialCloseSkipsUnclaimedRequestOnRetry|TestViaBackendBridgeClaimSurvivesRequestContextCancellation)$' -count=100 -timeout=2m`
- <code>`go test -v ./pkg/edition/java/proxy -run &#39;^(TestViaServerInfoDialCloseSkipsUnclaimedRequestOnRetry|TestViaBackendBridgeClaimSurvivesRequestContextCancellation)$&#39; -count=1 -timeout=30s` with temporary evidence narration, subsequently removed</code>
- <code>`go test -v ./pkg/edition/java/proxy -run &#39;^TestProxyRegisterDynamicViaBackendPreservesServerDialer$&#39; -count=1 -timeout=30s` with temporary evidence narration, subsequently removed</code>
- `go test ./pkg/edition/java/proxy -count=1 -timeout=5m`
- `go test ./... -count=1 -timeout=10m`
- <code>`go test -race ./pkg/edition/java/proxy -run &#39;^(TestProxyRegisterDynamicViaBackendPreservesServerDialer|TestViaServerInfoDialCloseSkipsUnclaimedRequestOnRetry|TestViaBackendBridgeClaimSurvivesRequestContextCancellation)$&#39; -count=20 -timeout=2m` after cleanup</code>
- <code>`git status --short --branch &amp;&amp; git diff --exit-code` after cleanup</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
