### PR TITLE
ci: use repaired release cascade workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -72,7 +72,7 @@ jobs:
   dispatch-moxy-bump:
     needs: release-please
     if: needs.release-please.outputs.release_created == 'true'
-    uses: minekube/actions/.github/workflows/dispatch-workflow.yml@1965ed6ae602a602f9f98edcb31fe177403e8d77
+    uses: minekube/actions/.github/workflows/dispatch-workflow.yml@0d24c686ae9c5df7841e2158f2f0942cd452f870
     permissions:
       contents: read
       id-token: write

--- a/release_please_workflow_test.go
+++ b/release_please_workflow_test.go
@@ -10,7 +10,7 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-const approvedDispatchWorkflow = "minekube/actions/.github/workflows/dispatch-workflow.yml@1965ed6ae602a602f9f98edcb31fe177403e8d77"
+const approvedDispatchWorkflow = "minekube/actions/.github/workflows/dispatch-workflow.yml@0d24c686ae9c5df7841e2158f2f0942cd452f870"
 
 const mergeToReleasePolicy = `# Merge-to-release policy (authoritative):
 # - Every push to master runs Release Please. When it finds a release-eligible


### PR DESCRIPTION
Update Gate's immutable release-to-Moxy dispatcher reference to the merged shared-actions fix. The `v1` reusable-workflow channel has also been advanced to the same commit for managed dependency callers.

Verification:
- `mise exec go@1.26 -- go test ./ -run "^(TestNormalizeWorkflowLineEndings|TestReleasePlease.*)$" -count=1`
- `git diff --check`