### PR TITLE
fix(java): preserve Lite status cache expiry

### DIFF
--- a/.web/docs/guide/lite.md
+++ b/.web/docs/guide/lite.md
@@ -244,7 +244,7 @@ config:
 
 _TTL - the Time-to-live before evicting the response data from the in-memory cache. The TTL starts when Gate fetches or refreshes a backend status response; later status requests return the cached response without extending its expiry._
 
-Note that routes can configure multiple random backends and each backend-address and protocol pair has its own TTL.
+Note that routes can configure multiple backends. Each backend address and client protocol combination has its own cached response and TTL.
 
 ### Disabling the cache
 

--- a/.web/docs/guide/lite.md
+++ b/.web/docs/guide/lite.md
@@ -242,9 +242,9 @@ config:
         cachePingTTL: 3m # or 180s [!code ++]
 ```
 
-_TTL - the Time-to-live before evicting the response data from the in-memory cache_
+_TTL - the Time-to-live before evicting the response data from the in-memory cache. The TTL starts when Gate fetches or refreshes a backend status response; later status requests return the cached response without extending its expiry._
 
-Note that routes can configure multiple random backends and each backend has its own TTL.
+Note that routes can configure multiple random backends and each backend-address and protocol pair has its own TTL.
 
 ### Disabling the cache
 

--- a/config-lite.yml
+++ b/config-lite.yml
@@ -57,7 +57,7 @@ config:
         # Options: sequential, random, round-robin, least-connections, lowest-latency
         # Default: sequential (tries backends in config order)
         # strategy: random  # Uncomment to use random instead of sequential
-        # Ping responses are cached per backend address by default.
+        # See https://gate.minekube.com/guide/lite#ping-response-caching for cache semantics.
         # To disable motd caching set it to -1.
         # Default: 10s
         cachePingTTL: 60s

--- a/config.yml
+++ b/config.yml
@@ -224,7 +224,7 @@ config:
         # Options: random, round-robin, least-connections, lowest-latency
         # Default: random
         strategy: random
-        # Ping responses are cached per backend address by default.
+        # See https://gate.minekube.com/guide/lite#ping-response-caching for cache semantics.
         # To disable motd caching set it to -1.
         # Default: 10s
         cachePingTTL: 60s

--- a/pkg/configs/config-lite.yml
+++ b/pkg/configs/config-lite.yml
@@ -57,7 +57,7 @@ config:
         # Options: sequential, random, round-robin, least-connections, lowest-latency
         # Default: sequential (tries backends in config order)
         # strategy: random  # Uncomment to use random instead of sequential
-        # Ping responses are cached per backend address by default.
+        # See https://gate.minekube.com/guide/lite#ping-response-caching for cache semantics.
         # To disable motd caching set it to -1.
         # Default: 10s
         cachePingTTL: 60s

--- a/pkg/configs/config.yml
+++ b/pkg/configs/config.yml
@@ -224,7 +224,7 @@ config:
         # Options: random, round-robin, least-connections, lowest-latency
         # Default: random
         strategy: random
-        # Ping responses are cached per backend address by default.
+        # See https://gate.minekube.com/guide/lite#ping-response-caching for cache semantics.
         # To disable motd caching set it to -1.
         # Default: 10s
         cachePingTTL: 60s

--- a/pkg/edition/java/lite/forward.go
+++ b/pkg/edition/java/lite/forward.go
@@ -411,7 +411,7 @@ func handleFallbackResponse(log logr.Logger, route *config.Route, protocol proto
 
 var pingCache = newPingStatusCache(time.Now, new(singleflight.Group))
 
-// ResetPingCache resets the ping cache.
+// ResetPingCache clears cached ping results and prevents in-flight loads from repopulating them.
 func ResetPingCache() {
 	pingCache.reset()
 	compiledRegexCache.DeleteAll()

--- a/pkg/edition/java/lite/forward.go
+++ b/pkg/edition/java/lite/forward.go
@@ -409,7 +409,7 @@ func handleFallbackResponse(log logr.Logger, route *config.Route, protocol proto
 }
 
 var (
-	pingCache = ttlcache.New[pingKey, *pingResult]()
+	pingCache = ttlcache.New[pingKey, *pingResult](ttlcache.WithDisableTouchOnHit[pingKey, *pingResult]())
 	sfg       = new(singleflight.Group)
 )
 

--- a/pkg/edition/java/lite/forward.go
+++ b/pkg/edition/java/lite/forward.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
@@ -408,19 +409,16 @@ func handleFallbackResponse(log logr.Logger, route *config.Route, protocol proto
 	return nil, log
 }
 
-var (
-	pingCache = ttlcache.New[pingKey, *pingResult](ttlcache.WithDisableTouchOnHit[pingKey, *pingResult]())
-	sfg       = new(singleflight.Group)
-)
+var pingCache = newPingStatusCache(time.Now, new(singleflight.Group))
 
 // ResetPingCache resets the ping cache.
 func ResetPingCache() {
-	pingCache.DeleteAll()
+	pingCache.reset()
 	compiledRegexCache.DeleteAll()
 }
 
 func init() {
-	go pingCache.Start() // start ttl eviction once
+	go pingCache.cache.Start() // start ttl eviction once
 }
 
 type pingKey struct {
@@ -431,6 +429,83 @@ type pingKey struct {
 type pingResult struct {
 	res *packet.StatusResponse
 	err error
+}
+
+type flightGroup interface {
+	DoChan(string, func() (any, error)) <-chan singleflight.Result
+}
+
+type pingStatusCache struct {
+	mu         sync.Mutex
+	cache      *ttlcache.Cache[pingKey, *pingResult]
+	group      flightGroup
+	now        func() time.Time
+	generation uint64
+}
+
+func newPingStatusCache(now func() time.Time, group flightGroup) *pingStatusCache {
+	return &pingStatusCache{
+		cache: ttlcache.New[pingKey, *pingResult](ttlcache.WithDisableTouchOnHit[pingKey, *pingResult]()),
+		group: group,
+		now:   now,
+	}
+}
+
+func (c *pingStatusCache) get(key pingKey) *pingResult {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.getLocked(key)
+}
+
+func (c *pingStatusCache) getLocked(key pingKey) *pingResult {
+	item := c.cache.Get(key)
+	if item == nil {
+		return nil
+	}
+	expiresAt := item.ExpiresAt()
+	if !expiresAt.IsZero() && !c.now().Before(expiresAt) {
+		c.cache.Delete(key)
+		return nil
+	}
+	return item.Value()
+}
+
+func (c *pingStatusCache) load(key pingKey, ttl time.Duration, load func() *pingResult) *pingResult {
+	c.mu.Lock()
+	generation := c.generation
+	if result := c.getLocked(key); result != nil {
+		c.mu.Unlock()
+		return result
+	}
+	c.mu.Unlock()
+
+	flightKey := fmt.Sprintf("%d:%s:%d", generation, key.backendAddr, key.protocol)
+	result := <-c.group.DoChan(flightKey, func() (any, error) {
+		c.mu.Lock()
+		if generation == c.generation {
+			if cached := c.getLocked(key); cached != nil {
+				c.mu.Unlock()
+				return cached, nil
+			}
+		}
+		c.mu.Unlock()
+
+		loaded := load()
+		c.mu.Lock()
+		if generation == c.generation {
+			c.cache.Set(key, loaded, ttl)
+		}
+		c.mu.Unlock()
+		return loaded, nil
+	})
+	return result.Val.(*pingResult)
+}
+
+func (c *pingStatusCache) reset() {
+	c.mu.Lock()
+	c.generation++
+	c.cache.DeleteAll()
+	c.mu.Unlock()
 }
 
 func resolveStatusResponse(
@@ -448,10 +523,9 @@ func resolveStatusResponse(
 
 	// fast path: use cache without loader
 	if route.CachePingEnabled() {
-		item := pingCache.Get(key)
-		if item != nil {
+		val := pingCache.get(key)
+		if val != nil {
 			log.V(1).Info("returning cached status result")
-			val := item.Value()
 			return log, val.res, val.err
 		}
 	}
@@ -483,13 +557,13 @@ func resolveStatusResponse(
 		return log, res, err
 	}
 
-	opt := withLoader(sfg, route.GetCachePingTTL(), func(key pingKey) *pingResult {
+	loadResult := func() *pingResult {
 		res, err := load(context.Background())
 		return &pingResult{res: res, err: err}
-	})
+	}
 
 	resultChan := make(chan *pingResult, 1)
-	go func() { resultChan <- pingCache.Get(key, opt).Value() }()
+	go func() { resultChan <- pingCache.load(key, route.GetCachePingTTL(), loadResult) }()
 
 	select {
 	case result := <-resultChan:
@@ -543,18 +617,4 @@ func decodeStatusResponse(dec statusDecoder) (*packet.StatusResponse, error) {
 	}
 
 	return res, nil
-}
-
-// withLoader returns a ttlcache option that uses the given load function to load a value for a key
-// if it is not already cached.
-func withLoader[K comparable, V any](group *singleflight.Group, ttl time.Duration, load func(key K) V) ttlcache.Option[K, V] {
-	loader := ttlcache.LoaderFunc[K, V](
-		func(c *ttlcache.Cache[K, V], key K) *ttlcache.Item[K, V] {
-			v := load(key)
-			return c.Set(key, v, ttl)
-		},
-	)
-	return ttlcache.WithLoader[K, V](
-		ttlcache.NewSuppressedLoader[K, V](loader, group),
-	)
 }

--- a/pkg/edition/java/lite/forward_test.go
+++ b/pkg/edition/java/lite/forward_test.go
@@ -7,67 +7,82 @@ import (
 	"testing"
 	"time"
 
-	"github.com/jellydator/ttlcache/v3"
 	"github.com/stretchr/testify/require"
 	"go.minekube.com/gate/pkg/edition/java/proto/packet"
 	"go.minekube.com/gate/pkg/gate/proto"
 	"golang.org/x/sync/singleflight"
 )
 
-func TestPingCacheDoesNotExtendExpiryOnHotGet(t *testing.T) {
-	ResetPingCache()
-	t.Cleanup(ResetPingCache)
-
+func TestPingCacheRefreshesAfterInsertionBasedExpiry(t *testing.T) {
+	now := time.Now()
+	cache := newPingStatusCache(func() time.Time { return now }, new(singleflight.Group))
 	key := pingKey{backendAddr: "backend.example:25565", protocol: proto.Protocol(765)}
-	item := pingCache.Set(key, &pingResult{}, time.Hour)
+	initial := &pingResult{res: &packet.StatusResponse{Status: "initial"}}
+	refreshed := &pingResult{res: &packet.StatusResponse{Status: "refreshed"}}
+	var loads atomic.Int32
+
+	result := cache.load(key, time.Hour, func() *pingResult {
+		loads.Add(1)
+		return initial
+	})
+	require.Same(t, initial, result)
+	item := cache.cache.Get(key)
+	require.NotNil(t, item)
 	expiresAt := item.ExpiresAt()
 
 	for range 100 {
-		require.Same(t, item, pingCache.Get(key))
+		require.Same(t, initial, cache.get(key))
 	}
-
 	require.Equal(t, expiresAt, item.ExpiresAt(), "status reads must not extend cache expiry")
+
+	now = expiresAt
+	result = cache.load(key, time.Hour, func() *pingResult {
+		loads.Add(1)
+		return refreshed
+	})
+
+	require.Same(t, refreshed, result)
+	require.Same(t, refreshed, cache.get(key))
+	require.Equal(t, int32(2), loads.Load())
 }
 
 func TestPingCacheLoaderSuppressesConcurrentMisses(t *testing.T) {
-	cache := ttlcache.New[pingKey, *pingResult]()
+	group := &observedFlightGroup{entered: make(chan struct{}, 33)}
+	cache := newPingStatusCache(time.Now, group)
 	key := pingKey{backendAddr: "backend.example:25565", protocol: proto.Protocol(765)}
 
 	var loads atomic.Int32
 	started := make(chan struct{})
 	release := make(chan struct{})
 	var startOnce sync.Once
-	loader := withLoader(new(singleflight.Group), time.Hour, func(pingKey) *pingResult {
+	loader := func() *pingResult {
 		loads.Add(1)
 		startOnce.Do(func() { close(started) })
 		<-release
 		return &pingResult{}
-	})
+	}
 
 	const requests = 32
-	results := make(chan *ttlcache.Item[pingKey, *pingResult], requests+1)
+	results := make(chan *pingResult, requests+1)
 	firstDone := make(chan struct{})
 	go func() {
 		defer close(firstDone)
-		results <- cache.Get(key, loader)
+		results <- cache.load(key, time.Hour, loader)
 	}()
-	<-started
+	receiveSignal(t, started)
+	receiveSignal(t, group.entered)
 
-	var ready sync.WaitGroup
-	ready.Add(requests)
 	var done sync.WaitGroup
 	done.Add(requests)
-	start := make(chan struct{})
 	for range requests {
 		go func() {
 			defer done.Done()
-			ready.Done()
-			<-start
-			results <- cache.Get(key, loader)
+			results <- cache.load(key, time.Hour, loader)
 		}()
 	}
-	ready.Wait()
-	close(start)
+	for range requests {
+		receiveSignal(t, group.entered)
+	}
 	close(release)
 	<-firstDone
 	done.Wait()
@@ -79,16 +94,18 @@ func TestPingCacheLoaderSuppressesConcurrentMisses(t *testing.T) {
 }
 
 func TestPingCacheSeparatesProtocols(t *testing.T) {
-	cache := ttlcache.New[pingKey, *pingResult]()
+	cache := newPingStatusCache(time.Now, new(singleflight.Group))
 	backendAddr := "backend.example:25565"
 	legacy := &pingResult{res: &packet.StatusResponse{Status: "legacy"}}
 	modern := &pingResult{res: &packet.StatusResponse{Status: "modern"}}
 
-	cache.Set(pingKey{backendAddr: backendAddr, protocol: proto.Protocol(47)}, legacy, time.Hour)
-	cache.Set(pingKey{backendAddr: backendAddr, protocol: proto.Protocol(765)}, modern, time.Hour)
+	legacyKey := pingKey{backendAddr: backendAddr, protocol: proto.Protocol(47)}
+	modernKey := pingKey{backendAddr: backendAddr, protocol: proto.Protocol(765)}
+	cache.load(legacyKey, time.Hour, func() *pingResult { return legacy })
+	cache.load(modernKey, time.Hour, func() *pingResult { return modern })
 
-	require.Same(t, legacy, cache.Get(pingKey{backendAddr: backendAddr, protocol: proto.Protocol(47)}).Value())
-	require.Same(t, modern, cache.Get(pingKey{backendAddr: backendAddr, protocol: proto.Protocol(765)}).Value())
+	require.Same(t, legacy, cache.get(legacyKey))
+	require.Same(t, modern, cache.get(modernKey))
 }
 
 func TestResetPingCacheInvalidatesAllBackendsAndProtocols(t *testing.T) {
@@ -101,13 +118,70 @@ func TestResetPingCacheInvalidatesAllBackendsAndProtocols(t *testing.T) {
 		{backendAddr: "two.example:25565", protocol: proto.Protocol(765)},
 	}
 	for _, key := range keys {
-		pingCache.Set(key, &pingResult{}, time.Hour)
+		pingCache.load(key, time.Hour, func() *pingResult { return &pingResult{} })
 	}
 
 	ResetPingCache()
 
 	for _, key := range keys {
-		require.Nil(t, pingCache.Get(key))
+		require.Nil(t, pingCache.get(key))
+	}
+}
+
+func TestResetPingCacheRejectsInFlightLoad(t *testing.T) {
+	cache := newPingStatusCache(time.Now, new(singleflight.Group))
+	key := pingKey{backendAddr: "backend.example:25565", protocol: proto.Protocol(765)}
+	stale := &pingResult{res: &packet.StatusResponse{Status: "stale"}}
+	fresh := &pingResult{res: &packet.StatusResponse{Status: "fresh"}}
+	started := make(chan struct{})
+	release := make(chan struct{})
+	staleResult := make(chan *pingResult, 1)
+
+	go func() {
+		staleResult <- cache.load(key, time.Hour, func() *pingResult {
+			close(started)
+			<-release
+			return stale
+		})
+	}()
+	receiveSignal(t, started)
+
+	cache.reset()
+	freshResultCh := make(chan *pingResult, 1)
+	go func() {
+		freshResultCh <- cache.load(key, time.Hour, func() *pingResult { return fresh })
+	}()
+	var freshResult *pingResult
+	select {
+	case freshResult = <-freshResultCh:
+	case <-time.After(5 * time.Second):
+		close(release)
+		t.Fatal("post-reset load joined stale in-flight work")
+	}
+	close(release)
+
+	require.Same(t, fresh, freshResult)
+	require.Same(t, stale, <-staleResult)
+	require.Same(t, fresh, cache.get(key))
+}
+
+type observedFlightGroup struct {
+	group   singleflight.Group
+	entered chan struct{}
+}
+
+func (g *observedFlightGroup) DoChan(key string, fn func() (any, error)) <-chan singleflight.Result {
+	result := g.group.DoChan(key, fn)
+	g.entered <- struct{}{}
+	return result
+}
+
+func receiveSignal(t *testing.T, ch <-chan struct{}) {
+	t.Helper()
+	select {
+	case <-ch:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for concurrent cache operation")
 	}
 }
 

--- a/pkg/edition/java/lite/forward_test.go
+++ b/pkg/edition/java/lite/forward_test.go
@@ -42,7 +42,9 @@ func TestPingCacheRefreshesAfterInsertionBasedExpiry(t *testing.T) {
 	})
 
 	require.Same(t, refreshed, result)
-	require.Same(t, refreshed, cache.get(key))
+	refreshedItem := cache.cache.Get(key)
+	require.NotNil(t, refreshedItem)
+	require.Same(t, refreshed, refreshedItem.Value())
 	require.Equal(t, int32(2), loads.Load())
 }
 

--- a/pkg/edition/java/lite/forward_test.go
+++ b/pkg/edition/java/lite/forward_test.go
@@ -2,12 +2,114 @@ package lite
 
 import (
 	"errors"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
+	"github.com/jellydator/ttlcache/v3"
 	"github.com/stretchr/testify/require"
 	"go.minekube.com/gate/pkg/edition/java/proto/packet"
 	"go.minekube.com/gate/pkg/gate/proto"
+	"golang.org/x/sync/singleflight"
 )
+
+func TestPingCacheDoesNotExtendExpiryOnHotGet(t *testing.T) {
+	ResetPingCache()
+	t.Cleanup(ResetPingCache)
+
+	key := pingKey{backendAddr: "backend.example:25565", protocol: proto.Protocol(765)}
+	item := pingCache.Set(key, &pingResult{}, time.Hour)
+	expiresAt := item.ExpiresAt()
+
+	for range 100 {
+		require.Same(t, item, pingCache.Get(key))
+	}
+
+	require.Equal(t, expiresAt, item.ExpiresAt(), "status reads must not extend cache expiry")
+}
+
+func TestPingCacheLoaderSuppressesConcurrentMisses(t *testing.T) {
+	cache := ttlcache.New[pingKey, *pingResult]()
+	key := pingKey{backendAddr: "backend.example:25565", protocol: proto.Protocol(765)}
+
+	var loads atomic.Int32
+	started := make(chan struct{})
+	release := make(chan struct{})
+	var startOnce sync.Once
+	loader := withLoader(new(singleflight.Group), time.Hour, func(pingKey) *pingResult {
+		loads.Add(1)
+		startOnce.Do(func() { close(started) })
+		<-release
+		return &pingResult{}
+	})
+
+	const requests = 32
+	results := make(chan *ttlcache.Item[pingKey, *pingResult], requests+1)
+	firstDone := make(chan struct{})
+	go func() {
+		defer close(firstDone)
+		results <- cache.Get(key, loader)
+	}()
+	<-started
+
+	var ready sync.WaitGroup
+	ready.Add(requests)
+	var done sync.WaitGroup
+	done.Add(requests)
+	start := make(chan struct{})
+	for range requests {
+		go func() {
+			defer done.Done()
+			ready.Done()
+			<-start
+			results <- cache.Get(key, loader)
+		}()
+	}
+	ready.Wait()
+	close(start)
+	close(release)
+	<-firstDone
+	done.Wait()
+
+	for range requests + 1 {
+		require.NotNil(t, <-results)
+	}
+	require.Equal(t, int32(1), loads.Load())
+}
+
+func TestPingCacheSeparatesProtocols(t *testing.T) {
+	cache := ttlcache.New[pingKey, *pingResult]()
+	backendAddr := "backend.example:25565"
+	legacy := &pingResult{res: &packet.StatusResponse{Status: "legacy"}}
+	modern := &pingResult{res: &packet.StatusResponse{Status: "modern"}}
+
+	cache.Set(pingKey{backendAddr: backendAddr, protocol: proto.Protocol(47)}, legacy, time.Hour)
+	cache.Set(pingKey{backendAddr: backendAddr, protocol: proto.Protocol(765)}, modern, time.Hour)
+
+	require.Same(t, legacy, cache.Get(pingKey{backendAddr: backendAddr, protocol: proto.Protocol(47)}).Value())
+	require.Same(t, modern, cache.Get(pingKey{backendAddr: backendAddr, protocol: proto.Protocol(765)}).Value())
+}
+
+func TestResetPingCacheInvalidatesAllBackendsAndProtocols(t *testing.T) {
+	ResetPingCache()
+	t.Cleanup(ResetPingCache)
+
+	keys := []pingKey{
+		{backendAddr: "one.example:25565", protocol: proto.Protocol(47)},
+		{backendAddr: "one.example:25565", protocol: proto.Protocol(765)},
+		{backendAddr: "two.example:25565", protocol: proto.Protocol(765)},
+	}
+	for _, key := range keys {
+		pingCache.Set(key, &pingResult{}, time.Hour)
+	}
+
+	ResetPingCache()
+
+	for _, key := range keys {
+		require.Nil(t, pingCache.Get(key))
+	}
+}
 
 // TestDecodeStatusResponse_WithErrDecoderLeftBytes tests that decodeStatusResponse
 // properly handles ErrDecoderLeftBytes error (from BetterCompatibilityChecker mod)

--- a/pkg/edition/java/proxy/lite_status_cache_integration_test.go
+++ b/pkg/edition/java/proxy/lite_status_cache_integration_test.go
@@ -41,7 +41,7 @@ func TestLiteStatusCacheWireFlow(t *testing.T) {
 		Routes: []liteconfig.Route{{
 			Host:         []string{host},
 			Backend:      []string{backend.Addr()},
-			CachePingTTL: configutil.Duration(300 * time.Millisecond),
+			CachePingTTL: configutil.Duration(2 * time.Second),
 		}},
 	}
 
@@ -136,17 +136,23 @@ func TestLiteStatusCacheWireFlow(t *testing.T) {
 		backend.SetDelay(0)
 		before := backend.Fetches()
 		initial := ping(765)
-		started := time.Now()
-		for i := 1; i <= 3; i++ {
-			time.Sleep(time.Until(started.Add(time.Duration(i) * 80 * time.Millisecond)))
-			require.Equal(t, initial, ping(765))
+		deadline := time.Now().Add(4 * time.Second)
+		var refreshed string
+		hotReads := 0
+		for time.Now().Before(deadline) {
+			status := ping(765)
+			if status != initial {
+				refreshed = status
+				break
+			}
+			hotReads++
+			time.Sleep(25 * time.Millisecond)
 		}
-		time.Sleep(time.Until(started.Add(380 * time.Millisecond)))
-		refreshed := ping(765)
 
-		require.NotEqual(t, initial, refreshed)
+		require.NotEmpty(t, refreshed, "cache entry never expired while continuously read")
+		require.Positive(t, hotReads, "test must observe at least one cached hot read")
 		require.Equal(t, int32(2), backend.Fetches()-before)
-		t.Logf("initial=%s; reads at +80ms/+160ms/+240ms stayed cached; +380ms=%s; backend fetch delta=2", initial, refreshed)
+		t.Logf("initial=%s; %d hot reads stayed cached until insertion-based expiry; refreshed=%s; backend fetch delta=2", initial, hotReads, refreshed)
 	})
 
 	t.Run("route ttl reload invalidates globally", func(t *testing.T) {
@@ -155,14 +161,14 @@ func TestLiteStatusCacheWireFlow(t *testing.T) {
 		previous := cfg
 		next := cfg
 		next.Lite.Routes = append([]liteconfig.Route(nil), cfg.Lite.Routes...)
-		next.Lite.Routes[0].CachePingTTL = configutil.Duration(2 * time.Second)
+		next.Lite.Routes[0].CachePingTTL = configutil.Duration(5 * time.Second)
 
 		reload.FireConfigUpdate(events, &next, &previous)
 		refreshed := ping(765)
 
 		require.NotEqual(t, cached, refreshed)
 		require.Equal(t, int32(1), backend.Fetches()-before)
-		t.Logf("cachePingTTL reload 300ms -> 2s invalidated %s; next client received %s immediately", cached, refreshed)
+		t.Logf("cachePingTTL reload 2s -> 5s invalidated %s; next client received %s immediately", cached, refreshed)
 	})
 }
 

--- a/pkg/edition/java/proxy/lite_status_cache_integration_test.go
+++ b/pkg/edition/java/proxy/lite_status_cache_integration_test.go
@@ -1,0 +1,344 @@
+package proxy
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/robinbraemer/event"
+	"github.com/stretchr/testify/require"
+	"go.minekube.com/gate/pkg/edition/java/config"
+	"go.minekube.com/gate/pkg/edition/java/lite"
+	liteconfig "go.minekube.com/gate/pkg/edition/java/lite/config"
+	"go.minekube.com/gate/pkg/edition/java/proto/util"
+	"go.minekube.com/gate/pkg/internal/reload"
+	"go.minekube.com/gate/pkg/util/configutil"
+)
+
+func TestLiteStatusCacheWireFlow(t *testing.T) {
+	lite.ResetPingCache()
+	t.Cleanup(lite.ResetPingCache)
+
+	backend := newStatusBackend(t)
+	defer backend.Close()
+
+	const host = "status.example.com"
+	cfg := config.DefaultConfig
+	cfg.Bind = reserveTCPAddress(t)
+	cfg.Quota.Connections.Enabled = false
+	cfg.PacketLimiter.PacketsPerSecond = -1
+	cfg.PacketLimiter.BytesPerSecond = -1
+	cfg.Lite = liteconfig.Config{
+		Enabled: true,
+		Routes: []liteconfig.Route{{
+			Host:         []string{host},
+			Backend:      []string{backend.Addr()},
+			CachePingTTL: configutil.Duration(300 * time.Millisecond),
+		}},
+	}
+
+	events := event.New(event.WithRecoverPanic(false))
+	ready := make(chan struct{})
+	unsubscribeReady := event.Subscribe(events, 0, func(*ReadyEvent) {
+		select {
+		case <-ready:
+		default:
+			close(ready)
+		}
+	})
+	defer unsubscribeReady()
+
+	p, err := New(Options{Config: &cfg, EventMgr: events})
+	require.NoError(t, err)
+	ctx, cancel := context.WithCancel(context.Background())
+	startResult := make(chan error, 1)
+	go func() { startResult <- p.Start(ctx) }()
+	select {
+	case <-ready:
+	case <-time.After(5 * time.Second):
+		cancel()
+		t.Fatal("Gate Lite did not become ready")
+	}
+	t.Cleanup(func() {
+		cancel()
+		select {
+		case err := <-startResult:
+			require.NoError(t, err)
+		case <-time.After(5 * time.Second):
+			t.Error("Gate Lite did not stop")
+		}
+	})
+
+	ping := func(protocol int) string {
+		result, err := statusPing(cfg.Bind, host, protocol)
+		require.NoError(t, err)
+		return result
+	}
+
+	t.Run("protocol keys are isolated", func(t *testing.T) {
+		legacy := ping(47)
+		modern := ping(765)
+		require.Equal(t, legacy, ping(47))
+		require.Equal(t, modern, ping(765))
+		require.NotEqual(t, legacy, modern)
+		require.Equal(t, int32(2), backend.Fetches())
+		t.Logf("protocol 47 -> %s; protocol 765 -> %s; hot repeats caused 0 backend fetches", legacy, modern)
+	})
+
+	t.Run("concurrent misses are singleflight", func(t *testing.T) {
+		lite.ResetPingCache()
+		backend.SetDelay(250 * time.Millisecond)
+		before := backend.Fetches()
+
+		const clients = 16
+		start := make(chan struct{})
+		type pingResult struct {
+			status string
+			err    error
+		}
+		results := make(chan pingResult, clients)
+		var wg sync.WaitGroup
+		wg.Add(clients)
+		for range clients {
+			go func() {
+				defer wg.Done()
+				<-start
+				status, err := statusPing(cfg.Bind, host, 765)
+				results <- pingResult{status: status, err: err}
+			}()
+		}
+		close(start)
+		wg.Wait()
+		close(results)
+
+		var shared string
+		for result := range results {
+			require.NoError(t, result.err)
+			if shared == "" {
+				shared = result.status
+			}
+			require.Equal(t, shared, result.status)
+		}
+		require.Equal(t, int32(1), backend.Fetches()-before)
+		t.Logf("%d simultaneous client pings -> %s; backend fetch delta=1", clients, shared)
+	})
+
+	t.Run("hot reads do not extend ttl", func(t *testing.T) {
+		lite.ResetPingCache()
+		backend.SetDelay(0)
+		before := backend.Fetches()
+		initial := ping(765)
+		started := time.Now()
+		for i := 1; i <= 3; i++ {
+			time.Sleep(time.Until(started.Add(time.Duration(i) * 80 * time.Millisecond)))
+			require.Equal(t, initial, ping(765))
+		}
+		time.Sleep(time.Until(started.Add(380 * time.Millisecond)))
+		refreshed := ping(765)
+
+		require.NotEqual(t, initial, refreshed)
+		require.Equal(t, int32(2), backend.Fetches()-before)
+		t.Logf("initial=%s; reads at +80ms/+160ms/+240ms stayed cached; +380ms=%s; backend fetch delta=2", initial, refreshed)
+	})
+
+	t.Run("route ttl reload invalidates globally", func(t *testing.T) {
+		cached := ping(765)
+		before := backend.Fetches()
+		previous := cfg
+		next := cfg
+		next.Lite.Routes = append([]liteconfig.Route(nil), cfg.Lite.Routes...)
+		next.Lite.Routes[0].CachePingTTL = configutil.Duration(2 * time.Second)
+
+		reload.FireConfigUpdate(events, &next, &previous)
+		refreshed := ping(765)
+
+		require.NotEqual(t, cached, refreshed)
+		require.Equal(t, int32(1), backend.Fetches()-before)
+		t.Logf("cachePingTTL reload 300ms -> 2s invalidated %s; next client received %s immediately", cached, refreshed)
+	})
+}
+
+type statusBackend struct {
+	t       *testing.T
+	ln      net.Listener
+	fetches atomic.Int32
+	delayNS atomic.Int64
+	wg      sync.WaitGroup
+}
+
+func newStatusBackend(t *testing.T) *statusBackend {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	b := &statusBackend{t: t, ln: ln}
+	b.wg.Add(1)
+	go b.serve()
+	return b
+}
+
+func (b *statusBackend) Addr() string { return b.ln.Addr().String() }
+
+func (b *statusBackend) Fetches() int32 { return b.fetches.Load() }
+
+func (b *statusBackend) SetDelay(d time.Duration) { b.delayNS.Store(int64(d)) }
+
+func (b *statusBackend) Close() {
+	_ = b.ln.Close()
+	b.wg.Wait()
+}
+
+func (b *statusBackend) serve() {
+	defer b.wg.Done()
+	for {
+		conn, err := b.ln.Accept()
+		if err != nil {
+			return
+		}
+		b.wg.Add(1)
+		go func() {
+			defer b.wg.Done()
+			defer conn.Close()
+			if err := b.handle(conn); err != nil {
+				b.t.Errorf("mock status backend: %v", err)
+			}
+		}()
+	}
+}
+
+func (b *statusBackend) handle(conn net.Conn) error {
+	_ = conn.SetDeadline(time.Now().Add(5 * time.Second))
+	id, handshake, err := readStatusFrame(conn)
+	if err != nil {
+		return fmt.Errorf("read handshake: %w", err)
+	}
+	if id != 0 {
+		return fmt.Errorf("handshake packet id=%d, want 0", id)
+	}
+	protocol, err := util.ReadVarInt(bytes.NewReader(handshake))
+	if err != nil {
+		return fmt.Errorf("read protocol: %w", err)
+	}
+	id, _, err = readStatusFrame(conn)
+	if err != nil {
+		return fmt.Errorf("read status request: %w", err)
+	}
+	if id != 0 {
+		return fmt.Errorf("status request packet id=%d, want 0", id)
+	}
+
+	fetch := b.fetches.Add(1)
+	time.Sleep(time.Duration(b.delayNS.Load()))
+	status := fmt.Sprintf(`{"version":{"name":"mock","protocol":%d},"players":{"max":20,"online":%d},"description":{"text":"backend-fetch-%d-protocol-%d"}}`, protocol, fetch, fetch, protocol)
+	var payload bytes.Buffer
+	pw := util.PanicWriter(&payload)
+	pw.VarInt(0)
+	pw.String(status)
+	return writeStatusFrame(conn, payload.Bytes())
+}
+
+func reserveTCPAddress(t *testing.T) string {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	addr := ln.Addr().String()
+	require.NoError(t, ln.Close())
+	return addr
+}
+
+func statusPing(gateAddr, host string, protocol int) (string, error) {
+	conn, err := net.DialTimeout("tcp", gateAddr, 5*time.Second)
+	if err != nil {
+		return "", fmt.Errorf("dial Gate Lite: %w", err)
+	}
+	defer conn.Close()
+	if err := conn.SetDeadline(time.Now().Add(5 * time.Second)); err != nil {
+		return "", fmt.Errorf("set client deadline: %w", err)
+	}
+
+	_, portText, err := net.SplitHostPort(gateAddr)
+	if err != nil {
+		return "", fmt.Errorf("split Gate Lite address: %w", err)
+	}
+	port, err := strconv.Atoi(portText)
+	if err != nil {
+		return "", fmt.Errorf("parse Gate Lite port: %w", err)
+	}
+
+	var handshake bytes.Buffer
+	pw := util.PanicWriter(&handshake)
+	pw.VarInt(0)
+	pw.VarInt(protocol)
+	pw.String(host)
+	if err := util.WriteUint16(&handshake, uint16(port)); err != nil {
+		return "", fmt.Errorf("encode handshake port: %w", err)
+	}
+	pw.VarInt(1)
+	if err := writeStatusFrame(conn, handshake.Bytes()); err != nil {
+		return "", fmt.Errorf("write handshake: %w", err)
+	}
+	if err := writeStatusFrame(conn, []byte{0}); err != nil {
+		return "", fmt.Errorf("write status request: %w", err)
+	}
+
+	id, response, err := readStatusFrame(conn)
+	if err != nil {
+		return "", fmt.Errorf("read status response: %w", err)
+	}
+	if id != 0 {
+		return "", fmt.Errorf("status response packet id=%d, want 0", id)
+	}
+	status, err := util.ReadString(bytes.NewReader(response))
+	if err != nil {
+		return "", fmt.Errorf("decode status response: %w", err)
+	}
+	var decoded struct {
+		Description struct {
+			Text string `json:"text"`
+		} `json:"description"`
+	}
+	if err := json.Unmarshal([]byte(status), &decoded); err != nil {
+		return "", fmt.Errorf("decode status JSON: %w", err)
+	}
+	return decoded.Description.Text, nil
+}
+
+func writeStatusFrame(w io.Writer, payload []byte) error {
+	var frame bytes.Buffer
+	requireNoError := util.WriteVarInt(&frame, len(payload))
+	if requireNoError != nil {
+		return requireNoError
+	}
+	_, _ = frame.Write(payload)
+	_, err := w.Write(frame.Bytes())
+	return err
+}
+
+func readStatusFrame(r io.Reader) (int, []byte, error) {
+	length, err := util.ReadVarInt(r)
+	if err != nil {
+		return 0, nil, err
+	}
+	if length <= 0 || length > 1<<20 {
+		return 0, nil, fmt.Errorf("invalid frame length %d", length)
+	}
+	payload := make([]byte, length)
+	if _, err := io.ReadFull(r, payload); err != nil {
+		return 0, nil, err
+	}
+	reader := bytes.NewReader(payload)
+	id, err := util.ReadVarInt(reader)
+	if err != nil {
+		return 0, nil, err
+	}
+	data := make([]byte, reader.Len())
+	_, _ = io.ReadFull(reader, data)
+	return id, data, nil
+}

--- a/pkg/edition/java/proxy/proxy.go
+++ b/pkg/edition/java/proxy/proxy.go
@@ -27,6 +27,7 @@ import (
 	"go.minekube.com/gate/pkg/command"
 	"go.minekube.com/gate/pkg/edition/java/auth"
 	"go.minekube.com/gate/pkg/edition/java/config"
+	liteconfig "go.minekube.com/gate/pkg/edition/java/lite/config"
 	"go.minekube.com/gate/pkg/edition/java/netmc"
 	"go.minekube.com/gate/pkg/edition/java/proxy/message"
 	"go.minekube.com/gate/pkg/gate/proto"
@@ -243,17 +244,7 @@ func (p *Proxy) Start(ctx context.Context) error {
 		if e.Config.Lite.Enabled {
 			// reset whole cache if routes have changed because
 			// backend addrs might have moved to another route or a cacheTTL changed
-			if func() bool {
-				if len(e.Config.Lite.Routes) != len(e.PrevConfig.Lite.Routes) {
-					return true
-				}
-				for i, route := range e.Config.Lite.Routes {
-					if !route.Equal(&e.PrevConfig.Lite.Routes[i]) {
-						return true
-					}
-				}
-				return false
-			}() {
+			if liteRoutesChanged(e.Config.Lite.Routes, e.PrevConfig.Lite.Routes) {
 				lite.ResetPingCache()
 				p.log.Info("lite ping cache was reset")
 			}
@@ -267,6 +258,18 @@ func (p *Proxy) Start(ctx context.Context) error {
 }
 
 type javaConfigUpdateEvent = reload.ConfigUpdateEvent[config.Config]
+
+func liteRoutesChanged(current, previous []liteconfig.Route) bool {
+	if len(current) != len(previous) {
+		return true
+	}
+	for i, route := range current {
+		if !route.Equal(&previous[i]) {
+			return true
+		}
+	}
+	return false
+}
 
 // Shutdown stops the Proxy and/or blocks until the Proxy has finished shutdown.
 //

--- a/pkg/edition/java/proxy/reload_test.go
+++ b/pkg/edition/java/proxy/reload_test.go
@@ -1,0 +1,47 @@
+package proxy
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	liteconfig "go.minekube.com/gate/pkg/edition/java/lite/config"
+	"go.minekube.com/gate/pkg/util/configutil"
+)
+
+func TestLiteRoutesChanged(t *testing.T) {
+	base := []liteconfig.Route{{
+		Host:         []string{"play.example.com"},
+		Backend:      []string{"backend.example:25565"},
+		CachePingTTL: configutil.Duration(30 * time.Second),
+	}}
+
+	tests := []struct {
+		name     string
+		current  []liteconfig.Route
+		previous []liteconfig.Route
+		want     bool
+	}{
+		{name: "unchanged routes", current: base, previous: base, want: false},
+		{
+			name:     "backend changed",
+			current:  []liteconfig.Route{{Host: []string{"play.example.com"}, Backend: []string{"new-backend.example:25565"}, CachePingTTL: configutil.Duration(30 * time.Second)}},
+			previous: base,
+			want:     true,
+		},
+		{
+			name:     "cache ttl changed",
+			current:  []liteconfig.Route{{Host: []string{"play.example.com"}, Backend: []string{"backend.example:25565"}, CachePingTTL: configutil.Duration(time.Minute)}},
+			previous: base,
+			want:     true,
+		},
+		{name: "route added", current: append(base, liteconfig.Route{Host: []string{"other.example.com"}, Backend: []string{"other.example:25565"}}), previous: base, want: true},
+		{name: "route removed", current: base, previous: append(base, liteconfig.Route{Host: []string{"other.example.com"}, Backend: []string{"other.example:25565"}}), want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, liteRoutesChanged(tt.current, tt.previous))
+		})
+	}
+}


### PR DESCRIPTION
## Intent

Ship Gate #913: make Lite status-cache TTL insertion/refresh based by disabling touch-on-hit, with deterministic tests for hot reads, singleflight suppression, protocol-key isolation, and route-change/global invalidation, plus matching Lite documentation. Keep scope source-local: do not add a reload command, implement #914, touch production/GitOps, or disconnect players.

## What Changed

- Make Lite status-cache expiry start at backend fetch or refresh time, so cache hits no longer extend the configured TTL.
- Make route-change cache resets reject stale in-flight loads while preserving singleflight behavior per backend address and client protocol.
- Add deterministic unit and real-TCP integration coverage for expiry, concurrent misses, protocol isolation, and reload invalidation; update Lite docs and sample configs to match.

## Risk Assessment

✅ Low: The change is well-bounded, and the generation-scoped cache wrapper plus deterministic synchronization address the prior expiry, singleflight, and stale-reinsertion concerns without exposing a material new risk in the reviewed paths.

## Testing

A base replay reproduced the original sliding-expiry defect, then the target passed a real Minecraft TCP flow covering hot reads, singleflight, protocol isolation, and route-TTL reload invalidation; repeated cache race stress, affected packages, and the full Go suite passed. Isolated live reload still exposes the known out-of-scope #914 data race. No screenshot was captured because this is a server wire-protocol and documentation-copy change with no application UI surface.

<details>
<summary>Evidence: Gate Lite real-TCP status transcript</summary>

`Protocol 47 and 765 received distinct cached responses; 16 simultaneous clients caused one backend fetch; hot reads at +80/+160/+240ms did not postpone refresh at +380ms; changing cachePingTTL immediately invalidated the cached response.`

```text
=== RUN   TestLiteStatusCacheWireFlow
=== RUN   TestLiteStatusCacheWireFlow/protocol_keys_are_isolated
    lite_status_cache_integration_test.go:93: protocol 47 -> backend-fetch-1-protocol-47; protocol 765 -> backend-fetch-2-protocol-765; hot repeats caused 0 backend fetches
