### PR TITLE
ci: codify merge-to-release policy

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,5 +1,14 @@
 name: Release Please
 
+# Merge-to-release policy (authoritative):
+# - Every push to master runs Release Please. When it finds a release-eligible
+#   change, this workflow merges the generated release PR, reruns itself on
+#   master, creates the tag and GitHub release, and calls release-publish.yml.
+# - Merging a release-eligible change to master therefore approves that release.
+#   PR text, labels, and task-local instructions such as "do not release" do not
+#   suppress it. A release hold must first be implemented in this workflow and
+#   protected by matching regression coverage.
+
 # Renovate can now auto-merge geyserlite bumps with a fix(deps): commit.
 # This workflow turns those conventional commits on master into normal Gate
 # GitHub releases. The release-please tag is created with GITHUB_TOKEN, so it

--- a/pkg/internal/reload/watch_test.go
+++ b/pkg/internal/reload/watch_test.go
@@ -26,12 +26,8 @@ func TestWatchCoalescesAtomicRenameAndRecreatedFile(t *testing.T) {
 	var calls atomic.Int32
 	done := make(chan struct{}, 2)
 	require.NoError(t, Watch(ctx, path, func() error {
-		content, err := os.ReadFile(path)
-		if err != nil {
-			return Reject("read_failed")
-		}
-		calls.Add(1)
-		if string(content) == "replacement" || string(content) == "recreated" {
+		call := calls.Add(1)
+		if call <= 2 {
 			done <- struct{}{}
 		}
 		return nil

--- a/pkg/internal/reload/watch_test.go
+++ b/pkg/internal/reload/watch_test.go
@@ -26,8 +26,12 @@ func TestWatchCoalescesAtomicRenameAndRecreatedFile(t *testing.T) {
 	var calls atomic.Int32
 	done := make(chan struct{}, 2)
 	require.NoError(t, Watch(ctx, path, func() error {
-		call := calls.Add(1)
-		if call <= 2 {
+		content, err := os.ReadFile(path)
+		if err != nil {
+			return Reject("read_failed")
+		}
+		calls.Add(1)
+		if string(content) == "replacement" || string(content) == "recreated" {
 			done <- struct{}{}
 		}
 		return nil

--- a/release_please_workflow_test.go
+++ b/release_please_workflow_test.go
@@ -40,6 +40,7 @@ func TestReleasePleaseMergeToReleasePolicy(t *testing.T) {
 		t.Fatal(err)
 	}
 	contents := normalizeWorkflowLineEndings(string(workflowBytes))
+	workflowBytes = []byte(contents)
 	if !strings.Contains(contents, mergeToReleasePolicy) {
 		t.Fatal("release-please workflow must state the authoritative merge-to-release policy")
 	}
@@ -116,6 +117,7 @@ func TestReleasePleaseMoxyDispatchWorkflowContract(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	workflowBytes = []byte(normalizeWorkflowLineEndings(string(workflowBytes)))
 
 	var workflow struct {
 		Jobs map[string]struct {

--- a/release_please_workflow_test.go
+++ b/release_please_workflow_test.go
@@ -12,7 +12,93 @@ import (
 
 const approvedDispatchWorkflow = "minekube/actions/.github/workflows/dispatch-workflow.yml@1965ed6ae602a602f9f98edcb31fe177403e8d77"
 
+const mergeToReleasePolicy = `# Merge-to-release policy (authoritative):
+# - Every push to master runs Release Please. When it finds a release-eligible
+#   change, this workflow merges the generated release PR, reruns itself on
+#   master, creates the tag and GitHub release, and calls release-publish.yml.
+# - Merging a release-eligible change to master therefore approves that release.
+#   PR text, labels, and task-local instructions such as "do not release" do not
+#   suppress it. A release hold must first be implemented in this workflow and
+#   protected by matching regression coverage.`
+
 var immutableWorkflowRef = regexp.MustCompile(`^[0-9a-f]{40}$`)
+
+func TestReleasePleaseMergeToReleasePolicy(t *testing.T) {
+	workflowBytes, err := os.ReadFile(".github/workflows/release-please.yml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	contents := string(workflowBytes)
+	if !strings.Contains(contents, mergeToReleasePolicy) {
+		t.Fatal("release-please workflow must state the authoritative merge-to-release policy")
+	}
+
+	var workflow struct {
+		On struct {
+			Push struct {
+				Branches []string `yaml:"branches"`
+			} `yaml:"push"`
+			RepositoryDispatch struct {
+				Types []string `yaml:"types"`
+			} `yaml:"repository_dispatch"`
+		} `yaml:"on"`
+		Jobs map[string]struct {
+			Needs string `yaml:"needs"`
+			If    string `yaml:"if"`
+			Uses  string `yaml:"uses"`
+			Steps []struct {
+				Name string `yaml:"name"`
+				If   string `yaml:"if"`
+				Run  string `yaml:"run"`
+			} `yaml:"steps"`
+		} `yaml:"jobs"`
+	}
+	if err := yaml.Unmarshal(workflowBytes, &workflow); err != nil {
+		t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(workflow.On.Push.Branches, []string{"master"}) {
+		t.Fatalf("release-please push branches = %v, want [master]", workflow.On.Push.Branches)
+	}
+	if !reflect.DeepEqual(workflow.On.RepositoryDispatch.Types, []string{"release-please-rerun"}) {
+		t.Fatalf("release-please repository dispatch types = %v, want [release-please-rerun]", workflow.On.RepositoryDispatch.Types)
+	}
+
+	releasePlease := workflow.Jobs["release-please"]
+	if releasePlease.If != "" {
+		t.Fatalf("release-please job has an additional gate %q", releasePlease.If)
+	}
+	var mergeStep *struct {
+		Name string `yaml:"name"`
+		If   string `yaml:"if"`
+		Run  string `yaml:"run"`
+	}
+	for i := range releasePlease.Steps {
+		if releasePlease.Steps[i].Name == "Auto-merge release PR" {
+			mergeStep = &releasePlease.Steps[i]
+			break
+		}
+	}
+	if mergeStep == nil {
+		t.Fatal("release-please must auto-merge its generated release PR")
+	}
+	if mergeStep.If != "${{ steps.rp.outputs.pr }}" {
+		t.Fatalf("release PR merge gate = %q, want only the release-please PR output", mergeStep.If)
+	}
+	for _, command := range []string{`gh pr merge "$PR_NUMBER"`, "--merge", `-f event_type=release-please-rerun`} {
+		if !strings.Contains(mergeStep.Run, command) {
+			t.Fatalf("release PR merge step must contain %q", command)
+		}
+	}
+
+	trigger := workflow.Jobs["trigger-release"]
+	if trigger.Needs != "release-please" || trigger.If != "needs.release-please.outputs.release_created == 'true'" {
+		t.Fatalf("publisher release gate = needs %q, if %q", trigger.Needs, trigger.If)
+	}
+	if trigger.Uses != "./.github/workflows/release-publish.yml" {
+		t.Fatalf("publisher workflow = %q, want ./.github/workflows/release-publish.yml", trigger.Uses)
+	}
+}
 
 func TestReleasePleaseMoxyDispatchWorkflowContract(t *testing.T) {
 	workflowBytes, err := os.ReadFile(".github/workflows/release-please.yml")

--- a/release_please_workflow_test.go
+++ b/release_please_workflow_test.go
@@ -23,12 +23,23 @@ const mergeToReleasePolicy = `# Merge-to-release policy (authoritative):
 
 var immutableWorkflowRef = regexp.MustCompile(`^[0-9a-f]{40}$`)
 
+func normalizeWorkflowLineEndings(contents string) string {
+	return strings.ReplaceAll(contents, "\r\n", "\n")
+}
+
+func TestNormalizeWorkflowLineEndings(t *testing.T) {
+	const workflow = "name: Release Please\n\n# Merge-to-release policy (authoritative):\n"
+	if got := normalizeWorkflowLineEndings(strings.ReplaceAll(workflow, "\n", "\r\n")); got != workflow {
+		t.Fatalf("normalized workflow = %q, want %q", got, workflow)
+	}
+}
+
 func TestReleasePleaseMergeToReleasePolicy(t *testing.T) {
 	workflowBytes, err := os.ReadFile(".github/workflows/release-please.yml")
 	if err != nil {
 		t.Fatal(err)
 	}
-	contents := string(workflowBytes)
+	contents := normalizeWorkflowLineEndings(string(workflowBytes))
 	if !strings.Contains(contents, mergeToReleasePolicy) {
 		t.Fatal("release-please workflow must state the authoritative merge-to-release policy")
 	}


### PR DESCRIPTION
## Intent

Update existing PR 958 from follow-up commit 3fde503 and reach green CI with a final diff against current origin/master strictly limited to .github/workflows/release-please.yml and release_please_workflow_test.go. The purpose is to make Gate’s existing merge-to-release authority explicit at the authoritative workflow surface and enforce it with executable regression coverage, while preserving current release behavior. Retain the CRLF normalization in the release policy contract. Do not change pkg/internal/reload, watcher behavior or tests, release semantics, credentials, publication, or any unrelated file. Do not merge or release.

## What Changed

- Documents Gate’s authoritative merge-to-release policy in `.github/workflows/release-please.yml`, including master pushes, release-PR auto-merge, rerun dispatch, and publication handoff.
- Adds regression coverage for those workflow gates and retains CRLF normalization while preserving existing Moxy dispatch checks.

## Risk Assessment

✅ Low: The net change is limited to the requested workflow policy comments and regression coverage, with no release behavior, credentials, publication, or unrelated source changes introduced.

## Testing

Ran focused release-policy regression tests plus existing publisher and token-boundary contracts; all passed. Verified the actual workflow contract manually and captured it as evidence. Confirmed the final diff contains only `.github/workflows/release-please.yml` and `release_please_workflow_test.go`; no live merge or release was performed.

<details>
<summary>Evidence: Release policy workflow transcript</summary>

```text
Read-only end-user workflow contract transcript
Source: .github/workflows/release-please.yml at target commit 3fde503dbacea18236edc491c74e0972c26a2fea

Trigger surface:
  on.push.branches: [master]
  on.repository_dispatch.types: [release-please-rerun]

Release-eligible change flow:
  Auto-merge release PR when: ${{ steps.rp.outputs.pr }}
  Merge command: gh pr merge "$PR_NUMBER" --merge
  Post-merge rerun: gh api --method POST ... -f event_type=release-please-rerun

Publication gate:
  trigger-release needs: release-please
  trigger-release if: needs.release-please.outputs.release_created == 'true'
  reusable publisher: ./.github/workflows/release-publish.yml

Focused executable verification:
  go test . -run 'Test(NormalizeWorkflowLineEndings|ReleasePleaseMergeToReleasePolicy|ReleasePleaseMoxyDispatchWorkflowContract)$' -count=1 -v
  PASS (all selected tests)
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `go test . -run 'Test(NormalizeWorkflowLineEndings|ReleasePleaseMergeToReleasePolicy|ReleasePleaseMoxyDispatchWorkflowContract)$' -count=1 -v`
- `go test . -run 'Test(CIGrantsNoAmbientWritePermission|ReleasePublishUsesTrustedDefaultBranchWorkflow)$' -count=1 -v`
- `Read-only workflow transcript of triggers, auto-merge, rerun, and publication gates`
- <code>`git diff --name-status origin/master...HEAD` and `git status --short`</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
