### PR TITLE
ci: pin release dispatch workflow immutably

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -63,7 +63,7 @@ jobs:
   dispatch-moxy-bump:
     needs: release-please
     if: needs.release-please.outputs.release_created == 'true'
-    uses: minekube/actions/.github/workflows/dispatch-workflow.yml@v1
+    uses: minekube/actions/.github/workflows/dispatch-workflow.yml@1965ed6ae602a602f9f98edcb31fe177403e8d77
     permissions:
       contents: read
       id-token: write

--- a/release_please_workflow_test.go
+++ b/release_please_workflow_test.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"os"
+	"reflect"
+	"regexp"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+const approvedDispatchWorkflow = "minekube/actions/.github/workflows/dispatch-workflow.yml@1965ed6ae602a602f9f98edcb31fe177403e8d77"
+
+var immutableWorkflowRef = regexp.MustCompile(`^[0-9a-f]{40}$`)
+
+func TestReleasePleaseMoxyDispatchWorkflowContract(t *testing.T) {
+	workflowBytes, err := os.ReadFile(".github/workflows/release-please.yml")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var workflow struct {
+		Jobs map[string]struct {
+			Needs       string            `yaml:"needs"`
+			If          string            `yaml:"if"`
+			Uses        string            `yaml:"uses"`
+			Permissions map[string]string `yaml:"permissions"`
+			With        map[string]string `yaml:"with"`
+			Secrets     string            `yaml:"secrets"`
+		} `yaml:"jobs"`
+	}
+	if err := yaml.Unmarshal(workflowBytes, &workflow); err != nil {
+		t.Fatal(err)
+	}
+
+	dispatch, ok := workflow.Jobs["dispatch-moxy-bump"]
+	if !ok {
+		t.Fatal("dispatch-moxy-bump job is missing")
+	}
+	if dispatch.Uses != approvedDispatchWorkflow {
+		t.Fatalf("dispatch workflow = %q, want %q", dispatch.Uses, approvedDispatchWorkflow)
+	}
+	if dispatch.Needs != "release-please" || dispatch.If != "needs.release-please.outputs.release_created == 'true'" {
+		t.Fatalf("dispatch release gate = needs %q, if %q", dispatch.Needs, dispatch.If)
+	}
+	if !reflect.DeepEqual(dispatch.Permissions, map[string]string{"contents": "read", "id-token": "write"}) {
+		t.Fatalf("dispatch permissions = %#v", dispatch.Permissions)
+	}
+	if dispatch.Secrets != "inherit" {
+		t.Fatalf("dispatch secrets = %q, want inherit", dispatch.Secrets)
+	}
+
+	_, ref, ok := strings.Cut(dispatch.Uses, "@")
+	if !ok || !immutableWorkflowRef.MatchString(ref) {
+		t.Fatalf("dispatch workflow ref = %q, want a 40-character lowercase commit SHA", ref)
+	}
+
+	wantInputs := map[string]string{
+		"target-repository": "moxy",
+		"target-workflow":   "bump-gate.yml",
+		"target-ref":        "main",
+		"inputs-json": `{
+  "version": "${{ needs.release-please.outputs.tag_name }}",
+  "source_repository": "${{ github.repository }}",
+  "source_release_url": "${{ github.server_url }}/${{ github.repository }}/releases/tag/${{ needs.release-please.outputs.tag_name }}"
+}
+`,
+	}
+	if !reflect.DeepEqual(dispatch.With, wantInputs) {
+		t.Fatalf("dispatch inputs = %#v, want %#v", dispatch.With, wantInputs)
+	}
+}


### PR DESCRIPTION
## Intent

Validate and ship the existing Gate immutable release-dispatch pin commit: pin only dispatch-moxy-bump to Minekube Actions merge 1965ed6ae602a602f9f98edcb31fe177403e8d77 with its focused guard, preserving all other workflow semantics and independent consumers. No manual dispatch/rerun, release, merge, deployment, Moxy change, website PR 106 touch, dependency, or toolchain change. Continue through exact-head green PR without --yes, then stop for captain approval.

## What Changed

- Pin the `dispatch-moxy-bump` reusable workflow to the approved immutable Minekube Actions commit.
- Add a focused contract test that guards the immutable reference and preserves the job’s release gate, permissions, secrets, and dispatch inputs.

## Risk Assessment

✅ Low: The change is narrowly scoped to the required immutable pin and focused contract guard, with no other workflow consumers, dependencies, toolchain files, or release behavior changed.