=== RUN   TestLiteStatusCacheWireFlow/concurrent_misses_are_singleflight
    lite_status_cache_integration_test.go:131: 16 simultaneous client pings -> backend-fetch-3-protocol-765; backend fetch delta=1
=== RUN   TestLiteStatusCacheWireFlow/hot_reads_do_not_extend_ttl
    lite_status_cache_integration_test.go:149: initial=backend-fetch-4-protocol-765; reads at +80ms/+160ms/+240ms stayed cached; +380ms=backend-fetch-5-protocol-765; backend fetch delta=2
=== RUN   TestLiteStatusCacheWireFlow/route_ttl_reload_invalidates_globally
    lite_status_cache_integration_test.go:165: cachePingTTL reload 300ms -> 2s invalidated backend-fetch-5-protocol-765; next client received backend-fetch-6-protocol-765 immediately
--- PASS: TestLiteStatusCacheWireFlow (0.64s)
    --- PASS: TestLiteStatusCacheWireFlow/protocol_keys_are_isolated (0.00s)
    --- PASS: TestLiteStatusCacheWireFlow/concurrent_misses_are_singleflight (0.25s)
    --- PASS: TestLiteStatusCacheWireFlow/hot_reads_do_not_extend_ttl (0.38s)
    --- PASS: TestLiteStatusCacheWireFlow/route_ttl_reload_invalidates_globally (0.00s)
