### PR TITLE
test(codec): cover trident sound packet forwarding

### DIFF
--- a/pkg/edition/java/proto/codec/decoder_test.go
+++ b/pkg/edition/java/proto/codec/decoder_test.go
@@ -47,6 +47,58 @@ func buildBCCExtraData(bccJSON string) []byte {
 	return buf.Bytes()
 }
 
+func buildSoundEntityPacket773() (frame, payload []byte) {
+	var payloadBuf bytes.Buffer
+	w := util.PanicWriter(&payloadBuf)
+	w.VarInt(0x72) // Clientbound Sound Entity, protocol 773
+	w.VarInt(123)  // registry-backed sound; inline name/range are absent
+	w.VarInt(int(packet.SoundSourcePlayer))
+	w.VarInt(42)
+	w.Float32(1)
+	w.Float32(0.8)
+	w.Int64(987654321)
+
+	var frameBuf bytes.Buffer
+	_ = util.WriteVarInt(&frameBuf, payloadBuf.Len())
+	frameBuf.Write(payloadBuf.Bytes())
+	return frameBuf.Bytes(), payloadBuf.Bytes()
+}
+
+// TestDecoder_SoundEntity_Protocol773_RegistryBacked verifies the decode and
+// raw-forward path for the entity-attached sound emitted when a trident is
+// thrown. Regression for https://github.com/minekube/gate/issues/597.
+func TestDecoder_SoundEntity_Protocol773_RegistryBacked(t *testing.T) {
+	frame, payload := buildSoundEntityPacket773()
+
+	dec := NewDecoder(bytes.NewReader(frame), proto.ClientBound, logr.Discard())
+	dec.SetState(state.Play)
+	dec.SetProtocol(version.Minecraft_1_21_9.Protocol)
+
+	ctx, err := dec.Decode()
+	require.NoError(t, err)
+	require.NotNil(t, ctx)
+
+	sound, ok := ctx.Packet.(*packet.SoundEntityPacket)
+	require.True(t, ok, "expected *packet.SoundEntityPacket, got %T", ctx.Packet)
+	assert.Equal(t, 123, sound.SoundID)
+	assert.Nil(t, sound.SoundName)
+	assert.Nil(t, sound.FixedRange)
+	assert.Equal(t, packet.SoundSourcePlayer, sound.SoundSource)
+	assert.Equal(t, 42, sound.EntityID)
+	assert.InDelta(t, 1, sound.Volume, 0)
+	assert.InDelta(t, 0.8, sound.Pitch, 0.000001)
+	assert.Equal(t, int64(987654321), sound.Seed)
+	assert.Equal(t, payload, ctx.Payload)
+
+	var forwarded bytes.Buffer
+	enc := NewEncoder(&forwarded, proto.ClientBound, logr.Discard())
+	enc.SetState(state.Play)
+	enc.SetProtocol(version.Minecraft_1_21_9.Protocol)
+	_, err = enc.Write(ctx.Payload)
+	require.NoError(t, err)
+	assert.Equal(t, frame, forwarded.Bytes())
+}
+
 func TestDecoder_StatusResponse_NormalPacket(t *testing.T) {
 	status := `{"version":{"name":"1.20.1","protocol":763},"players":{"max":20,"online":5},"description":"A Minecraft Server"}`
 	raw := buildStatusResponsePacket(status, nil)


### PR DESCRIPTION
## Intent

Fix Gate issue #597 so throwing a plain or Loyalty Trident through Gate on a Fabric 1.21.9 backend (protocol 773) forwards cleanly without varint EOF/protocol desynchronization or collateral viewer kicks. Diagnose the divergent Gate versus direct/Velocity packet path, preserve fail-before/pass-after behavioral evidence, and add regression coverage on the offending decode/forward path. Current repository history shows PR #605 already fixed the SoundEntityPacket decoder by correctly distinguishing registry-backed sounds from inline named sounds and reading the optional fixed-range boolean; do not duplicate or widen that production fix. Validate the focused protocol-773 raw-frame regression guarding that existing fix. Do not release, deploy, merge, change production, or touch the separate Gate release/Moxy-consumption decision.

## What Changed

- Adds protocol-773 regression coverage for registry-backed entity sounds on the trident throw path.
- Verifies decoding field alignment and byte-for-byte raw-frame forwarding, including absent inline sound fields.

## Risk Assessment

✅ Low: The change is a bounded protocol-773 regression test with no production modifications, matching the existing decoder fix and raw forwarding path.

## Testing

The pre-#605 decoder reproduces the EOF/desynchronization failure, while the target decoder decodes the registry-backed SoundEntity packet and forwards its raw frame byte-for-byte; no production files were changed.

<details>
<summary>Evidence: Pre-#605 regression failure</summary>

```text
=== RUN   TestDecoder_SoundEntity_Protocol773_RegistryBacked
    decoder_test.go:78: 
        	Error Trace:	/Users/robin/.no-mistakes/worktrees/543b8e602fb1/01KYTAZ7SJ9FBZ95J4KQ07WP2P/pkg/edition/java/proto/codec/decoder_test.go:78
        	Error:      	Received unexpected error:
        	            	error decoding packet (type: *packet.SoundEntityPacket, id: 72, protocol: 773, direction: ClientBound, read: 20, unread: 0): EOF
        	            	unexpected EOF
        	Test:       	TestDecoder_SoundEntity_Protocol773_RegistryBacked
--- FAIL: TestDecoder_SoundEntity_Protocol773_RegistryBacked (0.00s)
FAIL
FAIL	go.minekube.com/gate/pkg/edition/java/proto/codec	0.440s
FAIL
```
</details>
<details>
<summary>Evidence: Target protocol-773 regression</summary>

```text
=== RUN   TestDecoder_SoundEntity_Protocol773_RegistryBacked
--- PASS: TestDecoder_SoundEntity_Protocol773_RegistryBacked (0.00s)
PASS
ok  	go.minekube.com/gate/pkg/edition/java/proto/codec	0.369s
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `go test ./pkg/edition/java/proto/codec -run '^TestDecoder_SoundEntity_Protocol773_RegistryBacked$' -count=1 -v`
- `Same test against the pre-#605 decoder via Go overlay; reproduced unexpected EOF.`
- `Same test against the current base decoder via Go overlay; passed.`
- `Final target test rerun after cleanup; worktree remained clean.`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
