### PR TITLE
docs(web): use published installer URL

### DIFF
--- a/.web/docs/.vitepress/theme/components/LandingAfter.vue
+++ b/.web/docs/.vitepress/theme/components/LandingAfter.vue
@@ -310,7 +310,7 @@
                     {{
                       showWindowsCommand
                         ? 'powershell -c "irm https://gate.minekube.com/install.ps1 | iex"'
-                        : 'curl -sSL https://gate.minekube.com/install.sh | sh'
+                        : 'curl -sSL https://gate.minekube.com/install | sh'
                     }}
                   </code>
                 </div>
@@ -1239,7 +1239,7 @@ const showWindowsCommand = ref(isWindows);
 const copyInstallCommand = () => {
   const command = showWindowsCommand.value
     ? 'powershell -c "irm https://gate.minekube.com/install.ps1 | iex"'
-    : 'curl -sSL https://gate.minekube.com/install.sh | sh';
+    : 'curl -sSL https://gate.minekube.com/install | sh';
   navigator.clipboard.writeText(command);
 };
 

--- a/.web/scripts/workers-migration.test.mjs
+++ b/.web/scripts/workers-migration.test.mjs
@@ -97,6 +97,21 @@ test('deployment instructions provision the GitHub App private key as a Worker s
   assert.match(readme, /openssl pkcs8 -topk8 -nocrypt/);
 });
 
+test('the landing page uses the published Unix installer path', async () => {
+  const landingPage = await readFile(
+    new URL('../docs/.vitepress/theme/components/LandingAfter.vue', import.meta.url),
+    'utf8'
+  );
+  const installer = await readFile(
+    new URL('../docs/public/install', import.meta.url),
+    'utf8'
+  );
+
+  assert.match(landingPage, /https:\/\/gate\.minekube\.com\/install \| sh/);
+  assert.doesNotMatch(landingPage, /gate\.minekube\.com\/install\.sh/);
+  assert.match(installer, /^#!\/usr\/bin\/env bash/);
+});
+
 test('the Worker preserves Pages response headers for static assets and custom 404s', async () => {
   const html = normalizePagesResponse(
     new Response('<!doctype html>', {


### PR DESCRIPTION
## Problem

The Gate landing page advertises `curl -sSL https://gate.minekube.com/install.sh | sh`, but the published and documented Unix installer is `/install`. The advertised URL returns 404 in both the canary and production Worker deployments.

## Fix

- Point both landing-page command definitions at the published `/install` endpoint.
- Add a regression test that verifies the landing page uses that path, rejects `/install.sh`, and confirms the published file is a Bash installer.

## Verified

- `pnpm run test` — 9/9 passed.
- `pnpm run build:worker` — passed.
- `https://gate.minekube.com/install` returns 200.