## Testing

At exact target HEAD, diff inspection and repository search established the intended two-file scope and untouched independent consumer; the focused guard passed, the same guard rejected the base workflow’s movable tag, and the pinned remote workflow/commit resolved with compatible dispatch inputs. Reviewer-visible diff, red/green transcripts, and remote workflow evidence were captured; no manual dispatch, rerun, release, merge, deployment, Moxy operation, or website change was performed.

<details>
<summary>Evidence: Guard rejects baseline movable @v1 reference</summary>

```text
=== RUN   TestReleasePleaseMoxyDispatchWorkflowContract
    release_please_workflow_test.go:42: dispatch workflow = "minekube/actions/.github/workflows/dispatch-workflow.yml@v1", want "minekube/actions/.github/workflows/dispatch-workflow.yml@1965ed6ae602a602f9f98edcb31fe177403e8d77"
--- FAIL: TestReleasePleaseMoxyDispatchWorkflowContract (0.00s)
FAIL
```
</details>
<details>
<summary>Evidence: Guard accepts target immutable reference</summary>

```text
=== RUN   TestReleasePleaseMoxyDispatchWorkflowContract
--- PASS: TestReleasePleaseMoxyDispatchWorkflowContract (0.00s)
PASS
```
</details>
<details>
<summary>Evidence: Workflow-only before/after diff</summary>

```text
diff --git a/.github/workflows/release-please.yml b/.github/workflows/release-please.yml
index 6019541..d186a64 100644
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -58,17 +58,17 @@ jobs:
         run: |
           gh workflow run ci.yml \
             --repo "${{ github.repository }}" \
             --ref "${{ needs.release-please.outputs.tag_name }}"
 
   dispatch-moxy-bump:
     needs: release-please
     if: needs.release-please.outputs.release_created == 'true'
-    uses: minekube/actions/.github/workflows/dispatch-workflow.yml@v1
+    uses: minekube/actions/.github/workflows/dispatch-workflow.yml@1965ed6ae602a602f9f98edcb31fe177403e8d77
     permissions:
       contents: read
       id-token: write
     with:
       target-repository: moxy
       target-workflow: bump-gate.yml
       target-ref: main
       inputs-json: |
```
</details>
<details>
<summary>Evidence: Pinned reusable workflow fetched from exact SHA</summary>