PASS
ok  	go.minekube.com/gate/pkg/edition/java/proxy	0.965s
```
</details>
<details>
<summary>Evidence: Base-behavior red check</summary>

`The base cache remained on backend-fetch-4 at +380ms after hot reads, reproducing the original sliding-expiry defect.`

```text
=== RUN   TestLiteStatusCacheWireFlow
=== RUN   TestLiteStatusCacheWireFlow/protocol_keys_are_isolated
    lite_status_cache_integration_test.go:93: protocol 47 -> backend-fetch-1-protocol-47; protocol 765 -> backend-fetch-2-protocol-765; hot repeats caused 0 backend fetches
=== RUN   TestLiteStatusCacheWireFlow/concurrent_misses_are_singleflight
    lite_status_cache_integration_test.go:131: 16 simultaneous client pings -> backend-fetch-3-protocol-765; backend fetch delta=1
=== RUN   TestLiteStatusCacheWireFlow/hot_reads_do_not_extend_ttl
    lite_status_cache_integration_test.go:147: 
        	Error Trace:	/Users/robin/.no-mistakes/worktrees/543b8e602fb1/01KXDPYJZX8DVN2XYJF3PBQKMF/pkg/edition/java/proxy/lite_status_cache_integration_test.go:147
        	Error:      	Should not be: "backend-fetch-4-protocol-765"
        	Test:       	TestLiteStatusCacheWireFlow/hot_reads_do_not_extend_ttl
