### PR TITLE
fix(addrquota): bucket IPv6 rate limits at /64

### DIFF
--- a/.web/docs/guide/rate-limiting.md
+++ b/.web/docs/guide/rate-limiting.md
@@ -17,8 +17,9 @@ There are two rate limiters:
   - triggered just before authenticating player with Mojang
     to prevent flooding the Mojang API
 
-Each rate limiter is IP block based but cutting off
-the last numbers (/24 block) as in 255.255.255`.xxx`.
+Each rate limiter uses an IP-prefix bucket: IPv4 addresses share a /24 bucket
+(`255.255.255.xxx`), while IPv6 addresses share a /64 bucket (the first four
+hextets). IPv4-mapped IPv6 addresses are treated as IPv4 addresses.
 
 Too many connections from the same IP-block (as configured)
 will be simply disconnected, and the default settings should

--- a/.web/docs/guide/security/index.md
+++ b/.web/docs/guide/security/index.md
@@ -87,9 +87,7 @@ To address the identified threats, that Minekube Gate has implemented a range of
     - The use of an LRU cache for storing rate limiters per IP address ensures efficient memory usage by retaining only
       the most recently accessed limiters, automatically purging the least active ones when the cache reaches its
       maximum capacity. This approach balances the need for active quota management with system resource constraints.
