### PR TITLE
fix(chat): normalize compact show_text hover components for NBT

### DIFF
--- a/pkg/edition/java/proto/packet/chat/component_holder.go
+++ b/pkg/edition/java/proto/packet/chat/component_holder.go
@@ -174,6 +174,15 @@ func componentObjectValue(value any) any {
 				v[key] = componentObjectValue(item)
 			}
 		}
+		if hoverEvent, ok := v["hover_event"].(map[string]any); ok {
+			if action, ok := hoverEvent["action"].(string); ok && action == "show_text" {
+				for _, key := range []string{"value", "contents"} {
+					if item, ok := hoverEvent[key]; ok {
+						hoverEvent[key] = componentObjectValue(item)
+					}
+				}
+			}
+		}
 		for _, key := range []string{"separator"} {
 			if item, ok := v[key]; ok && item != nil {
 				v[key] = componentObjectValue(item)

--- a/pkg/edition/java/proto/packet/chat/component_holder.go
+++ b/pkg/edition/java/proto/packet/chat/component_holder.go
@@ -174,11 +174,13 @@ func componentObjectValue(value any) any {
 				v[key] = componentObjectValue(item)
 			}
 		}
-		if hoverEvent, ok := v["hover_event"].(map[string]any); ok {
-			if action, ok := hoverEvent["action"].(string); ok && action == "show_text" {
-				for _, key := range []string{"value", "contents"} {
-					if item, ok := hoverEvent[key]; ok {
-						hoverEvent[key] = componentObjectValue(item)
+		for _, hoverEventKey := range []string{"hover_event", "hoverEvent"} {
+			if hoverEvent, ok := v[hoverEventKey].(map[string]any); ok {
+				if action, ok := hoverEvent["action"].(string); ok && action == "show_text" {
+					for _, key := range []string{"value", "contents"} {
+						if item, ok := hoverEvent[key]; ok {
+							hoverEvent[key] = componentObjectValue(item)
+						}
 					}
 				}
 			}

--- a/pkg/edition/java/proto/packet/chat/component_holder_test.go
+++ b/pkg/edition/java/proto/packet/chat/component_holder_test.go
@@ -192,6 +192,52 @@ func TestComponentHolderAsBinaryTagExpandsCompactLegacyHoverTextChildren(t *test
 	}`, string(got))
 }
 
+func TestComponentHolderAsBinaryTagExpandsCompactCamelCaseHoverTextChildren(t *testing.T) {
+	holder := &ComponentHolder{
+		Protocol: version.Minecraft_26_2.Protocol,
+		JSON: []byte(`{
+			"text":"question",
+			"hoverEvent":{
+				"action":"show_text",
+				"value":{
+					"text":"answer",
+					"extra":[
+						{"italic":true,"text":"styled answer"},
+						"plain answer"
+					]
+				},
+				"contents":[
+					{"bold":true,"text":"styled contents"},
+					"plain contents"
+				]
+			}
+		}`),
+	}
+
+	tag, err := holder.AsBinaryTag()
+	require.NoError(t, err)
+
+	got, err := nbtconv.BinaryTagToJSON(&tag)
+	require.NoError(t, err)
+	require.JSONEq(t, `{
+		"text":"question",
+		"hoverEvent":{
+			"action":"show_text",
+			"value":{
+				"text":"answer",
+				"extra":[
+					{"italic":true,"text":"styled answer"},
+					{"text":"plain answer"}
+				]
+			},
+			"contents":[
+				{"bold":true,"text":"styled contents"},
+				{"text":"plain contents"}
+			]
+		}
+	}`, string(got))
+}
+
 func TestComponentHolderAsJsonDoesNotRewriteNonTextHoverPayloads(t *testing.T) {
 	tests := map[string]string{
 		"item": `{
@@ -205,6 +251,44 @@ func TestComponentHolderAsJsonDoesNotRewriteNonTextHoverPayloads(t *testing.T) {
 		"entity": `{
 			"text":"entity",
 			"hover_event":{
+				"action":"show_entity",
+				"value":"unchanged entity payload",
+				"contents":{
+					"type":"minecraft:player",
+					"id":"12345678-1234-1234-1234-123456789abc",
+					"name":"unchanged entity name"
+				}
+			}
+		}`,
+	}
+
+	for name, input := range tests {
+		t.Run(name, func(t *testing.T) {
+			holder := &ComponentHolder{
+				Protocol: version.Minecraft_26_2.Protocol,
+				JSON:     []byte(input),
+			}
+
+			got, err := holder.AsJson()
+			require.NoError(t, err)
+			require.JSONEq(t, input, string(got))
+		})
+	}
+}
+
+func TestComponentHolderAsJsonDoesNotRewriteCamelCaseNonTextHoverPayloads(t *testing.T) {
+	tests := map[string]string{
+		"item": `{
+			"text":"item",
+			"hoverEvent":{
+				"action":"show_item",
+				"value":"minecraft:stone",
+				"contents":{"id":"minecraft:stone","count":1}
+			}
+		}`,
+		"entity": `{
+			"text":"entity",
+			"hoverEvent":{
 				"action":"show_entity",
 				"value":"unchanged entity payload",
 				"contents":{

--- a/pkg/edition/java/proto/packet/chat/component_holder_test.go
+++ b/pkg/edition/java/proto/packet/chat/component_holder_test.go
@@ -115,3 +115,142 @@ func TestComponentHolderAsBinaryTagHandlesModernStyledTextWithChildren(t *testin
 	_, err = holder.AsBinaryTag()
 	require.NoError(t, err)
 }
+
+func TestComponentHolderAsBinaryTagExpandsCompactHoverTextChildren(t *testing.T) {
+	holder := &ComponentHolder{
+		Protocol: version.Minecraft_26_2.Protocol,
+		JSON: []byte(`{
+			"text":"question",
+			"hover_event":{
+				"action":"show_text",
+				"contents":{
+					"text":"answer",
+					"extra":[
+						{"bold":true,"text":"styled answer"},
+						"plain answer"
+					]
+				}
+			}
+		}`),
+	}
+
+	tag, err := holder.AsBinaryTag()
+	require.NoError(t, err)
+
+	got, err := nbtconv.BinaryTagToJSON(&tag)
+	require.NoError(t, err)
+	require.JSONEq(t, `{
+		"text":"question",
+		"hover_event":{
+			"action":"show_text",
+			"contents":{
+				"text":"answer",
+				"extra":[
+					{"bold":true,"text":"styled answer"},
+					{"text":"plain answer"}
+				]
+			}
+		}
+	}`, string(got))
+}
+
+func TestComponentHolderAsBinaryTagExpandsCompactLegacyHoverTextChildren(t *testing.T) {
+	holder := &ComponentHolder{
+		Protocol: version.Minecraft_26_2.Protocol,
+		JSON: []byte(`{
+			"text":"question",
+			"hover_event":{
+				"action":"show_text",
+				"value":{
+					"text":"answer",
+					"extra":[
+						{"italic":true,"text":"styled answer"},
+						"plain answer"
+					]
+				}
+			}
+		}`),
+	}
+
+	tag, err := holder.AsBinaryTag()
+	require.NoError(t, err)
+
+	got, err := nbtconv.BinaryTagToJSON(&tag)
+	require.NoError(t, err)
+	require.JSONEq(t, `{
+		"text":"question",
+		"hover_event":{
+			"action":"show_text",
+			"value":{
+				"text":"answer",
+				"extra":[
+					{"italic":true,"text":"styled answer"},
+					{"text":"plain answer"}
+				]
+			}
+		}
+	}`, string(got))
+}
+
+func TestComponentHolderAsJsonDoesNotRewriteNonTextHoverPayloads(t *testing.T) {
+	tests := map[string]string{
+		"item": `{
+			"text":"item",
+			"hover_event":{
+				"action":"show_item",
+				"value":"minecraft:stone",
+				"contents":{"id":"minecraft:stone","count":1}
+			}
+		}`,
+		"entity": `{
+			"text":"entity",
+			"hover_event":{
+				"action":"show_entity",
+				"value":"unchanged entity payload",
+				"contents":{
+					"type":"minecraft:player",
+					"id":"12345678-1234-1234-1234-123456789abc",
+					"name":"unchanged entity name"
+				}
+			}
+		}`,
+	}
+
+	for name, input := range tests {
+		t.Run(name, func(t *testing.T) {
+			holder := &ComponentHolder{
+				Protocol: version.Minecraft_26_2.Protocol,
+				JSON:     []byte(input),
+			}
+
+			got, err := holder.AsJson()
+			require.NoError(t, err)
+			require.JSONEq(t, input, string(got))
+		})
+	}
+}
+
+func TestComponentHolderAsJsonDoesNotRewriteUnrelatedStrings(t *testing.T) {
+	holder := &ComponentHolder{
+		Protocol: version.Minecraft_26_2.Protocol,
+		JSON: []byte(`{
+			"text":"link",
+			"custom":"leave unchanged",
+			"click_event":{
+				"action":"open_url",
+				"url":"https://example.com/path"
+			}
+		}`),
+	}
+
+	got, err := holder.AsJson()
+	require.NoError(t, err)
+	require.JSONEq(t, `{
+		"text":"link",
+		"custom":"leave unchanged",
+		"click_event":{
+			"action":"open_url",
+			"url":"https://example.com/path"
+		}
+	}`, string(got))
+}


### PR DESCRIPTION
## Intent

Fix the proven Minecraft 26.2 Connect outer-client writer failure by normalizing compact component children only inside show_text hover_event value and contents before binary-tag encoding. Preserve existing top-level extra, with, and separator handling and all supported JSON/NBT compatibility. Preserve non-text show_item and show_entity hover payloads, action names, URLs, unrelated strings, bundle behavior, ViaLite, Connect, Hub, Moxy, release metadata, and deployment behavior. Validate and ship exact implementation commit 32bf901 as a green Gate PR only, with scope limited to pkg/edition/java/proto/packet/chat/component_holder.go and component_holder_test.go. Do not merge, tag, release, bump Moxy, deploy, or perform production proof.

## What Changed

- Normalize compact string children in `show_text` hover-event `value` and `contents` for both snake_case and camelCase fields before NBT encoding.
- Preserve existing component handling and non-text hover payloads, with regression coverage for legacy/camelCase and unrelated values.

## Risk Assessment

✅ Low: The corrected change is bounded to the requested files, handles both snake_case and camelCase show_text hover events, and preserves non-text payload handling and existing normalization paths.

## Testing

Focused regression tests and the containing chat packet package passed. Manual wire-level round trips demonstrated show_text value/contents normalization, preserved extra/with/separator handling, and preserved show_item/show_entity payloads. The authorized diff contains only the two requested files; no full suite, linter, formatter, or static analysis was run.

<details>
<summary>Evidence: Component writer round-trip evidence</summary>

<code>show_text_value_and_contents&#10;wire: 304 bytes&#10;output: compact value/contents children normalized; extra/with/separator preserved&#10;show_item&#10;wire: 96 bytes&#10;output: payload preserved&#10;show_entity&#10;wire: 109 bytes&#10;output: payload preserved</code>

```text
show_text_value_and_contents
input:  {"text":"question","extra":["top-level child"],"with":["argument"],"separator":"separator","hover_event":{"action":"show_text","value":["legacy answer",{"italic":true,"text":"styled legacy answer"}],"contents":["plain answer",{"bold":true,"text":"styled answer"}]}}
wire:   304 bytes
output: {"extra":[{"text":"top-level child"}],"hover_event":{"action":"show_text","contents":[{"text":"plain answer"},{"bold":true,"text":"styled answer"}],"value":[{"text":"legacy answer"},{"italic":true,"text":"styled legacy answer"}]},"separator":{"text":"separator"},"text":"question","with":[{"text":"argument"}]}
show_item
input:  {"text":"item","hover_event":{"action":"show_item","contents":{"id":"minecraft:stone","count":1}}}
wire:   96 bytes
output: {"hover_event":{"action":"show_item","contents":{"count":1,"id":"minecraft:stone"}},"text":"item"}
show_entity
input:  {"text":"entity","hover_event":{"action":"show_entity","contents":{"type":"minecraft:player","name":"unchanged"}}}
wire:   109 bytes
output: {"hover_event":{"action":"show_entity","contents":{"name":"unchanged","type":"minecraft:player"}},"text":"entity"}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- 🚨 `pkg/edition/java/proto/packet/chat/component_holder.go:177` - The required criterion is to “Preserve ... all supported JSON/NBT compatibility,” but this guard only recognizes `v[&#34;hover_event&#34;]`. Supported pre-1.21.5 codecs emit `hoverEvent` (camelCase), leaving compact `show_text` value/contents children as strings before `JsonToBinaryTag`; normalize both field spellings at this boundary or confirm legacy compatibility is intentionally excluded.

🔧 Fix: Normalize camelCase show_text hover components
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `go test -count=1 -v ./pkg/edition/java/proto/packet/chat -run 'TestComponentHolder(AsBinaryTagExpandsCompact(HoverTextChildren|LegacyHoverTextChildren|CamelCaseHoverTextChildren)|AsJsonDoesNotRewrite(NonTextHoverPayloads|CamelCaseNonTextHoverPayloads|UnrelatedStrings))$'`
- `go test -count=1 ./pkg/edition/java/proto/packet/chat`
- <code>`go run .../hover_component_roundtrip.go` exercising ComponentHolder.Write and ReadComponentHolder</code>
- `git diff --name-only ba783c726ecc876f7b31ce40328d91c480eefbb1 17993abfa164f1930dff6ce601649a13c06136cf`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