=== RUN   TestLiteStatusCacheWireFlow/route_ttl_reload_invalidates_globally
    lite_status_cache_integration_test.go:165: cachePingTTL reload 300ms -> 2s invalidated backend-fetch-4-protocol-765; next client received backend-fetch-5-protocol-765 immediately
--- FAIL: TestLiteStatusCacheWireFlow (0.64s)
    --- PASS: TestLiteStatusCacheWireFlow/protocol_keys_are_isolated (0.00s)
    --- PASS: TestLiteStatusCacheWireFlow/concurrent_misses_are_singleflight (0.25s)
    --- FAIL: TestLiteStatusCacheWireFlow/hot_reads_do_not_extend_ttl (0.38s)
    --- PASS: TestLiteStatusCacheWireFlow/route_ttl_reload_invalidates_globally (0.00s)
FAIL
FAIL	go.minekube.com/gate/pkg/edition/java/proxy	0.953s
FAIL
```
</details>
<details>
<summary>Evidence: Live reload race evidence</summary>

`Race detector output showing reload writes at proxy.go:233-234 conflicting with active listener and connection reads.`

```text
==================
WARNING: DATA RACE
Read at 0x00c0002c8140 by goroutine 13:
  go.minekube.com/gate/pkg/edition/java/proxy.(*Proxy).listenAndServe()
      /Users/robin/.no-mistakes/worktrees/543b8e602fb1/01KXDPYJZX8DVN2XYJF3PBQKMF/pkg/edition/java/proxy/proxy.go:659 +0x474
  go.minekube.com/gate/pkg/edition/java/proxy.(*Proxy).Start.(*Proxy).Start.func3.func5()
      /Users/robin/.no-mistakes/worktrees/543b8e602fb1/01KXDPYJZX8DVN2XYJF3PBQKMF/pkg/edition/java/proxy/proxy.go:224 +0x70
  golang.org/x/sync/errgroup.(*Group).Go.func1()
      /Users/robin/go/pkg/mod/golang.org/x/sync@v0.21.0/errgroup/errgroup.go:93 +0x70

