### PR TITLE
fix(bedrock): fail closed when managed listener exits

### DIFF
--- a/pkg/edition/bedrock/geyser/geyser.go
+++ b/pkg/edition/bedrock/geyser/geyser.go
@@ -29,6 +29,8 @@ type managedRunner interface {
 	EnsureKey(context.Context) error
 	Start(context.Context) error
 	Stop()
+	Done() <-chan struct{}
+	Err() error
 }
 
 type javaManagedRunner struct {
@@ -58,6 +60,10 @@ func (r *javaManagedRunner) Stop() {
 	r.runner.Stop()
 }
 
+func (r *javaManagedRunner) Done() <-chan struct{} { return r.runner.Done() }
+
+func (r *javaManagedRunner) Err() error { return r.runner.Err() }
+
 func newManagedRunner(cfg *config.Config) (managedRunner, error) {
 	managedConfig := cfg.GetManaged()
 	switch managedConfig.Engine {
@@ -85,6 +91,8 @@ type Integration struct {
 	unsubs         []func()
 	unregisterHook func()
 	manager        managedRunner
+	runtimeErr     chan error
+	runtimeErrOnce sync.Once
 }
 
 // GeyserConnection represents a connection from Geyser.
@@ -121,6 +129,7 @@ func NewIntegration(ctx context.Context, p *proxy.Proxy, cfg *config.Config) (*I
 		config:         cfg,
 		profileManager: NewProfileManager(),
 		connections:    make(map[net.Addr]*GeyserConnection),
+		runtimeErr:     make(chan error, 1),
 	}
 
 	managedConfig := cfg.GetManaged()
@@ -175,7 +184,7 @@ func (i *Integration) Start() error {
 	}
 	go func() {
 		if err := i.serve(ln); err != nil {
-			i.log.Error(err, "geyser listener failed")
+			i.reportRuntimeError(fmt.Errorf("geyser listener failed: %w", err))
 		}
 	}()
 
@@ -185,10 +194,54 @@ func (i *Integration) Start() error {
 			_ = ln.Close()
 			return fmt.Errorf("managed geyser start failed: %w", err)
 		}
+		i.watchManagedRuntime()
 	}
 
 	i.log.Info("geyser integration started", "addr", i.config.GeyserListenAddr)
 	return nil
+}
+
+// RuntimeErrors reports an unexpected failure of the managed Bedrock runtime
+// or the local Geyser listener. Consumers must stop the enclosing proxy when
+// they receive an error: a healthy Java/TCP listener alone does not prove that
+// the public Bedrock UDP listener is still accepting players.
+func (i *Integration) RuntimeErrors() <-chan error { return i.runtimeErr }
+
+// Done closes when the integration is intentionally stopped. Runtime-error
+// observers use it to leave cleanly during a reload instead of waiting for an
+// error that is never meant to arrive.
+func (i *Integration) Done() <-chan struct{} { return i.ctx.Done() }
+
+func (i *Integration) watchManagedRuntime() {
+	done := i.manager.Done()
+	if done == nil {
+		return
+	}
+	go func() {
+		select {
+		case <-i.ctx.Done():
+			return
+		case <-done:
+			if i.ctx.Err() != nil {
+				return
+			}
+			err := i.manager.Err()
+			if err == nil {
+				err = fmt.Errorf("managed geyserlite exited unexpectedly")
+			}
+			i.reportRuntimeError(fmt.Errorf("managed geyser runtime failed: %w", err))
+		}
+	}()
+}
+
+func (i *Integration) reportRuntimeError(err error) {
+	if err == nil || i.ctx.Err() != nil {
+		return
+	}
+	i.runtimeErrOnce.Do(func() {
+		i.log.Error(err, "bedrock runtime failed")
+		i.runtimeErr <- err
+	})
 }
 
 // Stop stops the Geyser integration listener and unsubscribes events.

--- a/pkg/edition/bedrock/geyser/managed/download_test.go
+++ b/pkg/edition/bedrock/geyser/managed/download_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 )
@@ -414,8 +415,14 @@ func TestGeyserReadyDetection(t *testing.T) {
 			// Create a runner (we don't need a real config for this test)
 			runner := &Runner{}
 
-			// Start handleOutput in a goroutine
-			go runner.handleOutput(r, "[GEYSER] ", &outputBuffer, readyCh)
+			// Start handleOutput in a goroutine and wait for it before reading
+			// outputBuffer; strings.Builder itself is not synchronization-safe.
+			var outputDone sync.WaitGroup
+			outputDone.Add(1)
+			go func() {
+				defer outputDone.Done()
+				runner.handleOutput(r, "[GEYSER] ", &outputBuffer, readyCh)
+			}()
 
 			// Write test log lines
 			go func() {
@@ -440,6 +447,7 @@ func TestGeyserReadyDetection(t *testing.T) {
 			if gotReady != tt.expectReady {
 				t.Errorf("Ready detection: got %v, want %v. %s", gotReady, tt.expectReady, tt.description)
 			}
+			outputDone.Wait()
 
 			// Verify output was properly prefixed
 			output := outputBuffer.String()

--- a/pkg/edition/bedrock/geyser/managed/managed.go
+++ b/pkg/edition/bedrock/geyser/managed/managed.go
@@ -26,10 +26,12 @@ import (
 
 // Runner manages a managed Geyser Standalone process.
 type Runner struct {
-	cfg    *bconfig.Config
-	cmd    *exec.Cmd
-	mu     sync.Mutex
-	cancel context.CancelFunc
+	cfg           *bconfig.Config
+	cmd           *exec.Cmd
+	mu            sync.Mutex
+	done          chan struct{}
+	err           error
+	stopRequested bool
 }
 
 func New(cfg *bconfig.Config) *Runner { return &Runner{cfg: cfg} }
@@ -90,8 +92,8 @@ func (r *Runner) Ensure(ctx context.Context) (string, error) {
 // Start runs the Geyser process with provided config.
 func (r *Runner) Start(ctx context.Context, jarPath string, extraArgs ...string) error {
 	r.mu.Lock()
-	defer r.mu.Unlock()
 	if r.cmd != nil {
+		r.mu.Unlock()
 		return fmt.Errorf("geyser already running")
 	}
 
@@ -101,16 +103,19 @@ func (r *Runner) Start(ctx context.Context, jarPath string, extraArgs ...string)
 	// Create Geyser config file in the data directory
 	configPath, err := r.writeGeyserConfig(managed)
 	if err != nil {
+		r.mu.Unlock()
 		return fmt.Errorf("failed to write geyser config: %w", err)
 	}
 
 	// Convert to absolute paths to avoid working directory issues
 	absJarPath, err := filepath.Abs(jarPath)
 	if err != nil {
+		r.mu.Unlock()
 		return fmt.Errorf("failed to get absolute jar path: %w", err)
 	}
 	absConfigPath, err := filepath.Abs(configPath)
 	if err != nil {
+		r.mu.Unlock()
 		return fmt.Errorf("failed to get absolute config path: %w", err)
 	}
 
@@ -132,19 +137,31 @@ func (r *Runner) Start(ctx context.Context, jarPath string, extraArgs ...string)
 	// Create pipes to capture output and wait for ready signal
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
+		r.mu.Unlock()
 		return fmt.Errorf("failed to create stdout pipe: %w", err)
 	}
 	stderr, err := cmd.StderrPipe()
 	if err != nil {
+		r.mu.Unlock()
 		return fmt.Errorf("failed to create stderr pipe: %w", err)
 	}
 
 	if err := cmd.Start(); err != nil {
+		r.mu.Unlock()
 		return fmt.Errorf("failed to start geyser process: %w", err)
 	}
 
 	r.cmd = cmd
+	done := make(chan struct{})
+	r.done = done
+	r.err = nil
+	r.stopRequested = false
+	r.mu.Unlock()
 	log.Info("geyser standalone process started", "pid", cmd.Process.Pid)
+
+	// Wait is called in exactly one place. Its close-only completion signal is
+	// safe for both Stop and the Bedrock integration watcher to observe.
+	go r.waitForExit(ctx, cmd, done)
 
 	// Start goroutines to handle output and wait for ready signal
 	readyCtx, readyCancel := context.WithTimeout(ctx, 30*time.Second)
@@ -167,7 +184,42 @@ func (r *Runner) Start(ctx context.Context, jarPath string, extraArgs ...string)
 		return nil // Don't fail, just continue
 	case <-ctx.Done():
 		return ctx.Err()
+	case <-done:
+		if err := r.Err(); err != nil {
+			return fmt.Errorf("geyser exited before becoming ready: %w", err)
+		}
+		return fmt.Errorf("geyser exited before becoming ready")
 	}
+}
+
+func (r *Runner) waitForExit(ctx context.Context, cmd *exec.Cmd, done chan struct{}) {
+	err := cmd.Wait()
+	r.mu.Lock()
+	if r.done == done {
+		if r.stopRequested || ctx.Err() != nil {
+			err = nil
+		}
+		r.err = err
+		r.cmd = nil
+	}
+	r.mu.Unlock()
+	close(done)
+}
+
+// Done closes once the current or most recently started managed Java runtime
+// exits. It is safe for more than one observer to wait on it.
+func (r *Runner) Done() <-chan struct{} {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.done
+}
+
+// Err is the terminal process error, if the managed Java runtime exited
+// unexpectedly. It is nil for a requested clean stop.
+func (r *Runner) Err() error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.err
 }
 
 // handleOutput reads from a pipe, writes to destination with prefix, and optionally signals when ready
@@ -197,17 +249,22 @@ func (r *Runner) handleOutput(pipe io.ReadCloser, prefix string, dest io.Writer,
 // Stop stops the process if running.
 func (r *Runner) Stop() {
 	r.mu.Lock()
-	defer r.mu.Unlock()
-	if r.cmd == nil {
+	cmd := r.cmd
+	done := r.done
+	if cmd == nil {
+		r.mu.Unlock()
 		return
 	}
+	r.stopRequested = true
+	r.mu.Unlock()
 
 	log := logr.FromContextOrDiscard(context.Background()).WithName("managed")
-	log.Info("stopping geyser standalone process", "pid", r.cmd.Process.Pid)
+	log.Info("stopping geyser standalone process", "pid", cmd.Process.Pid)
 
-	_ = r.cmd.Process.Kill()
-	_ = r.cmd.Wait()
-	r.cmd = nil
+	_ = cmd.Process.Kill()
+	if done != nil {
+		<-done
+	}
 
 	log.Info("geyser standalone process stopped")
 }

--- a/pkg/edition/bedrock/geyser/managed/managed_test.go
+++ b/pkg/edition/bedrock/geyser/managed/managed_test.go
@@ -1,13 +1,85 @@
 package managed
 
 import (
+	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	bconfig "go.minekube.com/gate/pkg/edition/bedrock/config"
 	"gopkg.in/yaml.v3"
 )
+
+func init() {
+	if os.Getenv("GO_WANT_MANAGED_JAVA_HELPER") == "" {
+		return
+	}
+	fmt.Println("Done (0.01s)! Run /geyser help for help!")
+	if os.Getenv("GO_WANT_MANAGED_JAVA_HELPER") == "crash" {
+		time.Sleep(100 * time.Millisecond)
+		os.Exit(17)
+	}
+	for {
+		time.Sleep(time.Second)
+	}
+}
+
+func TestRunnerReportsUnexpectedExitAfterReady(t *testing.T) {
+	t.Setenv("GO_WANT_MANAGED_JAVA_HELPER", "crash")
+	runner := newTestRunner(t)
+	if err := runner.Start(context.Background(), filepath.Join(t.TempDir(), "geyser.jar")); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	done := runner.Done()
+	if done == nil {
+		t.Fatal("Done() = nil after successful startup")
+	}
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Done() did not close after unexpected process exit")
+	}
+	if err := runner.Err(); err == nil {
+		t.Fatal("Err() = nil after unexpected process exit")
+	}
+}
+
+func TestRunnerCleanStopHasNoTerminalError(t *testing.T) {
+	t.Setenv("GO_WANT_MANAGED_JAVA_HELPER", "block")
+	runner := newTestRunner(t)
+	if err := runner.Start(context.Background(), filepath.Join(t.TempDir(), "geyser.jar")); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	done := runner.Done()
+	runner.Stop()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Done() did not close after Stop()")
+	}
+	if err := runner.Err(); err != nil {
+		t.Fatalf("Err() = %v after requested clean stop, want nil", err)
+	}
+}
+
+func newTestRunner(t *testing.T) *Runner {
+	t.Helper()
+	dataDir := t.TempDir()
+	keyPath := filepath.Join(dataDir, "floodgate.pem")
+	if err := os.WriteFile(keyPath, []byte("test-key"), 0o600); err != nil {
+		t.Fatalf("write floodgate key: %v", err)
+	}
+	return New(&bconfig.Config{
+		GeyserListenAddr: "127.0.0.1:25567",
+		FloodgateKeyPath: keyPath,
+		Managed: &bconfig.ManagedGeyser{
+			DataDir:  dataDir,
+			JavaPath: os.Args[0],
+		},
+	})
+}
 
 func TestWriteGeyserConfigForwardsHostnameByDefault(t *testing.T) {
 	dataDir := t.TempDir()

--- a/pkg/edition/bedrock/geyser/managed_lite.go
+++ b/pkg/edition/bedrock/geyser/managed_lite.go
@@ -21,7 +21,8 @@ type liteManagedRunner struct {
 	newServer func(geyserlite.Options) (geyserliteServer, error)
 	server    geyserliteServer
 	cancel    context.CancelFunc
-	done      chan error
+	done      chan struct{}
+	err       error
 	mu        sync.Mutex
 }
 
@@ -64,32 +65,41 @@ func (r *liteManagedRunner) EnsureKey(ctx context.Context) error {
 
 func (r *liteManagedRunner) Start(ctx context.Context) error {
 	r.mu.Lock()
-	defer r.mu.Unlock()
 	if r.server != nil {
+		r.mu.Unlock()
 		return fmt.Errorf("geyserlite already running")
 	}
 
 	opts, err := r.options()
 	if err != nil {
+		r.mu.Unlock()
 		return err
 	}
 	server, err := r.newServer(opts)
 	if err != nil {
+		r.mu.Unlock()
 		return err
 	}
 
 	runCtx, cancel := context.WithCancel(ctx)
-	done := make(chan error, 1)
+	done := make(chan struct{})
 	r.server = server
 	r.cancel = cancel
 	r.done = done
+	r.err = nil
+	r.mu.Unlock()
 
 	go func() {
 		err := server.Start(runCtx)
 		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 			err = nil
 		}
-		done <- err
+		r.mu.Lock()
+		if r.done == done {
+			r.err = err
+		}
+		r.mu.Unlock()
+		close(done)
 	}()
 
 	ticker := time.NewTicker(liteManagedReadyPoll)
@@ -99,10 +109,9 @@ func (r *liteManagedRunner) Start(ctx context.Context) error {
 
 	for {
 		select {
-		case err := <-done:
-			r.server = nil
-			r.cancel = nil
-			r.done = nil
+		case <-done:
+			err := r.runErr(done)
+			r.clearRun(done)
 			if err != nil {
 				return err
 			}
@@ -113,18 +122,49 @@ func (r *liteManagedRunner) Start(ctx context.Context) error {
 			}
 		case <-timeout.C:
 			cancel()
-			r.server = nil
-			r.cancel = nil
-			r.done = nil
+			r.clearRun(done)
 			return fmt.Errorf("timed out after %s waiting for geyserlite to become healthy", liteManagedStartupTimeout)
 		case <-ctx.Done():
 			cancel()
-			r.server = nil
-			r.cancel = nil
-			r.done = nil
+			r.clearRun(done)
 			return ctx.Err()
 		}
 	}
+}
+
+func (r *liteManagedRunner) clearRun(done <-chan struct{}) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.done != done {
+		return
+	}
+	r.server = nil
+	r.cancel = nil
+	r.done = nil
+}
+
+// Done closes once the managed GeyserLite runtime has stopped. It remains safe
+// for more than one observer to wait on it, unlike the old one-consumer error
+// channel.
+func (r *liteManagedRunner) Done() <-chan struct{} {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.done
+}
+
+func (r *liteManagedRunner) Err() error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.err
+}
+
+func (r *liteManagedRunner) runErr(done <-chan struct{}) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.done != done {
+		return nil
+	}
+	return r.err
 }
 
 func (r *liteManagedRunner) Stop() {

--- a/pkg/edition/bedrock/geyser/managed_lite_disabled.go
+++ b/pkg/edition/bedrock/geyser/managed_lite_disabled.go
@@ -24,3 +24,10 @@ func (r *liteManagedRunner) Start(context.Context) error {
 }
 
 func (r *liteManagedRunner) Stop() {}
+
+// Done and Err preserve the managedRunner lifecycle contract on musl builds.
+// The runtime never starts on this platform, so it has no terminal lifecycle
+// signal to report.
+func (r *liteManagedRunner) Done() <-chan struct{} { return nil }
+
+func (r *liteManagedRunner) Err() error { return nil }

--- a/pkg/edition/bedrock/geyser/managed_runner_musl_test.go
+++ b/pkg/edition/bedrock/geyser/managed_runner_musl_test.go
@@ -29,6 +29,12 @@ func TestNoGeyserliteBuildRejectsGeyserliteEngine(t *testing.T) {
 	if !strings.Contains(err.Error(), "managed geyserlite engine is not available") {
 		t.Fatalf("EnsureKey() error = %q, want unavailable geyserlite error", err)
 	}
+	if runner.Done() != nil {
+		t.Fatal("Done() != nil for unavailable musl GeyserLite runtime")
+	}
+	if runner.Err() != nil {
+		t.Fatalf("Err() = %v, want nil for unavailable musl GeyserLite runtime", runner.Err())
+	}
 }
 
 func TestNoGeyserliteBuildKeepsJavaEngine(t *testing.T) {

--- a/pkg/edition/bedrock/geyser/managed_runner_test.go
+++ b/pkg/edition/bedrock/geyser/managed_runner_test.go
@@ -4,6 +4,7 @@ package geyser
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"sync/atomic"
@@ -231,17 +232,106 @@ func TestLiteManagedRunnerStartWaitsUntilHealthy(t *testing.T) {
 	runner.Stop()
 }
 
+func TestLiteManagedRunnerReportsExitAfterHealthy(t *testing.T) {
+	tempDir := t.TempDir()
+	keyPath := filepath.Join(tempDir, "floodgate.key")
+	if err := os.WriteFile(keyPath, []byte("0123456789abcdef"), 0o600); err != nil {
+		t.Fatalf("write key: %v", err)
+	}
+
+	fake := &fakeGeyserliteServer{
+		started: make(chan struct{}),
+		crash:   make(chan error, 1),
+	}
+	runner := newLiteManagedRunner(&config.Config{
+		GeyserListenAddr: "localhost:25567",
+		FloodgateKeyPath: keyPath,
+		Managed:          &config.ManagedGeyser{Enabled: true, Engine: config.ManagedEngineGeyserlite},
+	})
+	runner.newServer = func(geyserlite.Options) (geyserliteServer, error) { return fake, nil }
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- runner.Start(context.Background()) }()
+	select {
+	case <-fake.started:
+	case <-time.After(time.Second):
+		t.Fatal("geyserlite server did not start")
+	}
+	fake.healthy.Store(true)
+	if err := <-errCh; err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+
+	done := runner.Done()
+	if done == nil {
+		t.Fatal("Done() = nil after successful startup")
+	}
+	want := errors.New("simulated GeyserLite crash")
+	fake.crash <- want
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("Done() did not close after server exit")
+	}
+	if !errors.Is(runner.Err(), want) {
+		t.Fatalf("Err() = %v, want %v", runner.Err(), want)
+	}
+}
+
+func TestIntegrationReportsManagedRuntimeExit(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	want := errors.New("simulated GeyserLite crash")
+	manager := &fakeManagedRunner{done: make(chan struct{}), err: want}
+	integration := &Integration{
+		ctx:        ctx,
+		manager:    manager,
+		runtimeErr: make(chan error, 1),
+	}
+
+	integration.watchManagedRuntime()
+	close(manager.done)
+	select {
+	case got := <-integration.RuntimeErrors():
+		if !errors.Is(got, want) {
+			t.Fatalf("RuntimeErrors() = %v, want %v", got, want)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("RuntimeErrors() did not report managed runtime exit")
+	}
+}
+
 type fakeGeyserliteServer struct {
 	healthy atomic.Bool
 	started chan struct{}
+	crash   chan error
 }
 
 func (f *fakeGeyserliteServer) Start(ctx context.Context) error {
 	close(f.started)
-	<-ctx.Done()
-	return ctx.Err()
+	if f.crash == nil {
+		<-ctx.Done()
+		return ctx.Err()
+	}
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case err := <-f.crash:
+		return err
+	}
 }
 
 func (f *fakeGeyserliteServer) Stop(context.Context) error { return nil }
 
 func (f *fakeGeyserliteServer) Healthy() bool { return f.healthy.Load() }
+
+type fakeManagedRunner struct {
+	done chan struct{}
+	err  error
+}
+
+func (f *fakeManagedRunner) EnsureKey(context.Context) error { return nil }
+func (f *fakeManagedRunner) Start(context.Context) error     { return nil }
+func (f *fakeManagedRunner) Stop()                           {}
+func (f *fakeManagedRunner) Done() <-chan struct{}           { return f.done }
+func (f *fakeManagedRunner) Err() error                      { return f.err }

--- a/pkg/edition/bedrock/proxy/proxy.go
+++ b/pkg/edition/bedrock/proxy/proxy.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"sync"
 
 	"github.com/go-logr/logr"
 	"github.com/robinbraemer/event"
@@ -60,6 +61,10 @@ type Proxy struct {
 
 	geyserIntegration *geyser.Integration
 	javaProxy         *jproxy.Proxy // Reference to Java proxy for integration
+	mu                sync.RWMutex
+	reloadMu          sync.Mutex
+	runtimeFailures   chan error
+	reloadGeneration  uint64
 }
 
 func (p *Proxy) Event() event.Manager { return p.event }
@@ -74,13 +79,21 @@ func (p *Proxy) Start(ctx context.Context) error {
 		return err
 	}
 
+	p.mu.Lock()
 	p.geyserIntegration = integration
+	p.runtimeFailures = make(chan error, 1)
+	runtimeFailures := p.runtimeFailures
+	p.mu.Unlock()
 
 	if err := integration.Start(); err != nil {
 		p.log.Error(err, "failed to start geyser integration")
 		integration.Stop()
+		p.mu.Lock()
+		p.geyserIntegration = nil
+		p.mu.Unlock()
 		return err
 	}
+	p.watchRuntime(integration)
 
 	// Listen for config reloads and restart Geyser integration when relevant fields change
 	unsubReload := reload.Subscribe(p.event, func(e *bedrockConfigUpdateEvent) {
@@ -89,54 +102,147 @@ func (p *Proxy) Start(ctx context.Context) error {
 
 	p.log.Info("bedrock proxy started with geyser integration")
 
-	// Block until context cancellation - cleanup on exit
-	<-ctx.Done()
+	defer func() {
+		if unsubReload != nil {
+			unsubReload()
+		}
+		p.stopIntegration()
+		p.log.Info("bedrock proxy stopped")
+	}()
 
-	// Cleanup
-	if unsubReload != nil {
-		unsubReload()
+	// A managed GeyserLite process can exit after it has passed its startup
+	// health check. Returning the failure stops Gate as a whole, which in turn
+	// makes the Moxy/Fly runtime check fail instead of leaving Java/TCP green
+	// while Bedrock UDP has disappeared.
+	select {
+	case <-ctx.Done():
+		return nil
+	case err := <-runtimeFailures:
+		return fmt.Errorf("bedrock runtime failed: %w", err)
 	}
-	if p.geyserIntegration != nil {
-		p.geyserIntegration.Stop()
-	}
+}
 
-	p.log.Info("bedrock proxy stopped")
-	return nil
+func (p *Proxy) watchRuntime(integration *geyser.Integration) {
+	p.watchRuntimeSignals(integration.RuntimeErrors(), integration.Done(), func(err error) {
+		p.reportIntegrationRuntimeFailure(integration, err)
+	})
+}
+
+func (p *Proxy) watchRuntimeSignals(runtimeErrors <-chan error, done <-chan struct{}, report func(error)) <-chan struct{} {
+	stopped := make(chan struct{})
+	go func() {
+		defer close(stopped)
+		select {
+		case <-done:
+			return
+		case err := <-runtimeErrors:
+			if err == nil {
+				return
+			}
+			report(err)
+		}
+	}()
+	return stopped
+}
+
+func (p *Proxy) stopIntegration() {
+	p.mu.Lock()
+	integration := p.geyserIntegration
+	p.geyserIntegration = nil
+	p.mu.Unlock()
+	if integration != nil {
+		integration.Stop()
+	}
+}
+
+// beginReload first makes the old integration non-current before stopping it.
+// A late failure from that old instance can therefore never abort a healthy
+// replacement. The generation also prevents a slower failed reload from
+// reporting after a newer configuration has superseded it.
+func (p *Proxy) beginReload() uint64 {
+	p.mu.Lock()
+	p.reloadGeneration++
+	generation := p.reloadGeneration
+	integration := p.geyserIntegration
+	p.geyserIntegration = nil
+	p.mu.Unlock()
+	if integration != nil {
+		integration.Stop()
+	}
+	return generation
+}
+
+func (p *Proxy) reportReloadFailure(generation uint64, err error) {
+	if err == nil {
+		return
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.reloadGeneration != generation || p.runtimeFailures == nil {
+		return
+	}
+	select {
+	case p.runtimeFailures <- err:
+	default:
+	}
+}
+
+func (p *Proxy) reportIntegrationRuntimeFailure(integration *geyser.Integration, err error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.geyserIntegration != integration || p.runtimeFailures == nil {
+		return
+	}
+	select {
+	case p.runtimeFailures <- err:
+	default:
+	}
 }
 
 func (p *Proxy) handleConfigUpdate(ctx context.Context, e *bedrockConfigUpdateEvent) {
+	// Config events can arrive back-to-back while a managed runtime is still
+	// starting. Serialize replacement so a newer event cannot leave the old
+	// listener stopped while an earlier replacement is still in flight.
+	p.reloadMu.Lock()
+	defer p.reloadMu.Unlock()
+
 	if e == nil {
 		return
 	}
 	prev := e.PrevConfig
 	curr := e.Config
 	if curr == nil {
-		if p.geyserIntegration != nil {
-			p.geyserIntegration.Stop()
-			p.geyserIntegration = nil
-		}
+		p.beginReload()
 		return
 	}
 
 	if prev == nil || requiresRestart(prev, curr) {
 		p.log.Info("restarting geyser integration due to bedrock config change")
-		if p.geyserIntegration != nil {
-			p.geyserIntegration.Stop()
-			p.geyserIntegration = nil
-		}
+		generation := p.beginReload()
 		p.config = curr
 		integ, err := geyser.NewIntegration(ctx, p.javaProxy, p.config)
 		if err != nil {
 			p.log.Error(err, "failed to re-initialize geyser integration")
+			p.reportReloadFailure(generation, fmt.Errorf("failed to re-initialize geyser integration: %w", err))
 			return
 		}
-		p.geyserIntegration = integ
 		if err := integ.Start(); err != nil {
 			p.log.Error(err, "failed to restart geyser integration")
 			integ.Stop()
-			p.geyserIntegration = nil
+			p.reportReloadFailure(generation, fmt.Errorf("failed to restart geyser integration: %w", err))
 			return
 		}
+		p.mu.Lock()
+		current := p.reloadGeneration == generation
+		if current {
+			p.geyserIntegration = integ
+		}
+		p.mu.Unlock()
+		if !current {
+			integ.Stop()
+			return
+		}
+		p.watchRuntime(integ)
 		p.log.Info("geyser integration reloaded")
 		return
 	}

--- a/pkg/edition/bedrock/proxy/proxy_test.go
+++ b/pkg/edition/bedrock/proxy/proxy_test.go
@@ -3,10 +3,12 @@ package proxy
 import (
 	"bytes"
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/robinbraemer/event"
 
@@ -15,6 +17,43 @@ import (
 	jconfig "go.minekube.com/gate/pkg/edition/java/config"
 	jproxy "go.minekube.com/gate/pkg/edition/java/proxy"
 )
+
+func TestWatchRuntimeSignalsStopsOnCleanIntegrationShutdown(t *testing.T) {
+	p := &Proxy{runtimeFailures: make(chan error, 1)}
+	runtimeErrors := make(chan error)
+	done := make(chan struct{})
+	stopped := p.watchRuntimeSignals(runtimeErrors, done, func(err error) {
+		p.runtimeFailures <- err
+	})
+	close(done)
+
+	select {
+	case <-stopped:
+	case <-time.After(time.Second):
+		t.Fatal("runtime watcher did not exit after clean integration shutdown")
+	}
+	select {
+	case err := <-p.runtimeFailures:
+		t.Fatalf("clean shutdown reported runtime failure: %v", err)
+	default:
+	}
+}
+
+func TestReportReloadFailureOnlyForCurrentGeneration(t *testing.T) {
+	p := &Proxy{runtimeFailures: make(chan error, 1), reloadGeneration: 7}
+	want := errors.New("replacement failed")
+	p.reportReloadFailure(7, want)
+	if got := <-p.runtimeFailures; !errors.Is(got, want) {
+		t.Fatalf("current reload failure = %v, want %v", got, want)
+	}
+
+	p.reportReloadFailure(6, errors.New("stale replacement failed"))
+	select {
+	case err := <-p.runtimeFailures:
+		t.Fatalf("stale reload reported runtime failure: %v", err)
+	default:
+	}
+}
 
 func TestRequiresRestart(t *testing.T) {
 	// Base configuration for comparison


### PR DESCRIPTION
## Root cause

The managed GeyserLite runner waited for `Healthy()` only during startup. If the Bedrock UDP runtime exited later, its terminal error was never observed. Gate and Moxy could therefore retain healthy Java/TCP and HTTP health endpoints while the public Bedrock listener was unavailable.

## Change

- Surface unexpected managed GeyserLite exits and internal Geyser bridge-listener failures through the Bedrock proxy runtime.
- Return those failures from the Bedrock proxy so Gate/Moxy exits and the existing runtime check can restart the process.
- Make shutdown and config reloads safe: clean integration stops end watcher goroutines without a false failure; stale integrations cannot abort a replacement; failures to construct or start the current replacement fail closed.
- Serialize replacement reloads to prevent overlapping config events from leaving Bedrock absent.

## Verification

- `go test -race ./pkg/edition/bedrock/geyser ./pkg/edition/bedrock/proxy`
- `go test ./pkg/edition/bedrock/...`
- `go vet ./...`
- `go test ./...`
- `git diff --check`

## Scope

No Fly configuration, Machine capacity, deployment, or GitOps manifests are changed. Moxy should consume this only after a normal Gate release.