```text
name: Dispatch workflow

on:
  workflow_call:
    inputs:
      target-owner:
        description: Target repository owner.
        required: false
        type: string
        default: minekube
      target-repository:
        description: Target repository name.
        required: true
        type: string
      target-workflow:
        description: Target workflow file name or ID.
        required: true
        type: string
      target-ref:
        description: Target ref to dispatch.
        required: true
        type: string
      inputs-json:
        description: JSON object passed as workflow_dispatch inputs.
        required: false
        type: string
        default: "{}"
      runner-control-plane-url:
        description: Akua runner control plane URL.
        required: false
        type: string
        default: https://runner-control-plane.robinbraemer.workers.dev
      runner-oidc-audience:
        description: OIDC audience for the Akua runner control plane.
        required: false
        type: string
        default: akua-runner-control-plane
    secrets:
      RELEASE_CASCADE_APP_PRIVATE_KEY:
        required: true

permissions:
  contents: read
  id-token: write

jobs:
  runner-plan:
    uses: akua-dev/actions/.github/workflows/runner-plan.yml@9d86a1802f2ebc29c7d5770a4ffff7bb84b6cdc0
    with:
      control-plane-url: ${{ inputs.runner-control-plane-url }}
      oidc-audience: ${{ inputs.runner-oidc-audience }}
      jobs-json: '{"linux_x64":"linux-x64"}'

  dispatch:
    needs: runner-plan
    runs-on: ${{ fromJSON(needs.runner-plan.outputs.linux_x64) }}
    steps:
      - name: Validate dispatch inputs
        env:
          INPUTS_JSON: ${{ inputs.inputs-json }}
        run: |
          set -euo pipefail
          jq -e 'type == "object"' <<<"$INPUTS_JSON" >/dev/null

      - name: Create GitHub App token
        id: app-token
        uses: actions/create-github-app-token@v3
        with:
          app-id: ${{ vars.RELEASE_CASCADE_APP_ID }}
          private-key: ${{ secrets.RELEASE_CASCADE_APP_PRIVATE_KEY }}
          owner: ${{ inputs.target-owner }}
          repositories: ${{ inputs.target-repository }}
          permission-actions: write

      - name: Install GitHub CLI
        shell: bash
        run: |
          set -euo pipefail

          if command -v gh >/dev/null 2>&1; then
            gh --version
            exit 0
          fi

          os="$(uname -s | tr '[:upper:]' '[:lower:]')"
          case "$(uname -m)" in
            x86_64) arch="amd64" ;;
            aarch64|arm64) arch="arm64" ;;
            *)
              echo "::error::Unsupported architecture: $(uname -m)"
              exit 1
              ;;
          esac

          version="$(
            curl -fsSL https://api.github.com/repos/cli/cli/releases/latest |
              sed -n 's/.*"tag_name": "v\([^"]*\)".*/\1/p' |
              head -n 1
          )"
          if [ -z "$version" ]; then
            echo "::error::Could not resolve latest GitHub CLI version"
            exit 1
          fi

          tmp_dir="$(mktemp -d)"
          curl -fsSL \
            -o "${tmp_dir}/gh.tar.gz" \
            "https://github.com/cli/cli/releases/download/v${version}/gh_${version}_${os}_${arch}.tar.gz"
          tar -xzf "${tmp_dir}/gh.tar.gz" -C "$tmp_dir"

          install_dir="${RUNNER_TEMP}/gh-bin"
          mkdir -p "$install_dir"
          cp "${tmp_dir}"/gh_*/bin/gh "${install_dir}/gh"
          echo "$install_dir" >> "$GITHUB_PATH"
          "${install_dir}/gh" --version

      - name: Dispatch target workflow
        env:
          GH_TOKEN: ${{ steps.app-token.outputs.token }}
          TARGET_OWNER: ${{ inputs.target-owner }}
          TARGET_REPOSITORY: ${{ inputs.target-repository }}
          TARGET_WORKFLOW: ${{ inputs.target-workflow }}
          TARGET_REF: ${{ inputs.target-ref }}
          INPUTS_JSON: ${{ inputs.inputs-json }}
        run: |
          set -euo pipefail

          jq -n \
            --arg ref "$TARGET_REF" \
            --argjson inputs "$INPUTS_JSON" \
            '{ref: $ref, inputs: $inputs}' |
            gh api \
              --method POST \
              "repos/${TARGET_OWNER}/${TARGET_REPOSITORY}/actions/workflows/${TARGET_WORKFLOW}/dispatches" \
              --input -
```
</details>
<details>
<summary>Evidence: Approved Minekube Actions commit resolution</summary>

Source: [Approved Minekube Actions commit resolution](https://github.com/minekube/actions/commit/1965ed6ae602a602f9f98edcb31fe177403e8d77)

`{"sha":"1965ed6ae602a602f9f98edcb31fe177403e8d77","commit":{"message":"fix: pin reusable runner plan workflow (#1)"}}`

```text
{
  "sha": "1965ed6ae602a602f9f98edcb31fe177403e8d77",
  "commit": {
    "message": "fix: pin reusable runner plan workflow (#1)"
  },
  "html_url": "https://github.com/minekube/actions/commit/1965ed6ae602a602f9f98edcb31fe177403e8d77"
}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `git diff --find-renames --find-copies --full-index e9fa009e243dc71b190b410bba602a29b4ccdac5..a907e86329edfb88c091e57a519cf57635c317ef`
- `go test . -run '^TestReleasePleaseMoxyDispatchWorkflowContract$' -count=1 -v`
- <code>`go test -c -o &lt;evidence&gt;/release-workflow-guard.test .` followed by running the guard against the base-commit workflow; it failed specifically on movable `@v1` as expected</code>
- `Run the same compiled guard against the target workflow; it passed`
- `curl --fail --location https://raw.githubusercontent.com/minekube/actions/1965ed6ae602a602f9f98edcb31fe177403e8d77/.github/workflows/dispatch-workflow.yml`
- <code>GitHub commit API lookup for `minekube/actions@1965ed6ae602a602f9f98edcb31fe177403e8d77`</code>
- `rg --hidden -n 'minekube/actions|uses:' .github/workflows`
- `git diff --exit-code e9fa009e243dc71b190b410bba602a29b4ccdac5..a907e86329edfb88c091e57a519cf57635c317ef -- . ':!.github/workflows/release-please.yml' ':!release_please_workflow_test.go'`
- `Fresh exact-HEAD, two-file scope, remote-resolution, focused-test, and clean-worktree verification`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