Previous write at 0x00c0002c8140 by goroutine 15:
  go.minekube.com/gate/pkg/edition/java/proxy.(*Proxy).Start.func4()
      /Users/robin/.no-mistakes/worktrees/543b8e602fb1/01KXDPYJZX8DVN2XYJF3PBQKMF/pkg/edition/java/proxy/proxy.go:233 +0x90
  github.com/robinbraemer/event.Subscribe[*go.minekube.com/gate/pkg/internal/reload.ConfigUpdateEvent[go.shape.c5298970a2c31b80d79653bc9c6ba0fe0973fa784268bd588d5f8051514888fc]].func1()
      /Users/robin/go/pkg/mod/github.com/robinbraemer/event@v0.1.1/manager.go:53 +0x64
  github.com/robinbraemer/event.(*manager).callSubscriber()
      /Users/robin/go/pkg/mod/github.com/robinbraemer/event@v0.1.1/manager_internal.go:214 +0xdc
  github.com/robinbraemer/event.(*manager).fireSubscribers()
      /Users/robin/go/pkg/mod/github.com/robinbraemer/event@v0.1.1/manager_internal.go:199 +0xf0
  github.com/robinbraemer/event.(*manager).fire()
      /Users/robin/go/pkg/mod/github.com/robinbraemer/event@v0.1.1/manager_internal.go:188 +0x104
  github.com/robinbraemer/event.(*manager).Fire()
      /Users/robin/go/pkg/mod/github.com/robinbraemer/event@v0.1.1/manager_internal.go:174 +0x80
  go.minekube.com/gate/pkg/internal/reload.FireConfigUpdate[go.shape.c5298970a2c31b80d79653bc9c6ba0fe0973fa784268bd588d5f8051514888fc]()
      /Users/robin/.no-mistakes/worktrees/543b8e602fb1/01KXDPYJZX8DVN2XYJF3PBQKMF/pkg/internal/reload/event.go:41 +0x304
  go.minekube.com/gate/pkg/edition/java/proxy.TestLiteStatusCacheWireFlow.func8()
      /Users/robin/.no-mistakes/worktrees/543b8e602fb1/01KXDPYJZX8DVN2XYJF3PBQKMF/pkg/edition/java/proxy/lite_status_cache_integration_test.go:160 +0x258
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.26.2/libexec/src/testing/testing.go:2036 +0x164
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.26.2/libexec/src/testing/testing.go:2101 +0x34

