### PR TITLE
fix(java): configurable offline username blacklist

### DIFF
--- a/pkg/configs/config.yml
+++ b/pkg/configs/config.yml
@@ -4,6 +4,12 @@ config:
   bind: 0.0.0.0:25565
   # Whether to use the proxy in online (authenticate players with Mojang API) or offline mode (not recommended).
   onlineMode: true
+  # Reserve authenticated account names on offline-mode login paths, including a Connect
+  # integration that deliberately marks its already-authenticated inner connection offline.
+  # Matching is case-insensitive. Direct online-mode joins with these names remain allowed.
+  offlineModeUsernameBlacklist: []
+  # Either simple legacy '§' text or a modern text component JSON object.
+  offlineModeUsernameBlacklistReason: "§cThis username is reserved for its authenticated owner."
   # Registers servers with the proxy by giving the address of backend server a custom reference name.
   servers:
     # Server name: server address

--- a/pkg/edition/java/config/config.go
+++ b/pkg/edition/java/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"fmt"
 	"os"
+	"regexp"
 	"strings"
 	"time"
 
@@ -18,10 +19,11 @@ import (
 
 // DefaultConfig is a default Config.
 var DefaultConfig = Config{
-	Bind:                          "0.0.0.0:25565",
-	OnlineMode:                    true,
-	Auth:                          Auth{},
-	OnlineModeKickExistingPlayers: false,
+	Bind:                               "0.0.0.0:25565",
+	OnlineMode:                         true,
+	Auth:                               Auth{},
+	OnlineModeKickExistingPlayers:      false,
+	OfflineModeUsernameBlacklistReason: text("§cThis username is reserved for its authenticated owner."),
 	Forwarding: Forwarding{
 		Mode:           LegacyForwardingMode,
 		VelocitySecret: "",
@@ -129,6 +131,10 @@ type Config struct { // TODO use https://github.com/projectdiscovery/yamldoc-go 
 	OnlineMode                    bool `yaml:"onlineMode,omitempty" json:"onlineMode,omitempty"`                                       // Whether to enable online mode.
 	Auth                          Auth `yaml:"auth,omitempty" json:"auth,omitempty"`                                                   // Authentication settings.
 	OnlineModeKickExistingPlayers bool `yaml:"onlineModeKickExistingPlayers,omitempty" json:"onlineModeKickExistingPlayers,omitempty"` // Kicks existing players when a premium player with the same name joins.
+	// OfflineModeUsernameBlacklist reserves names only on login paths that are effectively
+	// offline mode. Authenticated direct joins remain allowed to use the same names.
+	OfflineModeUsernameBlacklist       []string                  `yaml:"offlineModeUsernameBlacklist,omitempty" json:"offlineModeUsernameBlacklist,omitempty"`
+	OfflineModeUsernameBlacklistReason *configutil.TextComponent `yaml:"offlineModeUsernameBlacklistReason,omitempty" json:"offlineModeUsernameBlacklistReason,omitempty"`
 
 	Forwarding Forwarding `yaml:"forwarding,omitempty" json:"forwarding,omitempty"` // Player info forwarding settings.
 	Status     Status     `yaml:"status,omitempty" json:"status,omitempty"`         // Status response settings.
@@ -290,6 +296,7 @@ func (c *Config) Validate() (warns []error, errs []error) {
 	validateProxyProtocol(c, e, w)
 
 	validateBackendFloodgate(c, e)
+	validateOfflineModeUsernameBlacklist(c, e)
 	if c.Lite.Enabled {
 		warnLiteIgnoredSettings(c, w)
 		warns2, errs2 := c.Lite.Validate()
@@ -357,6 +364,24 @@ func (c *Config) Validate() (warns []error, errs []error) {
 	return
 }
 
+var minecraftUsernamePattern = regexp.MustCompile(`^[A-Za-z0-9_]{2,16}$`)
+
+func validateOfflineModeUsernameBlacklist(c *Config, e func(string, ...any)) {
+	seen := make(map[string]string, len(c.OfflineModeUsernameBlacklist))
+	for _, username := range c.OfflineModeUsernameBlacklist {
+		if !minecraftUsernamePattern.MatchString(username) {
+			e("Invalid offlineModeUsernameBlacklist entry %q: use a 2-16 character Minecraft username", username)
+			continue
+		}
+		folded := strings.ToLower(username)
+		if previous, exists := seen[folded]; exists {
+			e("Duplicate offlineModeUsernameBlacklist entries %q and %q are case-insensitively identical", previous, username)
+			continue
+		}
+		seen[folded] = username
+	}
+}
+
 // warnLiteIgnoredSettings warns about full proxy settings that Lite mode ignores.
 //
 // Lite pipes the player connection through to the backend unchanged, so Gate never takes
@@ -402,6 +427,10 @@ func warnLiteIgnoredSettings(c *Config, w func(string, ...any)) {
 	if c.AnnounceForge {
 		w("Lite mode ignores announceForge: status responses are proxied from the backend, " +
 			"which announces its own mods.")
+	}
+
+	if len(c.OfflineModeUsernameBlacklist) != 0 {
+		w("Lite mode ignores offlineModeUsernameBlacklist: Lite forwards login unchanged, so configure username protection on the backend or disable lite.enabled.")
 	}
 }
 

--- a/pkg/edition/java/config/config_test.go
+++ b/pkg/edition/java/config/config_test.go
@@ -96,6 +96,26 @@ func TestViaConfigIgnoredInLiteMode(t *testing.T) {
 	require.Empty(t, errs)
 }
 
+func TestOfflineModeUsernameBlacklistValidation(t *testing.T) {
+	t.Run("accepts distinct Minecraft usernames", func(t *testing.T) {
+		cfg := DefaultConfig
+		cfg.OfflineModeUsernameBlacklist = []string{"AdminName", "Owner_2"}
+
+		_, errs := cfg.Validate()
+		require.Empty(t, errs)
+	})
+
+	t.Run("rejects invalid and case-insensitive duplicate usernames", func(t *testing.T) {
+		cfg := DefaultConfig
+		cfg.OfflineModeUsernameBlacklist = []string{"AdminName", "adminname", "not valid"}
+
+		_, errs := cfg.Validate()
+		require.Len(t, errs, 2)
+		require.Contains(t, errs[0].Error(), "case-insensitively identical")
+		require.Contains(t, errs[1].Error(), "2-16 character Minecraft username")
+	})
+}
+
 // TestLiteIgnoredSettingsWarn covers https://github.com/minekube/gate/issues/929: Lite mode
 // pipes the connection through unchanged, so full proxy settings are inert and Gate must say
 // so instead of silently accepting them.
@@ -180,6 +200,15 @@ func TestLiteIgnoredSettingsWarn(t *testing.T) {
 
 		warns, _ := cfg.Validate()
 		requireWarnContains(t, warns, "Lite mode ignores announceForge")
+	})
+
+	t.Run("offline username blacklist warns", func(t *testing.T) {
+		cfg := liteConfig()
+		cfg.OfflineModeUsernameBlacklist = []string{"AdminName"}
+
+		warns, errs := cfg.Validate()
+		require.Empty(t, errs)
+		requireWarnContains(t, warns, "Lite mode ignores offlineModeUsernameBlacklist")
 	})
 
 	t.Run("lite defaults do not warn", func(t *testing.T) {

--- a/pkg/edition/java/proxy/offline_username_blacklist_test.go
+++ b/pkg/edition/java/proxy/offline_username_blacklist_test.go
@@ -1,0 +1,25 @@
+package proxy
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.minekube.com/gate/pkg/edition/java/config"
+)
+
+func TestOfflineModeUsernameBlacklist(t *testing.T) {
+	cfg := config.DefaultConfig
+	cfg.OfflineModeUsernameBlacklist = []string{"AdminName"}
+
+	require.True(t, offlineModeUsernameBlocked(&cfg, ForceOfflineModePreLogin, "adminname"),
+		"Connect-style forced-offline login must not impersonate a reserved account")
+	require.False(t, offlineModeUsernameBlocked(&cfg, ForceOnlineModePreLogin, "AdminName"),
+		"an authenticated direct login must retain access to its reserved account")
+	require.False(t, offlineModeUsernameBlocked(&cfg, AllowedPreLogin, "AdminName"),
+		"the proxy-wide online-mode default must remain authenticated")
+
+	cfg.OnlineMode = false
+	require.True(t, offlineModeUsernameBlocked(&cfg, AllowedPreLogin, "ADMINNAME"),
+		"ordinary offline-mode login must enforce the same reservation")
+	require.False(t, offlineModeUsernameBlocked(&cfg, AllowedPreLogin, "AnotherPlayer"))
+}

--- a/pkg/edition/java/proxy/session_client_initial_login.go
+++ b/pkg/edition/java/proxy/session_client_initial_login.go
@@ -6,6 +6,7 @@ import (
 	"crypto/rand"
 	"errors"
 	"regexp"
+	"strings"
 	"time"
 
 	"go.minekube.com/gate/pkg/edition/java/proto/state"
@@ -13,6 +14,7 @@ import (
 	"github.com/go-logr/logr"
 	"go.minekube.com/common/minecraft/color"
 	"go.minekube.com/common/minecraft/component"
+	"go.minekube.com/gate/pkg/edition/java/config"
 	"go.minekube.com/gate/pkg/edition/java/netmc"
 	"go.minekube.com/gate/pkg/edition/java/proto/util"
 	"go.minekube.com/gate/pkg/edition/java/proxy/crypto"
@@ -151,6 +153,14 @@ func (l *initialLoginSessionHandler) handleServerLogin(login *packet.ServerLogin
 		_ = l.inbound.disconnect(e.Reason())
 		return
 	}
+	if offlineModeUsernameBlocked(l.config(), e.Result(), l.login.Username) {
+		reason := l.config().OfflineModeUsernameBlacklistReason
+		if reason == nil {
+			reason = config.DefaultConfig.OfflineModeUsernameBlacklistReason
+		}
+		_ = l.inbound.disconnect(reason.T())
+		return
+	}
 
 	_ = l.inbound.loginEventFired(func() error {
 		if netmc.Closed(l.conn) {
@@ -184,6 +194,20 @@ func (l *initialLoginSessionHandler) handleServerLogin(login *packet.ServerLogin
 		l.conn.SetActiveSessionHandler(state.Login, sh)
 		return nil
 	})
+}
+
+func offlineModeUsernameBlocked(cfg *config.Config, result PreLoginResult, username string) bool {
+	offline := result == ForceOfflineModePreLogin ||
+		(result != ForceOnlineModePreLogin && !cfg.OnlineMode)
+	if !offline {
+		return false
+	}
+	for _, blocked := range cfg.OfflineModeUsernameBlacklist {
+		if strings.EqualFold(blocked, username) {
+			return true
+		}
+	}
+	return false
 }
 
 func (l *initialLoginSessionHandler) newAuthSessionHandler(


### PR DESCRIPTION
Closes #980.

Adds a case-insensitive, configurable username blacklist for offline-mode login paths, validates entries, exposes a safe default, and emits the configured rejection reason. Includes config and proxy regression coverage.

Verified: go test ./...