### PR TITLE
ci(web): prevent stale docs HTML

### DIFF
--- a/.web/README.md
+++ b/.web/README.md
@@ -52,6 +52,10 @@ passes.
 The previous Cloudflare Pages deployment remains available as the rollback
 target until the Worker is verified in production.
 
+The Worker marks HTML and custom 404 responses `no-store` so a deployment
+cannot leave an old HTML shell pointing at retired content-hashed assets.
+Hashed static assets retain the cache policy supplied by Workers Static Assets.
+
 Worker deployments use the pinned Wrangler toolchain. Set
 `GITHUB_CACHE_KV_NAMESPACE_ID` to the existing `GITHUB_CACHE` Workers KV
 namespace ID in the deployment environment. Before the first uncached API

--- a/.web/scripts/workers-migration.test.mjs
+++ b/.web/scripts/workers-migration.test.mjs
@@ -112,7 +112,7 @@ test('the landing page uses the published Unix installer path', async () => {
   assert.match(installer, /^#!\/usr\/bin\/env bash/);
 });
 
-test('the Worker preserves Pages response headers for static assets and custom 404s', async () => {
+test('the Worker preserves safe response headers without caching HTML shells', async () => {
   const html = normalizePagesResponse(
     new Response('<!doctype html>', {
       headers: { 'content-type': 'text/html' },
@@ -120,6 +120,7 @@ test('the Worker preserves Pages response headers for static assets and custom 4
   );
   assert.equal(html.headers.get('access-control-allow-origin'), '*');
   assert.equal(html.headers.get('content-type'), 'text/html; charset=utf-8');
+  assert.equal(html.headers.get('cache-control'), 'no-store');
   assert.equal(html.headers.get('x-content-type-options'), 'nosniff');
   assert.equal(
     html.headers.get('referrer-policy'),
@@ -132,6 +133,7 @@ test('the Worker preserves Pages response headers for static assets and custom 4
     })
   );
   assert.equal(css.headers.get('content-type'), 'text/css; charset=utf-8');
+  assert.equal(css.headers.get('cache-control'), null);
 
   const missing = normalizePagesResponse(
     new Response('missing', {

--- a/.web/worker-response.mjs
+++ b/.web/worker-response.mjs
@@ -7,17 +7,20 @@ const utf8MediaTypes = new Set([
 export function normalizePagesResponse(response) {
   const headers = new Headers(response.headers);
   const contentType = headers.get('content-type');
+  const mediaType = contentType?.split(';', 1)[0].trim().toLowerCase();
 
   headers.set('access-control-allow-origin', '*');
   headers.set('x-content-type-options', 'nosniff');
   headers.set('referrer-policy', 'strict-origin-when-cross-origin');
 
-  if (response.status === 404) {
+  // The custom domain can retain an HTML shell from the prior deployment while
+  // its content-hashed assets have already changed. Do not edge-cache HTML;
+  // immutable assets keep the cache policy supplied by the assets binding.
+  if (response.status === 404 || mediaType === 'text/html') {
     headers.set('cache-control', 'no-store');
   }
 
   if (contentType && !/;\s*charset=/i.test(contentType)) {
-    const mediaType = contentType.split(';', 1)[0].trim().toLowerCase();
     if (mediaType.startsWith('text/') || utf8MediaTypes.has(mediaType)) {
       headers.set('content-type', `${contentType}; charset=utf-8`);
     }


### PR DESCRIPTION
## Problem

The production cutover and a subsequent Worker deployment both reproduced the same failure mode: Cloudflare could retain an older HTML shell after content-hashed CSS/JS had changed, leaving the page pointed at assets that now returned 404.

## Fix

- Mark HTML and custom 404 responses `Cache-Control: no-store` in the Worker wrapper.
- Preserve the Workers Static Assets cache policy for content-hashed non-HTML assets.
- Add focused assertions for both behaviors and document the deployment invariant.

## Verified

- `pnpm run test` — 9/9 passed.
- `pnpm run build:worker` — passed.
- Canary version `8a0180a7-e7e2-4706-976a-6e723d52df3a` deployed successfully.
- Refreshed canary HTML returns `no-store`, the corrected `/install` command, and only live 200 asset references.
- Production was proactively revalidated across all 118 canonical HTML URLs while this fix is reviewed; every referenced local asset exists and returns successfully.