Goroutine 13 (running) created at:
  golang.org/x/sync/errgroup.(*Group).Go()
      /Users/robin/go/pkg/mod/golang.org/x/sync@v0.21.0/errgroup/errgroup.go:78 +0x104
  go.minekube.com/gate/pkg/edition/java/proxy.(*Proxy).Start.func3()
      /Users/robin/.no-mistakes/worktrees/543b8e602fb1/01KXDPYJZX8DVN2XYJF3PBQKMF/pkg/edition/java/proxy/proxy.go:222 +0xbb4
  go.minekube.com/gate/pkg/edition/java/proxy.(*Proxy).Start()
      /Users/robin/.no-mistakes/worktrees/543b8e602fb1/01KXDPYJZX8DVN2XYJF3PBQKMF/pkg/edition/java/proxy/proxy.go:229 +0xa4c
  go.minekube.com/gate/pkg/edition/java/proxy.TestLiteStatusCacheWireFlow.func2()
      /Users/robin/.no-mistakes/worktrees/543b8e602fb1/01KXDPYJZX8DVN2XYJF3PBQKMF/pkg/edition/java/proxy/lite_status_cache_integration_test.go:63 +0x44

Goroutine 15 (running) created at:
  testing.(*T).Run()
      /opt/homebrew/Cellar/go/1.26.2/libexec/src/testing/testing.go:2101 +0x7bc
  go.minekube.com/gate/pkg/edition/java/proxy.TestLiteStatusCacheWireFlow()
      /Users/robin/.no-mistakes/worktrees/543b8e602fb1/01KXDPYJZX8DVN2XYJF3PBQKMF/pkg/edition/java/proxy/lite_status_cache_integration_test.go:152 +0xa90
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.26.2/libexec/src/testing/testing.go:2036 +0x164
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.26.2/libexec/src/testing/testing.go:2101 +0x34
==================
==================
WARNING: DATA RACE
Read at 0x00c000296658 by goroutine 20:
  go.minekube.com/gate/pkg/edition/java/proxy.(*Proxy).HandleConn()
      /Users/robin/.no-mistakes/worktrees/543b8e602fb1/01KXDPYJZX8DVN2XYJF3PBQKMF/pkg/edition/java/proxy/proxy.go:670 +0x44
  go.minekube.com/gate/pkg/edition/java/proxy.(*Proxy).listenAndServe.gowrap2()
      /Users/robin/.no-mistakes/worktrees/543b8e602fb1/01KXDPYJZX8DVN2XYJF3PBQKMF/pkg/edition/java/proxy/proxy.go:663 +0x40

Previous write at 0x00c000296658 by goroutine 15:
  go.minekube.com/gate/pkg/edition/java/proxy.(*Proxy).initQuota()
      /Users/robin/.no-mistakes/worktrees/543b8e602fb1/01KXDPYJZX8DVN2XYJF3PBQKMF/pkg/edition/java/proxy/proxy.go:145 +0x294
  go.minekube.com/gate/pkg/edition/java/proxy.(*Proxy).Start.func4()
      /Users/robin/.no-mistakes/worktrees/543b8e602fb1/01KXDPYJZX8DVN2XYJF3PBQKMF/pkg/edition/java/proxy/proxy.go:234 +0xfc
  github.com/robinbraemer/event.Subscribe[*go.minekube.com/gate/pkg/internal/reload.ConfigUpdateEvent[go.shape.c5298970a2c31b80d79653bc9c6ba0fe0973fa784268bd588d5f8051514888fc]].func1()
      /Users/robin/go/pkg/mod/github.com/robinbraemer/event@v0.1.1/manager.go:53 +0x64
  github.com/robinbraemer/event.(*manager).callSubscriber()
      /Users/robin/go/pkg/mod/github.com/robinbraemer/event@v0.1.1/manager_internal.go:214 +0xdc
  github.com/robinbraemer/event.(*manager).fireSubscribers()
      /Users/robin/go/pkg/mod/github.com/robinbraemer/event@v0.1.1/manager_internal.go:199 +0xf0
  github.com/robinbraemer/event.(*manager).fire()
      /Users/robin/go/pkg/mod/github.com/robinbraemer/event@v0.1.1/manager_internal.go:188 +0x104
  github.com/robinbraemer/event.(*manager).Fire()
      /Users/robin/go/pkg/mod/github.com/robinbraemer/event@v0.1.1/manager_internal.go:174 +0x80
  go.minekube.com/gate/pkg/internal/reload.FireConfigUpdate[go.shape.c5298970a2c31b80d79653bc9c6ba0fe0973fa784268bd588d5f8051514888fc]()
      /Users/robin/.no-mistakes/worktrees/543b8e602fb1/01KXDPYJZX8DVN2XYJF3PBQKMF/pkg/internal/reload/event.go:41 +0x304
  go.minekube.com/gate/pkg/edition/java/proxy.TestLiteStatusCacheWireFlow.func8()
      /Users/robin/.no-mistakes/worktrees/543b8e602fb1/01KXDPYJZX8DVN2XYJF3PBQKMF/pkg/edition/java/proxy/lite_status_cache_integration_test.go:160 +0x258
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.26.2/libexec/src/testing/testing.go:2036 +0x164
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.26.2/libexec/src/testing/testing.go:2101 +0x34

