### PR TITLE
fix(java): prevent chat acknowledgement desync across commands

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,7 +3,7 @@
 This file is the project's committed home for project-intrinsic agent knowledge: build, test, release, architecture, and sharp-edge notes that should travel with the code.
 
 - Add durable project-specific notes here as they are discovered through real work.
-- Secure-chat acknowledgement state is maintained in `pkg/edition/java/proxy/chat_queue.go`; its delayed-offset behavior was ported from Velocity, so changes require a protocol-level reproduction rather than treating the adjustment as dead code for modern clients.
+- Secure-chat acknowledgement state is maintained in `pkg/edition/java/proxy/chat_queue.go` and driven by the handlers in `handle_cmd.go`/`handle_chat.go`; it is a direct port of Velocity (`ChatQueue`, `SessionCommandHandler`), which is the reference for correct behavior. The `LastSeenMessages.Offset += delayedAckCount` adjustment is intentional and matches Velocity — not dead code — so validate any change against Velocity's source and a proxy-level reproduction. Key invariant: an `UnsignedPlayerCommand` (1.20.5+, commands with no signable args — the common path in offline mode) carries NO last-seen update, so it must not be fed into the chat queue (that flushes and discards the player's held acknowledgements) and must be forwarded command-only; a consumed command's `ChatAcknowledgement` gates on the offset, not the acknowledged bitset. Regression coverage: `handle_cmd_ack_test.go`.
 
 ## Maintaining this file
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,13 @@
+# Project agent memory
+
+This file is the project's committed home for project-intrinsic agent knowledge: build, test, release, architecture, and sharp-edge notes that should travel with the code.
+
+- Add durable project-specific notes here as they are discovered through real work.
+- Secure-chat acknowledgement state is maintained in `pkg/edition/java/proxy/chat_queue.go`; its delayed-offset behavior was ported from Velocity, so changes require a protocol-level reproduction rather than treating the adjustment as dead code for modern clients.
+
+## Maintaining this file
+
+Keep this file for knowledge useful to almost every future agent session in this project.
+Do not repeat what the codebase already shows; point to the authoritative file or command instead.
+Prefer rewriting or pruning existing entries over appending new ones.
+When updating this file, preserve this bar for all agents and keep entries concise.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/pkg/edition/java/proxy/chat_queue_test.go
+++ b/pkg/edition/java/proxy/chat_queue_test.go
@@ -1,0 +1,26 @@
+package proxy
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.minekube.com/gate/pkg/edition/java/proto/packet/chat"
+)
+
+func TestChatStateUpdateFromMessageDivergesAfterGateHoldsAcknowledgements(t *testing.T) {
+	directState := &ChatState{}
+	proxiedState := &ChatState{}
+
+	const (
+		heldAcknowledgements = 3
+		clientOffset         = 7
+	)
+	direct := directState.UpdateFromMessage(nil, &chat.LastSeenMessages{Offset: clientOffset})
+	proxiedState.AccumulateAckCount(heldAcknowledgements)
+	proxied := proxiedState.UpdateFromMessage(nil, &chat.LastSeenMessages{Offset: clientOffset})
+
+	require.NotNil(t, direct)
+	require.NotNil(t, proxied)
+	require.Equal(t, clientOffset, direct.Offset)
+	require.Equal(t, clientOffset+heldAcknowledgements, proxied.Offset)
+}

--- a/pkg/edition/java/proxy/handle_cmd.go
+++ b/pkg/edition/java/proxy/handle_cmd.go
@@ -183,8 +183,11 @@ func (c *chatHandler) handleSessionCommand(packet *chat.SessionPlayerCommand, un
 		}
 
 		// An unsigned command with a 'last seen' update will not happen as of 1.20.5+, but for earlier versions - we still
