### PR TITLE
feat: scope offline username blacklist to Connect

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -4,6 +4,14 @@ config:
   bind: 0.0.0.0:25565
   # Whether to use the proxy in online (authenticate players with Mojang API) or offline mode (not recommended).
   onlineMode: true
+  # Reserve authenticated account names on offline-mode login paths. Matching is
+  # case-insensitive; authenticated online-mode joins with these names remain allowed.
+  offlineModeUsernameBlacklist: []
+  # Reserve names on all offline-mode joins (default), or only sessions from Gate's
+  # authenticated Connect tunnel. This is not inferred from a hostname or player address.
+  offlineModeUsernameBlacklistScope: all
+  # Either simple legacy '§' text or a modern text component JSON object.
+  offlineModeUsernameBlacklistReason: "§cThis username is reserved for its authenticated owner."
   # Registers servers with the proxy by giving the address of backend server a custom reference name.
   servers:
     # Server name: server address

--- a/pkg/configs/config.yml
+++ b/pkg/configs/config.yml
@@ -4,10 +4,12 @@ config:
   bind: 0.0.0.0:25565
   # Whether to use the proxy in online (authenticate players with Mojang API) or offline mode (not recommended).
   onlineMode: true
-  # Reserve authenticated account names on offline-mode login paths, including a Connect
-  # integration that deliberately marks its already-authenticated inner connection offline.
-  # Matching is case-insensitive. Direct online-mode joins with these names remain allowed.
+  # Reserve authenticated account names on offline-mode login paths. Matching is
+  # case-insensitive; authenticated online-mode joins with these names remain allowed.
   offlineModeUsernameBlacklist: []
+  # Reserve names on all offline-mode joins (default), or only sessions from Gate's
+  # authenticated Connect tunnel. This is not inferred from a hostname or player address.
+  offlineModeUsernameBlacklistScope: all
   # Either simple legacy '§' text or a modern text component JSON object.
   offlineModeUsernameBlacklistReason: "§cThis username is reserved for its authenticated owner."
   # Registers servers with the proxy by giving the address of backend server a custom reference name.