Goroutine 20 (running) created at:
  go.minekube.com/gate/pkg/edition/java/proxy.(*Proxy).listenAndServe()
      /Users/robin/.no-mistakes/worktrees/543b8e602fb1/01KXDPYJZX8DVN2XYJF3PBQKMF/pkg/edition/java/proxy/proxy.go:663 +0x434
  go.minekube.com/gate/pkg/edition/java/proxy.(*Proxy).Start.(*Proxy).Start.func3.func5()
      /Users/robin/.no-mistakes/worktrees/543b8e602fb1/01KXDPYJZX8DVN2XYJF3PBQKMF/pkg/edition/java/proxy/proxy.go:224 +0x70
  golang.org/x/sync/errgroup.(*Group).Go.func1()
      /Users/robin/go/pkg/mod/golang.org/x/sync@v0.21.0/errgroup/errgroup.go:93 +0x70

Goroutine 15 (running) created at:
  testing.(*T).Run()
      /opt/homebrew/Cellar/go/1.26.2/libexec/src/testing/testing.go:2101 +0x7bc
  go.minekube.com/gate/pkg/edition/java/proxy.TestLiteStatusCacheWireFlow()
      /Users/robin/.no-mistakes/worktrees/543b8e602fb1/01KXDPYJZX8DVN2XYJF3PBQKMF/pkg/edition/java/proxy/lite_status_cache_integration_test.go:152 +0xa90
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.26.2/libexec/src/testing/testing.go:2036 +0x164
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.26.2/libexec/src/testing/testing.go:2101 +0x34
==================
==================
WARNING: DATA RACE
Read at 0x00c0002c8118 by goroutine 20:
  go.minekube.com/gate/pkg/edition/java/proxy.(*Proxy).HandleConn()
      /Users/robin/.no-mistakes/worktrees/543b8e602fb1/01KXDPYJZX8DVN2XYJF3PBQKMF/pkg/edition/java/proxy/proxy.go:709 +0x984
  go.minekube.com/gate/pkg/edition/java/proxy.(*Proxy).listenAndServe.gowrap2()
      /Users/robin/.no-mistakes/worktrees/543b8e602fb1/01KXDPYJZX8DVN2XYJF3PBQKMF/pkg/edition/java/proxy/proxy.go:663 +0x40

Previous write at 0x00c0002c8118 by goroutine 15:
  go.minekube.com/gate/pkg/edition/java/proxy.(*Proxy).Start.func4()
      /Users/robin/.no-mistakes/worktrees/543b8e602fb1/01KXDPYJZX8DVN2XYJF3PBQKMF/pkg/edition/jav

... [9159 bytes truncated] ...

utine 15 (running) created at:
  testing.(*T).Run()
      /opt/homebrew/Cellar/go/1.26.2/libexec/src/testing/testing.go:2101 +0x7bc
  go.minekube.com/gate/pkg/edition/java/proxy.TestLiteStatusCacheWireFlow()
      /Users/robin/.no-mistakes/worktrees/543b8e602fb1/01KXDPYJZX8DVN2XYJF3PBQKMF/pkg/edition/java/proxy/lite_status_cache_integration_test.go:152 +0xa90
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.26.2/libexec/src/testing/testing.go:2036 +0x164
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.26.2/libexec/src/testing/testing.go:2101 +0x34
==================
==================
WARNING: DATA RACE
Read at 0x00c0002c8138 by goroutine 20:
  go.minekube.com/gate/pkg/edition/java/proxy.(*Proxy).HandleConn()
      /Users/robin/.no-mistakes/worktrees/543b8e602fb1/01KXDPYJZX8DVN2XYJF3PBQKMF/pkg/edition/java/proxy/proxy.go:715 +0xd74
  go.minekube.com/gate/pkg/edition/java/proxy.(*Proxy).listenAndServe.gowrap2()
      /Users/robin/.no-mistakes/worktrees/543b8e602fb1/01KXDPYJZX8DVN2XYJF3PBQKMF/pkg/edition/java/proxy/proxy.go:663 +0x40

Previous write at 0x00c0002c8138 by goroutine 15:
  go.minekube.com/gate/pkg/edition/java/proxy.(*Proxy).Start.func4()
      /Users/robin/.no-mistakes/worktrees/543b8e602fb1/01KXDPYJZX8DVN2XYJF3PBQKMF/pkg/edition/java/proxy/proxy.go:233 +0x90
  github.com/robinbraemer/event.Subscribe[*go.minekube.com/gate/pkg/internal/reload.ConfigUpdateEvent[go.shape.c5298970a2c31b80d79653bc9c6ba0fe0973fa784268bd588d5f8051514888fc]].func1()
      /Users/robin/go/pkg/mod/github.com/robinbraemer/event@v0.1.1/manager.go:53 +0x64
  github.com/robinbraemer/event.(*manager).callSubscriber()
      /Users/robin/go/pkg/mod/github.com/robinbraemer/event@v0.1.1/manager_internal.go:214 +0xdc
  github.com/robinbraemer/event.(*manager).fireSubscribers()
      /Users/robin/go/pkg/mod/github.com/robinbraemer/event@v0.1.1/manager_internal.go:199 +0xf0
  github.com/robinbraemer/event.(*manager).fire()
      /Users/robin/go/pkg/mod/github.com/robinbraemer/event@v0.1.1/manager_internal.go:188 +0x104
  github.com/robinbraemer/event.(*manager).Fire()
      /Users/robin/go/pkg/mod/github.com/robinbraemer/event@v0.1.1/manager_internal.go:174 +0x80
  go.minekube.com/gate/pkg/internal/reload.FireConfigUpdate[go.shape.c5298970a2c31b80d79653bc9c6ba0fe0973fa784268bd588d5f8051514888fc]()
      /Users/robin/.no-mistakes/worktrees/543b8e602fb1/01KXDPYJZX8DVN2XYJF3PBQKMF/pkg/internal/reload/event.go:41 +0x304
  go.minekube.com/gate/pkg/edition/java/proxy.TestLiteStatusCacheWireFlow.func8()
      /Users/robin/.no-mistakes/worktrees/543b8e602fb1/01KXDPYJZX8DVN2XYJF3PBQKMF/pkg/edition/java/proxy/lite_status_cache_integration_test.go:160 +0x258
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.26.2/libexec/src/testing/testing.go:2036 +0x164
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.26.2/libexec/src/testing/testing.go:2101 +0x34

Goroutine 20 (running) created at:
  go.minekube.com/gate/pkg/edition/java/proxy.(*Proxy).listenAndServe()
      /Users/robin/.no-mistakes/worktrees/543b8e602fb1/01KXDPYJZX8DVN2XYJF3PBQKMF/pkg/edition/java/proxy/proxy.go:663 +0x434
  go.minekube.com/gate/pkg/edition/java/proxy.(*Proxy).Start.(*Proxy).Start.func3.func5()
      /Users/robin/.no-mistakes/worktrees/543b8e602fb1/01KXDPYJZX8DVN2XYJF3PBQKMF/pkg/edition/java/proxy/proxy.go:224 +0x70
  golang.org/x/sync/errgroup.(*Group).Go.func1()
      /Users/robin/go/pkg/mod/golang.org/x/sync@v0.21.0/errgroup/errgroup.go:93 +0x70

Goroutine 15 (running) created at:
  testing.(*T).Run()
      /opt/homebrew/Cellar/go/1.26.2/libexec/src/testing/testing.go:2101 +0x7bc
  go.minekube.com/gate/pkg/edition/java/proxy.TestLiteStatusCacheWireFlow()
      /Users/robin/.no-mistakes/worktrees/543b8e602fb1/01KXDPYJZX8DVN2XYJF3PBQKMF/pkg/edition/java/proxy/lite_status_cache_integration_test.go:152 +0xa90
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.26.2/libexec/src/testing/testing.go:2036 +0x164
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.26.2/libexec/src/testing/testing.go:2101 +0x34
==================
==================
WARNING: DATA RACE
Read at 0x00c000296660 by goroutine 20:
  go.minekube.com/gate/pkg/edition/java/proxy.(*Proxy).HandleConn()
      /Users/robin/.no-mistakes/worktrees/543b8e602fb1/01KXDPYJZX8DVN2XYJF3PBQKMF/pkg/edition/java/proxy/proxy.go:724 +0xf3c
  go.minekube.com/gate/pkg/edition/java/proxy.(*Proxy).listenAndServe.gowrap2()
      /Users/robin/.no-mistakes/worktrees/543b8e602fb1/01KXDPYJZX8DVN2XYJF3PBQKMF/pkg/edition/java/proxy/proxy.go:663 +0x40