-    - By grouping IP addresses with similar low-order bytes, the system can manage quotas for a range of IPs, reducing
-      the granularity of control but improving performance and memory usage. This trade-off is often acceptable in
-      scenarios where strict per-IP rate limiting is not required.
+    - Quota bucket granularity and configuration details are documented in the [Rate limiting guide](/guide/rate-limiting).
 
 - **Authentication**: Ensuring secure client verification for online mode
   connections. ([ref](https://github.com/minekube/gate/blob/0b3b733dc3bdede11873fce5f52704ef2ec519cf/pkg/edition/java/auth/authenticator.go#L28))

--- a/config-lite.yml
+++ b/config-lite.yml
@@ -104,7 +104,9 @@ config:
   #proxyProtocolTrustedProxies:
   #  - 203.0.113.7
   #  - 198.51.100.0/24
-  # The quota settings allows rate-limiting IP (last block cut off) for certain operations.
+  # The quota settings allow rate-limiting IP address ranges for certain operations.
+  # IPv4 addresses share a /24 bucket; IPv6 addresses share a /64 bucket.
+  # IPv4-mapped IPv6 addresses use the IPv4 /24 bucket.
   # ops: The allowed operations per second.
   # burst: The maximum operations per second (queue like). One burst unit per seconds is refilled.
   # maxEntries: The maximum IPs to keep track of in cache for rate-limiting (if full, deletes oldest).

--- a/config.yml
+++ b/config.yml
@@ -144,7 +144,9 @@ config:
   # Note: Players connecting via IP address or unmatched hostnames will use the 'try' list above.
   # For lightweight deployments, see Gate Lite mode which provides similar host-based routing.
   forcedHosts: {}
-  # The quota settings allows rate-limiting IP (last block cut off) for certain operations.
+  # The quota settings allow rate-limiting IP address ranges for certain operations.
+  # IPv4 addresses share a /24 bucket; IPv6 addresses share a /64 bucket.
+  # IPv4-mapped IPv6 addresses use the IPv4 /24 bucket.
   # ops: The allowed operations per second.
   # burst: The maximum operations per second (queue like). One burst unit per seconds is refilled.
   # maxEntries: The maximum IPs to keep track of in cache for rate-limiting (if full, deletes oldest).

--- a/pkg/configs/config-lite.yml
+++ b/pkg/configs/config-lite.yml
@@ -104,7 +104,9 @@ config:
   #proxyProtocolTrustedProxies:
   #  - 203.0.113.7
   #  - 198.51.100.0/24
-  # The quota settings allows rate-limiting IP (last block cut off) for certain operations.
+  # The quota settings allow rate-limiting IP address ranges for certain operations.
+  # IPv4 addresses share a /24 bucket; IPv6 addresses share a /64 bucket.
+  # IPv4-mapped IPv6 addresses use the IPv4 /24 bucket.
   # ops: The allowed operations per second.
   # burst: The maximum operations per second (queue like). One burst unit per seconds is refilled.
   # maxEntries: The maximum IPs to keep track of in cache for rate-limiting (if full, deletes oldest).

--- a/pkg/configs/config.yml
+++ b/pkg/configs/config.yml
@@ -144,7 +144,9 @@ config:
   # Note: Players connecting via IP address or unmatched hostnames will use the 'try' list above.
   # For lightweight deployments, see Gate Lite mode which provides similar host-based routing.
   forcedHosts: {}
-  # The quota settings allows rate-limiting IP (last block cut off) for certain operations.
+  # The quota settings allow rate-limiting IP address ranges for certain operations.
+  # IPv4 addresses share a /24 bucket; IPv6 addresses share a /64 bucket.
+  # IPv4-mapped IPv6 addresses use the IPv4 /24 bucket.
   # ops: The allowed operations per second.
   # burst: The maximum operations per second (queue like). One burst unit per seconds is refilled.
   # maxEntries: The maximum IPs to keep track of in cache for rate-limiting (if full, deletes oldest).

--- a/pkg/internal/addrquota/quota.go
+++ b/pkg/internal/addrquota/quota.go
@@ -8,8 +8,8 @@ import (
 )
 
 // Quota implements a simple IP-based rate limiter.
-// Each set of incoming IP addresses with the same
-// low-order byte gets events per second.
+// Incoming addresses are bucketed by network prefix (IPv4 /24, IPv6 /64,
+// see ipKey) and each bucket gets the configured events per second.
 // Information is kept in an LRU cache of size maxEntries.
 type Quota struct {
 	eps   float32    // allowed events per second
@@ -42,12 +42,20 @@ func NewQuota(eventsPerSecond float32, burst, maxEntries int) *Quota {
 	}
 }
 
+// ipKey derives the quota bucket key for an IP address.
+//
+// IPv4 addresses (including IPv4-mapped IPv6 addresses) are bucketed by their
+// /24 prefix. IPv6 addresses are bucketed by their /64 prefix: a /64 is the
+// standard allocation handed to a single end user, so bucketing any narrower
+// would let one subscriber rotate through its own addresses and evade the
+// limiter entirely.
 func ipKey(ipStr string) string {
 	ip := net.ParseIP(ipStr)
 	if ip == nil {
 		return ""
 	}
-	// Zero out last byte, to cover ranges.
-	ip[len(ip)-1] = 0
-	return ip.String()
+	if v4 := ip.To4(); v4 != nil {
+		return v4.Mask(net.CIDRMask(24, 32)).String()
+	}
+	return ip.Mask(net.CIDRMask(64, 128)).String()
 }

--- a/pkg/internal/addrquota/quota_test.go
+++ b/pkg/internal/addrquota/quota_test.go
@@ -1,0 +1,51 @@
+package addrquota
+
+import "testing"
+
+// TestIPKeyBucketing pins the quota bucket sizes: IPv4 /24 and IPv6 /64.
+// The IPv6 cases fail against a narrower mask (e.g. zeroing only the final
+// byte, a /120), which would let a single /64 subscriber rotate through 2^56
+// addresses and evade the limiter.
+func TestIPKeyBucketing(t *testing.T) {
+	tests := []struct {
+		name    string
+		a, b    string
+		sameKey bool
+	}{
+		{"ipv6 same /64", "2001:db8:1:2::1", "2001:db8:1:2:ffff:ffff:ffff:ffff", true},
+		{"ipv6 same /64, differing above the low byte", "2001:db8:1:2::1", "2001:db8:1:2:aaaa:bbbb:cccc:1", true},
+		{"ipv6 different /64", "2001:db8:1:2::1", "2001:db8:1:3::1", false},
+		{"ipv6 different /64, identical low 64 bits", "2001:db8:1:2:aaaa::1", "2001:db8:9:9:aaaa::1", false},
+		{"ipv4 same /24", "203.0.113.7", "203.0.113.200", true},
+		{"ipv4 different /24", "203.0.113.7", "203.0.114.7", false},
+		{"ipv4-mapped ipv6 matches its ipv4 /24", "::ffff:203.0.113.7", "203.0.113.200", true},
+		{"ipv4-mapped ipv6 different /24", "::ffff:203.0.113.7", "::ffff:203.0.114.7", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ka, kb := ipKey(tt.a), ipKey(tt.b)
+			if ka == "" || kb == "" {
+				t.Fatalf("ipKey returned empty key: ipKey(%q)=%q, ipKey(%q)=%q", tt.a, ka, tt.b, kb)
+			}
+			if got := ka == kb; got != tt.sameKey {
+				t.Errorf("ipKey(%q)=%q, ipKey(%q)=%q: same bucket = %v, want %v",
+					tt.a, ka, tt.b, kb, got, tt.sameKey)
+			}
+		})
+	}
+}
+
+func TestIPKeyPrefixes(t *testing.T) {
+	tests := []struct{ ip, want string }{
+		{"2001:db8:1:2:3:4:5:6", "2001:db8:1:2::"},
+		{"::1", "::"},
+		{"203.0.113.7", "203.0.113.0"},
+		{"::ffff:203.0.113.7", "203.0.113.0"},
+		{"not an ip", ""},
+	}
+	for _, tt := range tests {
+		if got := ipKey(tt.ip); got != tt.want {
+			t.Errorf("ipKey(%q) = %q, want %q", tt.ip, got, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
## Intent

Make IPv6 address-based rate limiting actually effective by bucketing IPv6 clients at /64 instead of the current /120. This is a deliberately scoped key-derivation change confined to ipKey in pkg/internal/addrquota/quota.go.

Security rationale: ipKey previously zeroed only the FINAL byte of the parsed address, which yields a /24 for IPv4 but a /120 for IPv6. A standard residential IPv6 allocation is a /64, so /120 bucketing let one subscriber rotate through 2^56 addresses at zero cost and evade the limiter entirely - the control existed but only constrained honest users. Masking to /64 makes a whole /64 share one bucket.

Deliberate decisions the diff will not show:
- IPv4 bucketing is INTENTIONALLY left at /24 and is explicitly out of scope for this change. Do not widen or narrow IPv4 behavior.
- IPv4-mapped IPv6 addresses (::ffff:a.b.c.d) must be classified as IPv4 (/24), not as a /64 of the v6 space. This is now explicit via ip.To4() instead of relying on ParseIP's 16-byte representation happening to do the right thing.
- No call-site changes were made and none are expected: Blocked(ip string) is unchanged and the bucketing is internal to key derivation. Touching call sites, the quota data structure/storage, or address parsing more broadly is explicitly outside the authorized scope.
- CODE ONLY: this change deliberately does NOT arm or enable quotas. Turning quotas on is separately gated on an operational prerequisite (all edge regions carrying the PROXY handler) owned by other work. Do not add config changes, defaults, or wiring that would enable quotas.
- The stale Quota doc comment claiming buckets are 'the same low-order byte' was corrected to describe the actual /24 and /64 prefixes; a mislabeled control is worse than an absent one.

Test: pkg/internal/addrquota/quota_test.go was added as a fail-pre regression test - it was verified FAILING against the pre-change /120 ipKey and passing after. It asserts two IPv6 addresses in the same /64 share a bucket, two in different /64s do not, IPv4 addresses in the same /24 still share a bucket, and IPv4-mapped addresses key as IPv4. This test must not be weakened or deleted to make anything pass.

## What Changed

- Bucket IPv6 quota keys at `/64` while preserving IPv4 `/24` behavior and classifying IPv4-mapped IPv6 addresses as IPv4.
- Add regression coverage for same/different prefixes and expected key values.
- Update quota documentation, comments, and shipped config templates to describe the `/24`/`/64` bucket semantics.

## Risk Assessment

✅ Low: The change is narrowly scoped and correctly implements IPv6 /64, IPv4 /24, and IPv4-mapped IPv6 bucketing without altering call sites or quota activation.

## Testing

No baseline or full-suite command was run in this targeted phase. Focused addrquota tests and an exported `Quota.Blocked` black-box check passed, evidence logs were captured, and no linters or formatters were run.

<details>
<summary>Evidence: Quota API evidence</summary>

<code>IPv6 /64, IPv4 /24, and IPv4-mapped IPv6 quota behavior all passed through `Quota.Blocked`.</code>

```text
=== RUN   TestQuotaAddressBucketsEndToEnd
    evidence_tmp_test.go:12: IPv6 /64: first=false, same-/64 second=true, different-/64 first=false
    evidence_tmp_test.go:21: IPv4 /24: first=false, same-/24 second=true, different-/24 first=false
    evidence_tmp_test.go:29: IPv4-mapped IPv6: mapped first=false, IPv4 same-/24 second=true
--- PASS: TestQuotaAddressBucketsEndToEnd (0.00s)
PASS
ok  	go.minekube.com/gate/pkg/internal/addrquota	0.341s
```
</details>
<details>
<summary>Evidence: Final focused tests</summary>

`Focused addrquota regression tests passed.`

```text
=== RUN   TestIPKeyBucketing
=== RUN   TestIPKeyBucketing/ipv6_same_/64
=== RUN   TestIPKeyBucketing/ipv6_same_/64,_differing_above_the_low_byte
=== RUN   TestIPKeyBucketing/ipv6_different_/64
=== RUN   TestIPKeyBucketing/ipv6_different_/64,_identical_low_64_bits
=== RUN   TestIPKeyBucketing/ipv4_same_/24
=== RUN   TestIPKeyBucketing/ipv4_different_/24
=== RUN   TestIPKeyBucketing/ipv4-mapped_ipv6_matches_its_ipv4_/24
=== RUN   TestIPKeyBucketing/ipv4-mapped_ipv6_different_/24
--- PASS: TestIPKeyBucketing (0.00s)
    --- PASS: TestIPKeyBucketing/ipv6_same_/64 (0.00s)
    --- PASS: TestIPKeyBucketing/ipv6_same_/64,_differing_above_the_low_byte (0.00s)
    --- PASS: TestIPKeyBucketing/ipv6_different_/64 (0.00s)
    --- PASS: TestIPKeyBucketing/ipv6_different_/64,_identical_low_64_bits (0.00s)
    --- PASS: TestIPKeyBucketing/ipv4_same_/24 (0.00s)
    --- PASS: TestIPKeyBucketing/ipv4_different_/24 (0.00s)
    --- PASS: TestIPKeyBucketing/ipv4-mapped_ipv6_matches_its_ipv4_/24 (0.00s)
    --- PASS: TestIPKeyBucketing/ipv4-mapped_ipv6_different_/24 (0.00s)
=== RUN   TestIPKeyPrefixes
--- PASS: TestIPKeyPrefixes (0.00s)
PASS
ok  	go.minekube.com/gate/pkg/internal/addrquota	0.157s
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `go test -count=1 -v -run 'TestIPKey(Bucketing|Prefixes)$' ./pkg/internal/addrquota`
- `go test -count=1 -v -run '^TestQuotaAddressBucketsEndToEnd$' ./pkg/internal/addrquota`
- `go test -count=1 -v ./pkg/internal/addrquota`
- <code>`git status --short` confirmed the temporary evidence test was removed and the worktree remained clean.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
