### PR TITLE
fix(codec): raise packet frame cap to vanilla maximum

### DIFF
--- a/pkg/edition/java/netmc/reader.go
+++ b/pkg/edition/java/netmc/reader.go
@@ -36,6 +36,7 @@ func NewReader(conn net.Conn, direction proto.Direction, readTimeout time.Durati
 	readBuf := bufio.NewReader(conn)
 	return &reader{
 		c:           conn,
+		direction:   direction,
 		readTimeout: readTimeout,
 		log:         log.WithName("reader"),
 		readBuf:     readBuf,
@@ -47,7 +48,10 @@ type reader struct {
 	log         logr.Logger
 	readTimeout time.Duration
 	c           net.Conn // underlying connection
-	readBuf     *bufio.Reader
+	// direction of the packets being read: ClientBound means this reader reads
+	// from a backend server, ServerBound means it reads from a client.
+	direction proto.Direction
+	readBuf   *bufio.Reader
 	*codec.Decoder
 }
 
@@ -61,10 +65,32 @@ func (r *reader) ReadPacket() (*proto.PacketContext, error) {
 			r.log.V(1).Info("error reading packet, recovered", "error", err)
 			return nil, ErrReadPacketRetry
 		}
-		r.log.V(1).Info("error reading packet, closing connection", "error", err)
+		r.logCloseErr(err)
 		return nil, err
 	}
 	return packetCtx, nil
+}
+
+// logCloseErr logs the error that is about to close the connection.
+//
+// Read errors are debug-only by default: most of them are untrusted clients
+// sending garbage, and logging those at INFO would let anyone spam the log.
+// An oversized frame from a backend server is the exception worth surfacing:
+// Gate just closes the socket, so the backend's own log stays empty and the
+// player only sees "unable to connect", leaving the operator with no path from
+// symptom to cause. It is also actionable, since the operator runs that server.
+// This fires at most once per connection, immediately before it is closed, so a
+// misbehaving backend cannot flood the log with it either.
+func (r *reader) logCloseErr(err error) {
+	var frameErr *codec.FrameTooLargeError
+	if r.direction == proto.ClientBound && errors.As(err, &frameErr) {
+		r.log.Error(err, "backend server sent a packet frame larger than the maximum allowed, closing connection",
+			"peer", r.c.RemoteAddr().String(),
+			"frameLength", frameErr.Length,
+			"maxFrameLength", frameErr.Max)
+		return
+	}
+	r.log.V(1).Info("error reading packet, closing connection", "error", err)
 }
 
 // handles error when read the next packet

--- a/pkg/edition/java/netmc/reader_frame_test.go
+++ b/pkg/edition/java/netmc/reader_frame_test.go
@@ -1,0 +1,79 @@
+package netmc
+
+import (
+	"bytes"
+	"net"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr/funcr"
+	"github.com/stretchr/testify/require"
+
+	"go.minekube.com/gate/pkg/edition/java/proto/codec"
+	"go.minekube.com/gate/pkg/edition/java/proto/util"
+	"go.minekube.com/gate/pkg/gate/proto"
+)
+
+// readOversizedFrame feeds the reader a frame header announcing a length above
+// codec.MaximumFrameLength and returns everything logged at the verbosity an
+// operator runs with by default (V(1) debug lines are dropped).
+func readOversizedFrame(t *testing.T, direction proto.Direction) []string {
+	t.Helper()
+
+	local, remote := net.Pipe()
+	t.Cleanup(func() {
+		_ = local.Close()
+		_ = remote.Close()
+	})
+
+	var mu sync.Mutex
+	var lines []string
+	log := funcr.New(func(prefix, args string) {
+		mu.Lock()
+		defer mu.Unlock()
+		lines = append(lines, prefix+" "+args)
+	}, funcr.Options{Verbosity: 0})
+
+	go func() {
+		// Only the length prefix is needed: the frame is rejected on its
+		// announced length, before any payload is read.
+		var frame bytes.Buffer
+		_ = util.WriteVarInt(&frame, codec.MaximumFrameLength+1)
+		_, _ = remote.Write(frame.Bytes())
+	}()
+
+	_, err := NewReader(local, direction, time.Second, log).ReadPacket()
+	require.Error(t, err, "an oversized frame must fail the read and close the connection")
+
+	mu.Lock()
+	defer mu.Unlock()
+	return append([]string(nil), lines...)
+}
+
+// A backend server sending an oversized frame is operator-actionable: Gate just
+// closes the socket, so the backend's own log stays empty and the player only
+// sees "unable to connect". That diagnosis has to be visible at default
+// verbosity, with the peer and the observed length.
+//
+// See https://github.com/minekube/gate/issues/930.
+func TestReaderLogsOversizedBackendFrame(t *testing.T) {
+	lines := readOversizedFrame(t, proto.ClientBound)
+	require.NotEmpty(t, lines, "an oversized backend frame must be visible at default verbosity")
+
+	logged := strings.Join(lines, "\n")
+	require.Contains(t, logged, "larger than the maximum allowed")
+	require.Contains(t, logged, "peer")
+	require.Contains(t, logged, "frameLength")
+	require.Contains(t, logged, "2097152", "the observed frame length must be reported")
+	require.Contains(t, logged, "2097151", "the maximum must be reported alongside it")
+}
+
+// A client is untrusted and anyone can open a connection, so the same oversized
+// frame from a client stays a quiet close — otherwise it becomes a log flood
+// primitive.
+func TestReaderDoesNotLogOversizedClientFrame(t *testing.T) {
+	lines := readOversizedFrame(t, proto.ServerBound)
+	require.Empty(t, lines, "an oversized client frame must not be logged at default verbosity")
+}