Previous write at 0x00c000296660 by goroutine 15:
  go.minekube.com/gate/pkg/edition/java/proxy.(*Proxy).initQuota()
      /Users/robin/.no-mistakes/worktrees/543b8e602fb1/01KXDPYJZX8DVN2XYJF3PBQKMF/pkg/edition/java/proxy/proxy.go:150 +0x4e8
  go.minekube.com/gate/pkg/edition/java/proxy.(*Proxy).Start.func4()
      /Users/robin/.no-mistakes/worktrees/543b8e602fb1/01KXDPYJZX8DVN2XYJF3PBQKMF/pkg/edition/java/proxy/proxy.go:234 +0xfc
  github.com/robinbraemer/event.Subscribe[*go.minekube.com/gate/pkg/internal/reload.ConfigUpdateEvent[go.shape.c5298970a2c31b80d79653bc9c6ba0fe0973fa784268bd588d5f8051514888fc]].func1()
      /Users/robin/go/pkg/mod/github.com/robinbraemer/event@v0.1.1/manager.go:53 +0x64
  github.com/robinbraemer/event.(*manager).callSubscriber()
      /Users/robin/go/pkg/mod/github.com/robinbraemer/event@v0.1.1/manager_internal.go:214 +0xdc
  github.com/robinbraemer/event.(*manager).fireSubscribers()
      /Users/robin/go/pkg/mod/github.com/robinbraemer/event@v0.1.1/manager_internal.go:199 +0xf0
  github.com/robinbraemer/event.(*manager).fire()
      /Users/robin/go/pkg/mod/github.com/robinbraemer/event@v0.1.1/manager_internal.go:188 +0x104
  github.com/robinbraemer/event.(*manager).Fire()
      /Users/robin/go/pkg/mod/github.com/robinbraemer/event@v0.1.1/manager_internal.go:174 +0x80
  go.minekube.com/gate/pkg/internal/reload.FireConfigUpdate[go.shape.c5298970a2c31b80d79653bc9c6ba0fe0973fa784268bd588d5f8051514888fc]()
      /Users/robin/.no-mistakes/worktrees/543b8e602fb1/01KXDPYJZX8DVN2XYJF3PBQKMF/pkg/internal/reload/event.go:41 +0x304
  go.minekube.com/gate/pkg/edition/java/proxy.TestLiteStatusCacheWireFlow.func8()
      /Users/robin/.no-mistakes/worktrees/543b8e602fb1/01KXDPYJZX8DVN2XYJF3PBQKMF/pkg/edition/java/proxy/lite_status_cache_integration_test.go:160 +0x258
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.26.2/libexec/src/testing/testing.go:2036 +0x164
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.26.2/libexec/src/testing/testing.go:2101 +0x34

Goroutine 20 (running) created at:
  go.minekube.com/gate/pkg/edition/java/proxy.(*Proxy).listenAndServe()
      /Users/robin/.no-mistakes/worktrees/543b8e602fb1/01KXDPYJZX8DVN2XYJF3PBQKMF/pkg/edition/java/proxy/proxy.go:663 +0x434
  go.minekube.com/gate/pkg/edition/java/proxy.(*Proxy).Start.(*Proxy).Start.func3.func5()
      /Users/robin/.no-mistakes/worktrees/543b8e602fb1/01KXDPYJZX8DVN2XYJF3PBQKMF/pkg/edition/java/proxy/proxy.go:224 +0x70
  golang.org/x/sync/errgroup.(*Group).Go.func1()
      /Users/robin/go/pkg/mod/golang.org/x/sync@v0.21.0/errgroup/errgroup.go:93 +0x70

Goroutine 15 (running) created at:
  testing.(*T).Run()
      /opt/homebrew/Cellar/go/1.26.2/libexec/src/testing/testing.go:2101 +0x7bc
  go.minekube.com/gate/pkg/edition/java/proxy.TestLiteStatusCacheWireFlow()
      /Users/robin/.no-mistakes/worktrees/543b8e602fb1/01KXDPYJZX8DVN2XYJF3PBQKMF/pkg/edition/java/proxy/lite_status_cache_integration_test.go:152 +0xa90
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.26.2/libexec/src/testing/testing.go:2036 +0x164
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.26.2/libexec/src/testing/testing.go:2101 +0x34
==================
--- FAIL: TestLiteStatusCacheWireFlow (0.02s)
    --- FAIL: TestLiteStatusCacheWireFlow/route_ttl_reload_invalidates_globally (0.00s)
        lite_status_cache_integration_test.go:165: cachePingTTL reload 300ms -> 2s invalidated backend-fetch-1-protocol-765; next client received backend-fetch-2-protocol-765 immediately
        testing.go:1712: race detected during execution of test
FAIL
FAIL	go.minekube.com/gate/pkg/edition/java/proxy	3.957s
FAIL
```
</details>
- Outcome: ⚠️ 2 issues (1 warning, 1 info) across 1 run (9m53s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 3 issues found → auto-fixed ✅</summary>

- ⚠️ `pkg/edition/java/proxy/proxy.go:247` - A route reload only deletes current entries. A status load started before the reload uses context.Background and can subsequently call Set, repopulating the cache with the old route result and TTL. Prevent pre-reload loaders from committing after invalidation, such as with a cache generation check, and cover this ordering explicitly.
- ⚠️ `pkg/edition/java/lite/forward_test.go:71` - The singleflight test releases the leader immediately after opening the workers&#39; start gate. The leader may populate the cache before any worker calls Get, so the test can report one load even without suppression. Synchronize until contenders have entered the miss path while the leader remains blocked.
- ⚠️ `pkg/edition/java/lite/forward_test.go:29` - The hot-read regression test only verifies that ExpiresAt metadata remains unchanged across immediate reads. It never crosses the TTL or invokes refresh, so it does not prove that an expired entry is rejected and replaced with fresh backend status. Add an injectable clock/cache seam and assert the post-expiry load returns a new result.

🔧 Fix: Harden Lite cache invalidation and expiry tests
✅ Re-checked - no issues remain.

</details>

<details>
<summary>⚠️ **Test** - 2 issues (1 warning, 1 info)</summary>

- ⚠️ `pkg/edition/java/proxy/proxy.go:233` - The existing live config-reload path writes `p.cfg` and quota pointers while listener and connection goroutines read them. This is a real pre-existing reload-safety issue aligned with tracked #914; the stated #913 scope explicitly excludes implementing #914. Normal end-to-end behavior and the full non-race suite pass.
- ℹ️ `pkg/edition/java/proxy/lite_status_cache_integration_test.go` - new test file written by agent: pkg/edition/java/proxy/lite_status_cache_integration_test.go
- <code>Inspected `git diff a5fbfbb59eb8e0bee5a138c4bf7abd23f79d4aeb..b43b946eb3c3ade6d47e5d814495ac6df79654e0` and existing Lite/proxy integration patterns.</code>
- <code>`go test ./pkg/edition/java/proxy -run &#39;^TestLiteStatusCacheWireFlow$&#39; -count=1 -v -timeout=30s` against a full product-code base replay; encountered and corrected a mixed-revision setup compile dependency.</code>
- <code>`go test ./pkg/edition/java/proxy -run &#39;^TestLiteStatusCacheWireFlow$&#39; -count=1 -v -timeout=30s` with only the cache implementation replayed to base; expected red failure reproduced hot-read sliding expiry.</code>
- <code>`go test ./pkg/edition/java/proxy -run &#39;^TestLiteStatusCacheWireFlow$&#39; -count=1 -v -timeout=30s` at target state; generated the real-TCP evidence transcript.</code>
- `go test -race ./pkg/edition/java/lite -run '^(TestPingCacheRefreshesAfterInsertionBasedExpiry|TestPingCacheLoaderSuppressesConcurrentMisses|TestPingCacheSeparatesProtocols|TestResetPingCacheInvalidatesAllBackendsAndProtocols|TestResetPingCacheRejectsInFlightLoad)$' -count=10 -timeout=2m`
- `go test -race ./pkg/edition/java/proxy -run '^TestLiteStatusCacheWireFlow/(protocol_keys_are_isolated|concurrent_misses_are_singleflight|hot_reads_do_not_extend_ttl)$' -count=5 -timeout=2m`
- `go test ./pkg/edition/java/lite ./pkg/edition/java/proxy -count=1 -timeout=5m`
- `go test ./... -count=1 -timeout=10m`
- <code>`go test -race ./pkg/edition/java/proxy -run &#39;^TestLiteStatusCacheWireFlow/route_ttl_reload_invalidates_globally$&#39; -count=1 -timeout=30s`; expected failure confirmed the pre-existing #914 reload races.</code>
- `Verified the Lite documentation explicitly describes fetch/refresh-based TTL and backend-address/protocol cache keys.`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