--- a/pkg/edition/java/config/config.go
+++ b/pkg/edition/java/config/config.go
@@ -23,6 +23,7 @@ var DefaultConfig = Config{
 	OnlineMode:                         true,
 	Auth:                               Auth{},
 	OnlineModeKickExistingPlayers:      false,
+	OfflineModeUsernameBlacklistScope:  OfflineModeUsernameBlacklistScopeAll,
 	OfflineModeUsernameBlacklistReason: text("§cThis username is reserved for its authenticated owner."),
 	Forwarding: Forwarding{
 		Mode:           LegacyForwardingMode,
@@ -132,9 +133,10 @@ type Config struct { // TODO use https://github.com/projectdiscovery/yamldoc-go 
 	Auth                          Auth `yaml:"auth,omitempty" json:"auth,omitempty"`                                                   // Authentication settings.
 	OnlineModeKickExistingPlayers bool `yaml:"onlineModeKickExistingPlayers,omitempty" json:"onlineModeKickExistingPlayers,omitempty"` // Kicks existing players when a premium player with the same name joins.
 	// OfflineModeUsernameBlacklist reserves names only on login paths that are effectively
-	// offline mode. Authenticated direct joins remain allowed to use the same names.
-	OfflineModeUsernameBlacklist       []string                  `yaml:"offlineModeUsernameBlacklist,omitempty" json:"offlineModeUsernameBlacklist,omitempty"`
-	OfflineModeUsernameBlacklistReason *configutil.TextComponent `yaml:"offlineModeUsernameBlacklistReason,omitempty" json:"offlineModeUsernameBlacklistReason,omitempty"`
+	// offline mode. Authenticated joins remain allowed to use the same names.
+	OfflineModeUsernameBlacklist       []string                          `yaml:"offlineModeUsernameBlacklist,omitempty" json:"offlineModeUsernameBlacklist,omitempty"`
+	OfflineModeUsernameBlacklistScope  OfflineModeUsernameBlacklistScope `yaml:"offlineModeUsernameBlacklistScope,omitempty" json:"offlineModeUsernameBlacklistScope,omitempty"`
+	OfflineModeUsernameBlacklistReason *configutil.TextComponent         `yaml:"offlineModeUsernameBlacklistReason,omitempty" json:"offlineModeUsernameBlacklistReason,omitempty"`
 
 	Forwarding Forwarding `yaml:"forwarding,omitempty" json:"forwarding,omitempty"` // Player info forwarding settings.
 	Status     Status     `yaml:"status,omitempty" json:"status,omitempty"`         // Status response settings.
@@ -185,6 +187,10 @@ type Config struct { // TODO use https://github.com/projectdiscovery/yamldoc-go 
 }
 
 type (
+	// OfflineModeUsernameBlacklistScope selects which offline-mode login paths
+	// apply OfflineModeUsernameBlacklist.
+	OfflineModeUsernameBlacklistScope string
+
 	ForcedHosts map[string][]string // virtualhost:server names
 	Status      struct {
 		ShowMaxPlayers  int                   `yaml:"showMaxPlayers"`
@@ -242,6 +248,15 @@ type (
 		// Defaults to https://sessionserver.mojang.com/session/minecraft/hasJoined
 		SessionServerURL *configutil.URL `yaml:"sessionServerUrl"` // TODO support multiple urls configutil.SingleOrMulti[URL]
 	}
+)
+
+const (
+	// OfflineModeUsernameBlacklistScopeAll is deliberately the default for
+	// compatibility with configurations created before this setting existed.
+	OfflineModeUsernameBlacklistScopeAll OfflineModeUsernameBlacklistScope = "all"
+	// OfflineModeUsernameBlacklistScopeConnect applies the reservation only to
+	// connections created by Gate's authenticated Connect tunnel adapter.
+	OfflineModeUsernameBlacklistScopeConnect OfflineModeUsernameBlacklistScope = "connect"
 )
 
 // ForwardingMode is a player info forwarding mode.
@@ -367,6 +382,13 @@ func (c *Config) Validate() (warns []error, errs []error) {
 var minecraftUsernamePattern = regexp.MustCompile(`^[A-Za-z0-9_]{2,16}$`)
 
 func validateOfflineModeUsernameBlacklist(c *Config, e func(string, ...any)) {
+	switch c.OfflineModeUsernameBlacklistScope {
+	case "", OfflineModeUsernameBlacklistScopeAll, OfflineModeUsernameBlacklistScopeConnect:
+		// An omitted key is "all", preserving pre-scope behaviour.
+	default:
+		e("Invalid offlineModeUsernameBlacklistScope %q, must be one of all,connect", c.OfflineModeUsernameBlacklistScope)
+	}
+
 	seen := make(map[string]string, len(c.OfflineModeUsernameBlacklist))
 	for _, username := range c.OfflineModeUsernameBlacklist {
 		if !minecraftUsernamePattern.MatchString(username) {

--- a/pkg/edition/java/config/config_test.go
+++ b/pkg/edition/java/config/config_test.go
@@ -114,6 +114,23 @@ func TestOfflineModeUsernameBlacklistValidation(t *testing.T) {
 		require.Contains(t, errs[0].Error(), "case-insensitively identical")
 		require.Contains(t, errs[1].Error(), "2-16 character Minecraft username")
 	})
+
+	t.Run("accepts all and connect scopes, rejects other values", func(t *testing.T) {
+		cfg := DefaultConfig
+		for _, scope := range []OfflineModeUsernameBlacklistScope{
+			OfflineModeUsernameBlacklistScopeAll,
+			OfflineModeUsernameBlacklistScopeConnect,
+			"", // omitted in older configurations means all
+		} {
+			cfg.OfflineModeUsernameBlacklistScope = scope
+			_, errs := cfg.Validate()
+			require.Empty(t, errs, "scope %q", scope)
+		}
+
+		cfg.OfflineModeUsernameBlacklistScope = "tunnel"
+		_, errs := cfg.Validate()
+		requireErrorContains(t, errs, "Invalid offlineModeUsernameBlacklistScope")
+	})
 }
 
 // TestLiteIgnoredSettingsWarn covers https://github.com/minekube/gate/issues/929: Lite mode

--- a/pkg/edition/java/proxy/offline_username_blacklist_test.go
+++ b/pkg/edition/java/proxy/offline_username_blacklist_test.go
@@ -1,25 +1,105 @@
 package proxy
 
 import (
+	"context"
+	"net"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"go.minekube.com/gate/pkg/edition/java/config"
+	"go.minekube.com/gate/pkg/edition/java/netmc"
+	"go.minekube.com/gate/pkg/gate/proto"
 )
 
 func TestOfflineModeUsernameBlacklist(t *testing.T) {
 	cfg := config.DefaultConfig
 	cfg.OfflineModeUsernameBlacklist = []string{"AdminName"}
 
-	require.True(t, offlineModeUsernameBlocked(&cfg, ForceOfflineModePreLogin, "adminname"),
-		"Connect-style forced-offline login must not impersonate a reserved account")
-	require.False(t, offlineModeUsernameBlocked(&cfg, ForceOnlineModePreLogin, "AdminName"),
-		"an authenticated direct login must retain access to its reserved account")
-	require.False(t, offlineModeUsernameBlocked(&cfg, AllowedPreLogin, "AdminName"),
+	// all is the default, so direct and Connect offline sessions retain the
+	// original protection behaviour.
+	require.True(t, offlineModeUsernameBlocked(&cfg, ForceOfflineModePreLogin, false, "adminname"))
+	require.True(t, offlineModeUsernameBlocked(&cfg, ForceOfflineModePreLogin, true, "adminname"))
+	require.False(t, offlineModeUsernameBlocked(&cfg, ForceOnlineModePreLogin, false, "AdminName"),
+		"ForceOnline must stay authenticated even if the listener defaults offline")
+	require.False(t, offlineModeUsernameBlocked(&cfg, ForceOnlineModePreLogin, true, "AdminName"),
+		"Connect ingress must not override ForceOnline")
+	require.False(t, offlineModeUsernameBlocked(&cfg, AllowedPreLogin, false, "AdminName"),
 		"the proxy-wide online-mode default must remain authenticated")
 
 	cfg.OnlineMode = false
-	require.True(t, offlineModeUsernameBlocked(&cfg, AllowedPreLogin, "ADMINNAME"),
-		"ordinary offline-mode login must enforce the same reservation")
-	require.False(t, offlineModeUsernameBlocked(&cfg, AllowedPreLogin, "AnotherPlayer"))
+	require.True(t, offlineModeUsernameBlocked(&cfg, AllowedPreLogin, false, "ADMINNAME"))
+	require.True(t, offlineModeUsernameBlocked(&cfg, AllowedPreLogin, true, "ADMINNAME"))
+	require.False(t, offlineModeUsernameBlocked(&cfg, AllowedPreLogin, false, "AnotherPlayer"))
+}
+
+func TestOfflineModeUsernameBlacklistConnectScope(t *testing.T) {
+	cfg := config.DefaultConfig
+	cfg.OnlineMode = false
+	cfg.OfflineModeUsernameBlacklist = []string{"AdminName"}
+	cfg.OfflineModeUsernameBlacklistScope = config.OfflineModeUsernameBlacklistScopeConnect
+
+	require.False(t, offlineModeUsernameBlocked(&cfg, AllowedPreLogin, false, "AdminName"),
+		"a direct offline join must not be classified from its hostname, IP, or handshake")
+	require.True(t, offlineModeUsernameBlocked(&cfg, AllowedPreLogin, true, "AdminName"),
+		"only the authenticated Connect tunnel provenance marker enables this scope")
+	require.False(t, offlineModeUsernameBlocked(&cfg, ForceOnlineModePreLogin, true, "AdminName"),
+		"Mojang-authenticated joins remain exempt")
+	require.False(t, offlineModeUsernameBlocked(&cfg, ForceOnlineModePreLogin, false, "AdminName"))
+
+	// A Connect session explicitly forced offline is still an offline session.
+	require.True(t, offlineModeUsernameBlocked(&cfg, ForceOfflineModePreLogin, true, "AdminName"))
+	require.False(t, offlineModeUsernameBlocked(&cfg, ForceOfflineModePreLogin, false, "AdminName"))
+}
+
+func TestOfflineModeUsernameBlacklistScopeEmptyIsCompatible(t *testing.T) {
+	cfg := config.DefaultConfig
+	cfg.OnlineMode = false
+	cfg.OfflineModeUsernameBlacklist = []string{"AdminName"}
+	cfg.OfflineModeUsernameBlacklistScope = ""
+
+	require.True(t, offlineModeUsernameBlocked(&cfg, AllowedPreLogin, false, "AdminName"),
+		"an omitted key in an older config must continue to mean all")
+}
+
+func TestOfflineModeUsernameBlacklistConcurrentReads(t *testing.T) {
+	cfg := config.DefaultConfig
+	cfg.OnlineMode = false
+	cfg.OfflineModeUsernameBlacklist = []string{"AdminName"}
+	cfg.OfflineModeUsernameBlacklistScope = config.OfflineModeUsernameBlacklistScopeConnect
+
+	var wg sync.WaitGroup
+	errs := make(chan bool, 64)
+	for i := 0; i < 64; i++ {
+		wg.Add(1)
+		go func(connectIngress bool) {
+			defer wg.Done()
+			got := offlineModeUsernameBlocked(&cfg, AllowedPreLogin, connectIngress, "AdminName")
+			errs <- got == connectIngress
+		}(i%2 == 0)
+	}
+	wg.Wait()
+	close(errs)
+	for ok := range errs {
+		require.True(t, ok)
+	}
+}
+
+type markedConnectTunnelConn struct{ net.Conn }
+
+func (markedConnectTunnelConn) IsConnectTunnelIngress() bool { return true }
+
+func TestConnectTunnelIngressUsesAdapterMarker(t *testing.T) {
+	directServer, directClient := net.Pipe()
+	t.Cleanup(func() { _ = directServer.Close() })
+	t.Cleanup(func() { _ = directClient.Close() })
+	direct, _ := netmc.NewMinecraftConn(context.Background(), directServer, proto.ServerBound, time.Second, time.Second, -1, nil)
+	require.False(t, connectTunnelIngress(direct), "a direct socket has no Connect provenance")
+
+	tunnelServer, tunnelClient := net.Pipe()
+	t.Cleanup(func() { _ = tunnelServer.Close() })
+	t.Cleanup(func() { _ = tunnelClient.Close() })
+	tunnel, _ := netmc.NewMinecraftConn(context.Background(), markedConnectTunnelConn{tunnelServer}, proto.ServerBound, time.Second, time.Second, -1, nil)
+	require.True(t, connectTunnelIngress(tunnel), "only a trusted adapter marker reaches login through netmc")
 }

--- a/pkg/edition/java/proxy/session_client_initial_login.go
+++ b/pkg/edition/java/proxy/session_client_initial_login.go
@@ -157,7 +157,7 @@ func (l *initialLoginSessionHandler) handleServerLogin(login *packet.ServerLogin
 		_ = l.inbound.disconnect(e.Reason())
 		return
 	}
-	if offlineModeUsernameBlocked(l.config(), e.Result(), l.login.Username) {
+	if offlineModeUsernameBlocked(l.config(), e.Result(), connectTunnelIngress(l.conn), l.login.Username) {
 		reason := l.config().OfflineModeUsernameBlacklistReason
 		if reason == nil {
 			reason = config.DefaultConfig.OfflineModeUsernameBlacklistReason
@@ -200,10 +200,30 @@ func (l *initialLoginSessionHandler) handleServerLogin(login *packet.ServerLogin
 	})
 }
 
-func offlineModeUsernameBlocked(cfg *config.Config, result PreLoginResult, username string) bool {
+// ConnectTunnelIngress is a provenance marker installed only by Gate's
+// authenticated Connect tunnel adapter. It is intentionally independent of a
+// player's address and handshake, both of which are player-controlled inputs.
+type ConnectTunnelIngress interface {
+	IsConnectTunnelIngress() bool
+}
+
+func connectTunnelIngress(conn netmc.MinecraftConn) bool {
+	ingress, ok := netmc.Assert[ConnectTunnelIngress](conn)
+	return ok && ingress.IsConnectTunnelIngress()
+}
+
+func offlineModeUsernameBlocked(
+	cfg *config.Config,
+	result PreLoginResult,
+	connectIngress bool,
+	username string,
+) bool {
 	offline := result == ForceOfflineModePreLogin ||
 		(result != ForceOnlineModePreLogin && !cfg.OnlineMode)
 	if !offline {
+		return false
+	}
+	if cfg.OfflineModeUsernameBlacklistScope == config.OfflineModeUsernameBlacklistScopeConnect && !connectIngress {
 		return false
 	}
 	for _, blocked := range cfg.OfflineModeUsernameBlacklist {

--- a/pkg/util/connectutil/config/setup_client.go
+++ b/pkg/util/connectutil/config/setup_client.go
@@ -282,12 +282,18 @@ type (
 var (
 	_ proxy.GameProfileProvider             = (*tunnelConnWithGameProfile)(nil)
 	_ proxy.GameProfileProvider             = (*tunnelConnWithPrincipal)(nil)
+	_ proxy.ConnectTunnelIngress            = (*tunnelConnWithSession)(nil)
+	_ proxy.ConnectTunnelIngress            = (*tunnelConnWithGameProfile)(nil)
+	_ proxy.ConnectTunnelIngress            = (*tunnelConnWithPrincipal)(nil)
 	_ connectutil.VerifiedPrincipalProvider = (*tunnelConnWithPrincipal)(nil)
 )
 
 func (t *tunnelConnWithGameProfile) GameProfile() *profile.GameProfile { return t.gp }
 func (t *tunnelConnWithPrincipal) GameProfile() *profile.GameProfile   { return t.gp }
 func (t *tunnelConnWithSession) Session() *connect.Session             { return t.s }
+func (*tunnelConnWithSession) IsConnectTunnelIngress() bool            { return true }
+func (*tunnelConnWithGameProfile) IsConnectTunnelIngress() bool        { return true }
+func (*tunnelConnWithPrincipal) IsConnectTunnelIngress() bool          { return true }
 func (t *tunnelConnWithPrincipal) VerifiedPrincipal() bedrockprincipal.VerifiedBedrockPrincipal {
 	return t.principal
 }

--- a/pkg/util/connectutil/config/setup_client_wrap_test.go
+++ b/pkg/util/connectutil/config/setup_client_wrap_test.go
@@ -42,6 +42,10 @@ func TestWrapTunnelSessionExposesVerifiedProfile(t *testing.T) {
 	require.True(t, ok)
 	require.Equal(t, principal, pp.VerifiedPrincipal())
 
+	ingress, ok := netmc.Assert[proxy.ConnectTunnelIngress](conn)
+	require.True(t, ok, "a verified Connect tunnel must keep its trusted ingress marker")
+	require.True(t, ingress.IsConnectTunnelIngress())
+
 	require.Equal(t, "sess-wrap-1", conn.Session().GetId())
 }
 
@@ -55,8 +59,14 @@ func TestWrapTunnelSessionWithoutPrincipal(t *testing.T) {
 	require.Equal(t, gp, gpp.GameProfile())
 	_, ok = netmc.Assert[connectutil.VerifiedPrincipalProvider](conn)
 	require.False(t, ok)
+	ingress, ok := netmc.Assert[proxy.ConnectTunnelIngress](conn)
+	require.True(t, ok, "a proposed-profile Connect tunnel still originates at Connect")
+	require.True(t, ingress.IsConnectTunnelIngress())
 
 	passthrough := wrapTunnelSession(nil, session, nil, nil)
 	_, ok = netmc.Assert[proxy.GameProfileProvider](passthrough)
 	require.False(t, ok)
+	ingress, ok = netmc.Assert[proxy.ConnectTunnelIngress](passthrough)
+	require.True(t, ok, "a passthrough Connect tunnel must not lose its ingress provenance")
+	require.True(t, ingress.IsConnectTunnelIngress())
 }


### PR DESCRIPTION
Closes #1068

Adds `offlineModeUsernameBlacklistScope: all | connect` (default `all`).

`connect` consults only a provenance marker installed by Gate’s existing authenticated Connect tunnel adapter; it does not inspect player-controlled hostnames, IP addresses, or handshake content. Mojang-authenticated / `ForceOnlineMode` joins remain exempt.

Validation and coverage include direct vs Connect offline sessions, force-online/offline interactions, omitted-key compatibility, tunnel wrapper propagation, parallel reads, and race detection.

Validation run:
- `go test -race ./pkg/edition/java/config ./pkg/edition/java/proxy ./pkg/util/connectutil/config`
- `make test`

`make lint` was attempted but its current unpinned latest golangci-lint fails repository-wide during typecheck (including Go export-data version incompatibility), unrelated to this patch.