--- a/pkg/edition/java/proto/codec/decoder.go
+++ b/pkg/edition/java/proto/codec/decoder.go
@@ -165,6 +165,19 @@ func (d *Decoder) readPayload() (payload []byte, n int, err error) {
 	return payload, n, nil
 }
 
+// FrameTooLargeError is returned when a peer announces a packet frame longer
+// than MaximumFrameLength. It carries the announced length so callers can decide
+// how loudly to report it: an oversized frame from an untrusted client is noise,
+// while one from a backend server is operator-actionable.
+type FrameTooLargeError struct {
+	Length int // the frame length the peer announced
+	Max    int // the maximum length Gate accepts
+}
+
+func (e *FrameTooLargeError) Error() string {
+	return fmt.Sprintf("received invalid packet length %d (maximum is %d)", e.Length, e.Max)
+}
+
 func readVarIntFrame(rd io.Reader) (payload []byte, n int, err error) {
 	length, n, err := util.ReadVarIntReturnN(rd)
 	if err != nil {
@@ -173,8 +186,8 @@ func readVarIntFrame(rd io.Reader) (payload []byte, n int, err error) {
 	if length == 0 {
 		return // function caller should skip over empty packet
 	}
-	if length < 0 || length > 1048576 { // 2^(21-1)
-		return nil, n, fmt.Errorf("received invalid packet length %d", length)
+	if length < 0 || length > MaximumFrameLength {
+		return nil, n, &FrameTooLargeError{Length: length, Max: MaximumFrameLength}
 	}
 
 	payload = make([]byte, length)

--- a/pkg/edition/java/proto/codec/decoder_frame_test.go
+++ b/pkg/edition/java/proto/codec/decoder_frame_test.go
@@ -1,0 +1,80 @@
+package codec
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"go.minekube.com/gate/pkg/edition/java/proto/util"
+)
+
+// vanillaMaxFrameLength is the largest frame vanilla's Varint21FrameDecoder
+// accepts: its length prefix is a VarInt of at most 21 bits, so 2^21-1 bytes.
+// Spelled out literally rather than derived from MaximumFrameLength so these
+// tests pin Gate to vanilla's number instead of to whatever Gate currently uses.
+const vanillaMaxFrameLength = 2097151
+
+// buildFrame builds a raw wire frame: VarInt(length) + length payload bytes.
+func buildFrame(length int) []byte {
+	var frame bytes.Buffer
+	_ = util.WriteVarInt(&frame, length)
+	frame.Write(make([]byte, length))
+	return frame.Bytes()
+}
+
+func readFrame(b []byte) ([]byte, error) {
+	// fullReader is what production wraps the connection in, so read the same way.
+	payload, _, err := readVarIntFrame(&fullReader{bytes.NewReader(b)})
+	return payload, err
+}
+
+// Gate must accept exactly the frame sizes vanilla accepts. Gate used to cap
+// frames at 1MiB — half of vanilla, in the strict direction — which silently
+// killed modded (Forge/NeoForge) backends whose config-phase traffic, such as
+// registry sync and mod network queries, exceeds 1MiB. Gate closed the socket,
+// the backend's log stayed empty, and the player got a bare "unable to connect".
+//
+// See https://github.com/minekube/gate/issues/930 (supersedes #587).
+func TestReadVarIntFrameAcceptsVanillaMaximum(t *testing.T) {
+	payload, err := readFrame(buildFrame(vanillaMaxFrameLength))
+	require.NoError(t, err, "a %d byte frame is legal for vanilla and must be accepted", vanillaMaxFrameLength)
+	require.Len(t, payload, vanillaMaxFrameLength)
+}
+
+func TestReadVarIntFrameRejectsOverVanillaMaximum(t *testing.T) {
+	over := vanillaMaxFrameLength + 1
+
+	_, err := readFrame(buildFrame(over))
+	require.Error(t, err, "a %d byte frame exceeds vanilla's cap and must be rejected", over)
+
+	var frameErr *FrameTooLargeError
+	require.True(t, errors.As(err, &frameErr), "expected *FrameTooLargeError, got %T: %v", err, err)
+	require.Equal(t, over, frameErr.Length)
+	require.Equal(t, vanillaMaxFrameLength, frameErr.Max)
+}
+
+// A negative length (a VarInt with the sign bit set) must be rejected before it
+// reaches make([]byte, length).
+func TestReadVarIntFrameRejectsNegativeLength(t *testing.T) {
+	var frame bytes.Buffer
+	_ = util.WriteVarInt(&frame, -1)
+
+	_, err := readFrame(frame.Bytes())
+	require.Error(t, err)
+
+	var frameErr *FrameTooLargeError
+	require.True(t, errors.As(err, &frameErr), "expected *FrameTooLargeError, got %T: %v", err, err)
+	require.Equal(t, -1, frameErr.Length)
+}
+
+// The frame cap bounds the still-compressed frame as it arrives on the wire,
+// while the caps in decompress() bound the claimed decompressed size. The frame
+// cap must stay the tighter of the two, otherwise the decompression caps become
+// unreachable dead code rather than a second line of defense.
+func TestMaximumFrameLengthBelowUncompressedCaps(t *testing.T) {
+	require.Equal(t, vanillaMaxFrameLength, MaximumFrameLength, "frame cap must match vanilla's 2^21-1")
+	require.Less(t, MaximumFrameLength, ServerboundUncompressedCap)
+	require.Less(t, MaximumFrameLength, UncompressedCap)
+}

--- a/pkg/edition/java/proto/codec/encoder.go
+++ b/pkg/edition/java/proto/codec/encoder.go
@@ -26,6 +26,19 @@ const (
 	// data comes from the (untrusted) client, limiting how much memory a client
 	// can force the proxy to allocate. Clientbound data keeps UncompressedCap.
 	ServerboundUncompressedCap = 2 * 1024 * 1024 // 2MiB
+	// MaximumFrameLength is the largest packet frame Gate accepts off the wire,
+	// matching vanilla's Varint21FrameDecoder: its length prefix is a VarInt of at
+	// most 21 bits, so a frame can announce up to 2^21-1 bytes.
+	//
+	// This bounds the frame as it arrives, before decompression, so it also caps
+	// compressed frames. The decompressed size is capped separately and higher by
+	// UncompressedCap / ServerboundUncompressedCap.
+	//
+	// Modded backends (Forge/NeoForge) legitimately send config-phase frames well
+	// past 1MiB, e.g. registry sync and mod network queries, so a tighter-than-
+	// vanilla cap here kills those connections. See
+	// https://github.com/minekube/gate/issues/930.
+	MaximumFrameLength = 1<<21 - 1 // 2097151
 )
 
 // Encoder is a synchronized packet encoder.


### PR DESCRIPTION
## Intent

Fix gate#930: Gate's wire-frame decoder rejected any packet frame over 1 MiB (1048576), but vanilla Minecraft's Varint21FrameDecoder allows 2^21-1 = 2097151. The old code's comment said '2^(21-1)' — the correct vanilla value — while the constant written was 2^20, so this was an off-by-a-power-of-two typo in the strict direction, not a deliberate hardening choice.

Impact, reproduced on live traffic: modded Forge/NeoForge backends send config-phase payloads (registry sync, mod network query) above 1 MiB. Gate closed the socket, so the backend's own log stayed empty and the player got only a bare 'Unable to connect / internal server error'. The real cause was DEBUG-only, leaving operators no path from symptom to cause. This supersedes the closed gate#587, which the reporter confirmed works fine on Velocity.

Deliberate decisions made, so they are not mistakes:
1. The cap is named MaximumFrameLength and placed in encoder.go's existing size-constant block rather than decoder.go, even though it is a decoder-only concern. This was requested explicitly ('name it as a constant alongside the other size constants') and matches how UncompressedCap / ServerboundUncompressedCap are already placed — those are likewise defined in encoder.go and consumed only by decoder.go.
2. The check intentionally stays at the pre-decompression wire-frame layer, so it also caps compressed frames. This was verified as the right layer: 2097151 stays strictly below both ServerboundUncompressedCap (2 MiB) and UncompressedCap (8 MiB), so the post-decompression caps in encoder.go remain a reachable second line of defense rather than dead code. TestMaximumFrameLengthBelowUncompressedCaps pins that ordering.
3. Raising the cap doubles the per-connection frame allocation ceiling for untrusted clients from 1 to 2 MiB. This is accepted on purpose: it is exact vanilla and Velocity parity, and the tighter serverbound decompressed-size cap is unchanged.
4. A new typed error codec.FrameTooLargeError replaces the plain fmt.Errorf so callers can distinguish this case; its message keeps the original 'received invalid packet length %d' prefix for continuity with existing logs.
5. Log surfacing was requested and is deliberately asymmetric by direction: an oversized frame from a backend server (ClientBound reader) logs at ERROR with peer, frameLength and maxFrameLength, because the operator runs that server and can act on it; the identical frame from an untrusted client stays a quiet V(1) close so it cannot be used as a log-flood primitive. It fires at most once per connection since the connection closes immediately after.

Mandatory regression test, verified fails-pre and passes-post by temporarily reverting the constant to 1048576: codec/decoder_frame_test.go asserts against the literal 2097151 rather than against MaximumFrameLength, deliberately, so it pins Gate to vanilla's number instead of to whatever Gate currently uses. 2097151 must be accepted, 2097152 must be rejected. These are separate top-level tests rather than subtests under a shared constant assertion, on purpose, so each boundary case fails on its own merits. netmc/reader_frame_test.go covers both halves of the log behaviour and was verified to fail when the direction condition is stubbed out.

Scope is intentionally limited to the frame-cap fix, the log surfacing and the tests. Two sibling Forge findings, gate#928 and gate#929, are separate tasks and must not be touched here. go build, go vet, gofmt and the full go test ./... are green locally.

## What Changed

- Raises the wire-frame limit to vanilla’s `2^21 - 1` maximum and adds typed oversized-frame errors.
- Logs oversized backend frames with peer and length details while keeping oversized client frames quiet.
- Adds regression coverage for frame boundaries, decompression-cap ordering, and directional logging.

## Risk Assessment

✅ Low: The change is narrowly scoped, conforms to the authoritative intent, and its cap, error propagation, direction mapping, and logging paths are internally consistent.

## Testing

No baseline commands were run in this targeted phase. Codec boundary tests and directional reader tests passed; the runtime harness confirmed backend ERROR logging with peer and frame limits, while client frames close silently. Evidence was saved as a transcript; no UI evidence applies.

<details>
<summary>Evidence: Oversized-frame runtime transcript</summary>

<code>direction=ClientBound ... logLines=1&#10;frameLength=2097152 maxFrameLength=2097151&#10;direction=ServerBound ... logLines=0</code>

```text
direction=ClientBound error=error reading packet frame: received invalid packet length 2097152 (maximum is 2097151) logLines=1
reader "msg"="backend server sent a packet frame larger than the maximum allowed, closing connection" "error"="error reading packet frame: received invalid packet length 2097152 (maximum is 2097151)" "peer"="pipe" "frameLength"=2097152 "maxFrameLength"=2097151
direction=ServerBound error=error reading packet frame: received invalid packet length 2097152 (maximum is 2097151) logLines=0
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `go test ./pkg/edition/java/proto/codec -run 'Test(ReadVarIntFrameAcceptsVanillaMaximum|ReadVarIntFrameRejectsOverVanillaMaximum|TestReadVarIntFrameRejectsNegativeLength|MaximumFrameLengthBelowUncompressedCaps)$' -count=1 -v`
- `go test ./pkg/edition/java/netmc -run '^TestReader(LogsOversizedBackendFrame|DoesNotLogOversizedClientFrame)$' -count=1 -v`
- `go run /var/folders/1y/cjgf53nj31n_dxsspqnjfjvc0000gn/T/no-mistakes-evidence/01KYFMAJNH32QZBTYSAN42EB65/oversized_frame_evidence.go`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