-		// need to pass through the acknowledgement
-		if c.player.Protocol().GreaterEqual(version.Minecraft_1_19_3) && !packet.LastSeenMessages.Empty() {
+		// need to pass through the acknowledgement. A ChatAcknowledgement only carries an offset, so we must gate on the
+		// offset (the number of messages to advance the backend's window), not on the acknowledged bitset: a consumed
+		// command with a non-zero offset but an empty bitset still has to advance the window, otherwise the backend
+		// desyncs and rejects the next message. This matches Velocity's SessionCommandHandler.consumeCommand.
+		if c.player.Protocol().GreaterEqual(version.Minecraft_1_19_3) && packet.LastSeenMessages.Offset != 0 {
 			return &chat.ChatAcknowledgement{
 				Offset: packet.LastSeenMessages.Offset,
 			}
@@ -207,13 +210,30 @@ func (c *chatHandler) handleSessionCommand(packet *chat.SessionPlayerCommand, un
 
 	forwardCommand := func(packet *chat.SessionPlayerCommand, newCommand string) proto.Packet {
 		if newCommand == packet.Command {
+			if unsigned {
+				// An UnsignedPlayerCommand (1.20.5+) carries no 'last seen' update. Forward it as-is
+				// (command only) instead of re-encoding it as a signed session command with an empty
+				// acknowledgement, which the backend would validate against its last-seen window and
+				// reject. This mirrors Velocity's UnsignedPlayerCommandPacket.withLastSeenMessages,
+				// which returns the unmodified command-only packet.
+				return &chat.UnsignedPlayerCommand{SessionPlayerCommand: *packet}
+			}
 			return packet
 		}
 		return modifyCommand(packet, newCommand)
 	}
 
-	c.queueCommandResult(packet.Command, packet.Timestamp, &packet.LastSeenMessages, func(e *CommandExecuteEvent, newLastSeenMessages *chat.LastSeenMessages) proto.Packet {
-		if newLastSeenMessages != nil && !unsigned {
+	// Unsigned commands (1.20.5+) carry no 'last seen' update, so we must not feed one into the chat queue.
+	// Doing so flushes the player's held acknowledgements (delayedAckCount) and then discards them, desyncing
+	// the backend's last-seen window and causing "message acknowledgement" kicks (gate#915, gate#921). This
+	// mirrors Velocity, whose UnsignedPlayerCommandPacket has a null lastSeenMessages.
+	var lastSeenMessages *chat.LastSeenMessages
+	if !unsigned {
+		lastSeenMessages = &packet.LastSeenMessages
+	}
+
+	c.queueCommandResult(packet.Command, packet.Timestamp, lastSeenMessages, func(e *CommandExecuteEvent, newLastSeenMessages *chat.LastSeenMessages) proto.Packet {
+		if newLastSeenMessages != nil {
 			packet.LastSeenMessages = *newLastSeenMessages // fixed packet
 		}
 

--- a/pkg/edition/java/proxy/handle_cmd_ack_test.go
+++ b/pkg/edition/java/proxy/handle_cmd_ack_test.go
@@ -1,0 +1,155 @@
+package proxy
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/robinbraemer/event"
+	"github.com/stretchr/testify/require"
+
+	"go.minekube.com/gate/pkg/edition/java/config"
+	"go.minekube.com/gate/pkg/edition/java/netmc"
+	"go.minekube.com/gate/pkg/edition/java/proto/packet/chat"
+	"go.minekube.com/gate/pkg/edition/java/proto/version"
+	"go.minekube.com/gate/pkg/gate/proto"
+)
+
+// recordingConn is a MinecraftConn with a configurable protocol version that
+// records the packets written to it in a thread-safe way (the chat queue writes
+// from a background goroutine).
+type recordingConn struct {
+	*testMinecraftConn
+	protocol proto.Protocol
+	mu       sync.Mutex
+	packets  []proto.Packet
+}
+
+func (c *recordingConn) Protocol() proto.Protocol { return c.protocol }
+
+func (c *recordingConn) WritePacket(p proto.Packet) error {
+	c.mu.Lock()
+	c.packets = append(c.packets, p)
+	c.mu.Unlock()
+	return nil
+}
+
+func (c *recordingConn) written() []proto.Packet {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]proto.Packet(nil), c.packets...)
+}
+
+var _ netmc.MinecraftConn = (*recordingConn)(nil)
+
+type fakeConfigProvider struct{ cfg *config.Config }
+
+func (f fakeConfigProvider) config() *config.Config { return f.cfg }
+
+// newChatCmdFixture wires a connectedPlayer to a fake backend so the real
+// command/chat handler and chat queue can be driven end-to-end. configureEvent
+// controls the CommandExecuteEvent outcome (e.g. forward or deny) so we can
+// exercise the packet actually sent to the backend.
+func newChatCmdFixture(protocol proto.Protocol, configureEvent func(*CommandExecuteEvent)) (*connectedPlayer, *recordingConn, *chatHandler) {
+	client := &recordingConn{testMinecraftConn: &testMinecraftConn{}, protocol: protocol}
+	player := &connectedPlayer{MinecraftConn: client, log: logr.Discard()}
+	player.chatQueue = newChatQueue(player)
+
+	backend := &recordingConn{testMinecraftConn: &testMinecraftConn{}, protocol: protocol}
+	sc := &serverConnection{player: player, log: logr.Discard()}
+	sc.connection = backend
+	player.connectedServer_ = sc
+
+	eventMgr := event.New()
+	event.Subscribe(eventMgr, 0, configureEvent)
+
+	h := &chatHandler{
+		log:            logr.Discard(),
+		eventMgr:       eventMgr,
+		player:         player,
+		configProvider: fakeConfigProvider{cfg: &config.Config{}},
+	}
+	return player, backend, h
+}
+
+func forwardEvent(e *CommandExecuteEvent) { e.SetForward(true) }
+func denyEvent(e *CommandExecuteEvent)    { e.SetAllowed(false) }
+
+// TestUnsignedCommandPreservesHeldAcknowledgements reproduces the 1.21.x
+// "message acknowledgement" kick (gate#915 / gate#921).
+//
+// On 1.20.5+, a command with no signable arguments is sent as an
+// UnsignedPlayerCommand, which carries NO last-seen update - exactly like a
+// direct connection and like Velocity's UnsignedPlayerCommandPacket (whose
+// lastSeenMessages is null). Gate instead fed a non-nil zero-value last-seen
+// into the chat queue, which:
+//
+//  1. flushed the player's held ChatAcknowledgements (delayedAckCount) and then
+//     discarded them, so the backend's last-seen window fell behind the client's
+//     and the next chat/command was rejected with
+//     "Last seen update ignored previously acknowledged message at index N"; and
+//  2. re-encoded the command as a signed session command carrying an empty
+//     acknowledgement, which the backend validates (and rejects) even though a
+//     direct connection sends no acknowledgement at all.
+//
+// This test fails against the pre-fix code.
+func TestUnsignedCommandPreservesHeldAcknowledgements(t *testing.T) {
+	_, backend, h := newChatCmdFixture(version.Minecraft_1_21_5.Protocol, forwardEvent)
+	cq := h.player.chatQueue
+
+	// The client acknowledged 3 messages via ChatAcknowledgement packets that the
+	// proxy holds back (well below the 20-message window). These must not be lost.
+	cq.HandleAcknowledgement(3)
+
+	// A 1.20.5+ client runs a plain command (no signable args): an
+	// UnsignedPlayerCommand carrying no last-seen update.
+	require.NoError(t, h.handleCommand(&chat.UnsignedPlayerCommand{
+		SessionPlayerCommand: chat.SessionPlayerCommand{Command: "spawn"},
+	}))
+
+	// Wait for the command to reach the backend.
+	require.Eventually(t, func() bool { return len(backend.written()) == 1 },
+		2*time.Second, 5*time.Millisecond, "command was never forwarded to backend")
+
+	// (1) The held acknowledgements must be preserved, not flushed-and-discarded.
+	require.Equal(t, int32(3), cq.chatState.delayedAckCount.Load(),
+		"held acknowledgements were lost when forwarding an unsigned command")
+
+	// (2) The command must be forwarded command-only (UnsignedPlayerCommand), not
+	// re-encoded as a signed session command with a spurious empty last-seen update.
+	got := backend.written()[0]
+	_, ok := got.(*chat.UnsignedPlayerCommand)
+	require.Truef(t, ok, "expected *chat.UnsignedPlayerCommand forwarded, got %T", got)
+}
+
+// TestConsumedCommandAcknowledgesOffsetWithEmptyBitset covers the second
+// divergence from Velocity: when the proxy consumes a command (here a plugin
+// denies it) on a pre-1.20.5 signed-session client, it must forward a
+// ChatAcknowledgement carrying the command's last-seen offset so the backend
+// advances its window. Gate previously gated this on the acknowledged bitset
+// being non-empty; a ChatAcknowledgement only carries an offset, so a command
+// with a non-zero offset but an empty bitset was dropped, desyncing the backend.
+// This matches Velocity's SessionCommandHandler.consumeCommand (offset != 0).
+//
+// This test fails against the pre-fix code.
+func TestConsumedCommandAcknowledgesOffsetWithEmptyBitset(t *testing.T) {
+	// 1.20.3: commands are SessionPlayerCommand carrying a last-seen update (no
+	// UnsignedPlayerCommand until 1.20.5), with no argument signatures here.
+	_, backend, h := newChatCmdFixture(version.Minecraft_1_20_3.Protocol, denyEvent)
+
+	// A consumed command whose last-seen update advances the window (offset 4) but
+	// acknowledges no in-window messages (empty bitset).
+	require.NoError(t, h.handleCommand(&chat.SessionPlayerCommand{
+		Command:          "hub",
+		LastSeenMessages: chat.LastSeenMessages{Offset: 4},
+	}))
+
+	require.Eventually(t, func() bool { return len(backend.written()) == 1 },
+		2*time.Second, 5*time.Millisecond, "no acknowledgement was forwarded for the consumed command")
+
+	got := backend.written()[0]
+	ack, ok := got.(*chat.ChatAcknowledgement)
+	require.Truef(t, ok, "expected *chat.ChatAcknowledgement forwarded, got %T", got)
+	require.Equal(t, 4, ack.Offset, "acknowledgement must carry the command's last-seen offset")
+}

--- a/pkg/edition/java/proxy/handle_cmd_ack_test.go
+++ b/pkg/edition/java/proxy/handle_cmd_ack_test.go
@@ -95,7 +95,12 @@ func denyEvent(e *CommandExecuteEvent)    { e.SetAllowed(false) }
 //
 // This test fails against the pre-fix code.
 func TestUnsignedCommandPreservesHeldAcknowledgements(t *testing.T) {
-	_, backend, h := newChatCmdFixture(version.Minecraft_1_21_5.Protocol, forwardEvent)
+	player, backend, chatHandler := newChatCmdFixture(version.Minecraft_1_21_5.Protocol, forwardEvent)
+	h := &clientPlaySessionHandler{
+		log:         logr.Discard(),
+		player:      player,
+		chatHandler: chatHandler,
+	}
 	cq := h.player.chatQueue
 
 	// The client acknowledged 3 messages via ChatAcknowledgement packets that the
@@ -104,9 +109,12 @@ func TestUnsignedCommandPreservesHeldAcknowledgements(t *testing.T) {
 
 	// A 1.20.5+ client runs a plain command (no signable args): an
 	// UnsignedPlayerCommand carrying no last-seen update.
-	require.NoError(t, h.handleCommand(&chat.UnsignedPlayerCommand{
-		SessionPlayerCommand: chat.SessionPlayerCommand{Command: "spawn"},
-	}))
+	h.HandlePacket(&proto.PacketContext{
+		Protocol: version.Minecraft_1_21_5.Protocol,
+		Packet: &chat.UnsignedPlayerCommand{
+			SessionPlayerCommand: chat.SessionPlayerCommand{Command: "spawn"},
+		},
+	})
 
 	// Wait for the command to reach the backend.
 	require.Eventually(t, func() bool { return len(backend.written()) == 1 },

--- a/pkg/edition/java/proxy/session_client_play.go
+++ b/pkg/edition/java/proxy/session_client_play.go
@@ -156,9 +156,9 @@ func (c *clientPlaySessionHandler) HandlePacket(pc *proto.PacketContext) {
 	case *chat.KeyedPlayerCommand:
 		c.handleKeyedPlayerCommand(p)
 	case *chat.SessionPlayerCommand:
-		c.handleSessionPlayerCommand(p)
+		c.handleSessionPlayerCommand(p, p)
 	case *chat.UnsignedPlayerCommand:
-		c.handleSessionPlayerCommand(&p.SessionPlayerCommand)
+		c.handleSessionPlayerCommand(&p.SessionPlayerCommand, p)
 	case *packet.TabCompleteRequest:
 		c.handleTabCompleteRequest(p, pc)
 	case *plugin.Message:
@@ -712,7 +712,7 @@ func (c *clientPlaySessionHandler) handleLegacyChat(p *chat.LegacyChat) {
 	}
 }
 
-func (c *clientPlaySessionHandler) handleSessionPlayerCommand(p *chat.SessionPlayerCommand) {
+func (c *clientPlaySessionHandler) handleSessionPlayerCommand(p *chat.SessionPlayerCommand, original proto.Packet) {
 	_, ok := c.player.ensureBackendConnection()
 	if !ok {
 		return
@@ -724,7 +724,7 @@ func (c *clientPlaySessionHandler) handleSessionPlayerCommand(p *chat.SessionPla
 		return
 	}
 
-	err := c.chatHandler.handleCommand(p)
+	err := c.chatHandler.handleCommand(original)
 	if err != nil {
 		c.log.Error(err, "error handling session player command")
 	}


### PR DESCRIPTION
## Intent

Fix the chat-acknowledgement kick (gate#915, gate#921) where modern Minecraft clients (1.21.x, protocol >= 1.20.5) routed through Gate get 'message acknowledgement' errors ('Last seen update ignored previously acknowledged message at index N') and have chat/commands rejected, while a direct connection works. Root cause was found by comparing Gate's port against Velocity (the proven reference) plus the decompiled server-side LastSeenMessagesValidator: Gate mishandled the unsigned-command path. On 1.20.5+, a command with no signable arguments is an UnsignedPlayerCommand that carries NO last-seen update (like a direct connection, and like Velocity's UnsignedPlayerCommandPacket whose lastSeenMessages is null) - the common path when the backend runs online-mode=false / enforce-secure-profile=false, which matches both operators. Gate instead fed a non-nil zero-value last-seen into the chat queue, which flushed and then discarded the player's held ChatAcknowledgements (delayedAckCount), and re-encoded the command as a signed session command carrying an empty acknowledgement. Both desync the backend's last-seen window so the next message is rejected. The fix is three minimal changes in pkg/edition/java/proxy/handle_cmd.go, all matching Velocity's SessionCommandHandler: (1) do not feed a last-seen update into the chat queue for unsigned commands, so held acknowledgements are preserved; (2) forward unsigned commands command-only instead of re-encoding them as a signed session command with an empty acknowledgement; (3) gate a consumed command's ChatAcknowledgement on the offset (which the packet actually carries) rather than the acknowledged bitset, so a command with a non-zero offset but empty bitset still advances the backend window. Deliberately NOT changed: the LastSeenMessages.Offset += delayedAckCount adjustment in chat_queue.go (identical to Velocity, not a bug - the reporter's naive hypothesis was refuted), and nothing on the checksum path (the 1.21.5 checksum is a red herring: checksum 0 skips server-side validation and the client never emits 0). Regression tests in a new handle_cmd_ack_test.go drive the real handler and chat queue against a fake backend at the acknowledgement/offset layer (no live server available in this worktree) and were verified to fail against the pre-fix code and pass after. AGENTS.md's chat-acknowledgement note was updated to record the invariant. The change is intentionally minimal and scoped to the chat-acknowledgement path.

## What Changed

- Preserve `UnsignedPlayerCommand` through production dispatch, skip chat-queue last-seen updates for it, and forward it command-only.
- Forward acknowledgements for consumed commands when the last-seen offset is non-zero, even with an empty bitset.
- Add regression coverage and document the Velocity-aligned acknowledgement invariant in `AGENTS.md`.

## Risk Assessment

✅ Low: The updated change is narrowly scoped and now preserves unsigned packet identity through production dispatch while applying the intended acknowledgement invariants.

## Testing

The real handler, chat queue, and fake backend were exercised for modern unsigned commands and offset-only acknowledgements; focused tests and race tests passed, direct packet evidence was captured, and no transient worktree files remain.

<details>
<summary>Evidence: Chat acknowledgement end-user evidence</summary>

<code>modern client -&gt; backend: output=*chat.UnsignedPlayerCommand(command=&#34;spawn&#34;), held_acknowledgements=3, last_seen_update=none&#10;consumed command -&gt; backend: output=ChatAcknowledgement(offset=4)</code>

```text
=== RUN   TestChatAckEndUserEvidence
    zz_chat_ack_evidence_test.go:32: modern client -> backend: input=UnsignedPlayerCommand(command=spawn), output=*chat.UnsignedPlayerCommand(command="spawn"), held_acknowledgements=3, last_seen_update=none
    zz_chat_ack_evidence_test.go:44: consumed command -> backend: input=SessionPlayerCommand(command=hub, offset=4, acknowledged_bitset=empty), output=ChatAcknowledgement(offset=4)
--- PASS: TestChatAckEndUserEvidence (0.01s)
PASS
ok  	go.minekube.com/gate/pkg/edition/java/proxy	0.381s
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- 🚨 `pkg/edition/java/proxy/handle_cmd.go:230` - The required behavior is not reached for real client packets: the change says “do not feed a last-seen update into the chat queue for unsigned commands” and “forward unsigned commands command-only,” but `HandlePacket` unwraps `*chat.UnsignedPlayerCommand` at `session_client_play.go:161` before calling `handleCommand`. Consequently `handle_cmd.go:230` receives `unsigned == false`, still queues `&amp;packet.LastSeenMessages`, and forwards a `SessionPlayerCommand`. The regression test calls `handleCommand` directly and misses this dispatch path; preserve the unsigned type/flag through production dispatch and cover it.

🔧 Fix: Preserve unsigned command dispatch through production path
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `go test ./pkg/edition/java/proxy -run 'Test(UnsignedCommandPreservesHeldAcknowledgements|ConsumedCommandAcknowledgesOffsetWithEmptyBitset|ChatStateUpdateFromMessageDivergesAfterGateHoldsAcknowledgements)$' -count=1 -v`
- `go test -race ./pkg/edition/java/proxy -run 'Test(UnsignedCommandPreservesHeldAcknowledgements|ConsumedCommandAcknowledgesOffsetWithEmptyBitset|ChatStateUpdateFromMessageDivergesAfterGateHoldsAcknowledgements)$' -count=1 -v`
- `Temporary fake-backend evidence test; removed afterward`
- `git status --short`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
